### PR TITLE
Fix hydration crash on layout-shell routes + dev-mode rate limit

### DIFF
--- a/examples/blog_app/app/templates/posts/_layout.svelte
+++ b/examples/blog_app/app/templates/posts/_layout.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
+<p class="kicker">
+  <a href="/" class="back">← fymo●blog</a>
+</p>
+{@render children()}
+
+<style>
+  .kicker { margin: 0 0 2.5rem; }
+  .back {
+    font-family: var(--font-mono); font-size: 0.78rem; letter-spacing: 0.04em;
+    color: var(--muted); transition: color 0.15s ease;
+  }
+  .back:hover { color: var(--accent); }
+</style>

--- a/examples/blog_app/app/templates/posts/show.svelte
+++ b/examples/blog_app/app/templates/posts/show.svelte
@@ -19,9 +19,6 @@
 </script>
 
 <article>
-  <p class="kicker">
-    <a href="/" class="back">← fymo●blog</a>
-  </p>
   <header class="post-head">
     <p class="dateline">
       <time>{new Date(post.published_at).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</time>
@@ -36,13 +33,6 @@
 <Comments slug={post.slug} initial={initial_comments} {create_comment} />
 
 <style>
-  .kicker { margin: 0 0 2.5rem; }
-  .back {
-    font-family: var(--font-mono); font-size: 0.78rem; letter-spacing: 0.04em;
-    color: var(--muted); transition: color 0.15s ease;
-  }
-  .back:hover { color: var(--accent); }
-
   .post-head { margin-bottom: 2.5rem; }
   .dateline {
     display: flex; gap: 1rem; align-items: center;

--- a/fymo/build/composition_generator.py
+++ b/fymo/build/composition_generator.py
@@ -11,14 +11,23 @@ SSR_TREE_TEMPLATE = """\
 {imports}
   let {{ leafProps, layoutProps }} = $props();
 
+  // Bound via $state (never actually reassigned during SSR) purely so the
+  // compiler treats this component reference as *dynamic* -- see the long
+  // comment below on SSR_RESOURCE_BLOCK_WITH_LAYOUT for why a plain static
+  // import reference here would structurally desync from the client shell's
+  // hydration expectations.
+  let CurrentLeaf = $state(Leaf);
+{resource_state_decl}
   function onLeafError(error) {{
-    if (typeof console !== 'undefined') console.error('[fymo] leaf render error:', error);
+    if (typeof console !== 'undefined') {{
+      console.error('[fymo] leaf render error:', error && error.stack || error && error.message || error);
+    }}
   }}
 </script>
 
 {{#snippet leafSlot()}}
   <svelte:boundary onerror={{onLeafError}}>
-    <Leaf {{...leafProps}} />
+    <CurrentLeaf {{...leafProps}} />
     {{#snippet failed(error, reset)}}
       <div class="fymo-leaf-error">Something went wrong. <button onclick={{reset}}>Retry</button></div>
     {{/snippet}}
@@ -43,10 +52,33 @@ SSR_ROOT_CLOSE = "\n</RootLayout>"
 # both branches still compile and both `generate: 'server'` and
 # `generate: 'client'` output the same anchor/comment structure regardless of
 # the literal value), so this preserves hydration compatibility.
+#
+# CurrentResourceLayout is likewise bound via $state rather than referencing
+# `ResourceLayout` (the static import) directly as the tag. This is not
+# cosmetic: Svelte's compiler decides whether a `<Component .../>` tag emits
+# the plain static-component codegen or the dynamic-component codegen (a
+# `$.component(...)` wrapper with its own hydration marker comment) based on
+# whether the tag's binding is "dynamic" -- and a binding is only dynamic if
+# its `kind` is something other than `'normal'` (see
+# `phases/2-analyze/visitors/Component.js`: `node.metadata.dynamic = ...
+# binding.kind !== 'normal' ...`). A plain `import X from '...'` and even a
+# plain `let x = X` both get `kind: 'normal'` -- only rune-derived bindings
+# ($state, $props, $derived, ...) get a non-'normal' kind. The client shell's
+# `CurrentResourceLayout`/`CurrentLeaf` are `$state(...)`, so they always
+# compile to the dynamic-component form; a route's SSR tree MUST use the same
+# form for the identical tag, or the server output is missing the hydration
+# marker comment the client's compiled `$.component()` call requires --
+# producing a real, user-visible bug: `svelte.dev/e/hydration_mismatch` plus
+# the leaf's `<svelte:boundary>` catching a bare `HYDRATION_ERROR` sentinel
+# and discarding the entire SSR'd subtree in favour of the `failed` snippet.
+# (Root-caused by tracing a live `hydration_mismatch` through
+# `read_hydration_instruction` straight to the `$.component()` call compiled
+# for `<CurrentLeaf .../>` in the shell bundle -- confirmed by reproducing
+# with and without this fix against a real browser.)
 SSR_RESOURCE_BLOCK_WITH_LAYOUT = """{#if true}
-  <ResourceLayout {...layoutProps.resource}>
+  <CurrentResourceLayout {...layoutProps.resource}>
     {@render leafSlot()}
-  </ResourceLayout>
+  </CurrentResourceLayout>
 {:else}
   {@render leafSlot()}
 {/if}
@@ -110,12 +142,19 @@ def generate_ssr_tree(route: Route, out_dir: Path) -> Optional[Path]:
     resource_block = (
         SSR_RESOURCE_BLOCK_WITH_LAYOUT if has_resource else SSR_RESOURCE_BLOCK_WITHOUT_LAYOUT
     )
+    # Same $state-binding rationale as CurrentLeaf above -- only emitted when
+    # this route actually has a resource layout (ResourceLayout is only
+    # imported in that case).
+    resource_state_decl = (
+        "  let CurrentResourceLayout = $state(ResourceLayout);\n" if has_resource else ""
+    )
 
     body = SSR_TREE_TEMPLATE.format(
         imports="\n".join(imports),
         root_open=root_open,
         root_close=root_close,
         resource_block=resource_block,
+        resource_state_decl=resource_state_decl,
     )
 
     out_path = out_dir / f"{route.name}.tree.svelte"

--- a/fymo/build/dev_orchestrator.py
+++ b/fymo/build/dev_orchestrator.py
@@ -7,10 +7,12 @@ import time
 from pathlib import Path
 from typing import Callable, List, Optional
 
-from fymo.build.discovery import discover_routes
+from fymo.build.composition_generator import generate_ssr_tree
+from fymo.build.discovery import discover_routes, discover_all_layouts
 from fymo.build.entry_generator import write_client_entries
 from fymo.build.hygiene import check_directory_hygiene, format_hygiene_error
-from fymo.build.manifest import Manifest, RemoteModuleAssets, RouteAssets
+from fymo.build.manifest import Manifest, RemoteModuleAssets
+from fymo.build.manifest_matching import match_esbuild_outputs
 from fymo.remote.codegen import emit_module, emit_runtime
 from fymo.remote.discovery import discover_remote_modules
 
@@ -27,6 +29,8 @@ class DevOrchestrator:
         self._listeners: List[Callable[[dict], None]] = []
         self._latest_metafile: Optional[dict] = None
         self._routes = []
+        self._all_layouts = []
+        self._has_global_css = False
         self._remote_assets: dict[str, RemoteModuleAssets] = {}
 
     def add_listener(self, fn: Callable[[dict], None]) -> None:
@@ -45,6 +49,20 @@ class DevOrchestrator:
         templates = self.project_root / "app" / "templates"
         self._routes = discover_routes(templates)
         client_entries = write_client_entries(self._routes, self.cache_dir, self.project_root, dev=True)
+
+        # Layout + global-CSS entries, mirroring BuildPipeline.build() so
+        # `fymo dev` and `fymo build` can't drift on what gets built --
+        # this file previously stopped at write_client_entries() and never
+        # discovered layouts or _global.css at all, which is exactly what
+        # let the manifest fields below go stale (see match_esbuild_outputs
+        # docstring for the bug this caused).
+        self._all_layouts = discover_all_layouts(templates)
+        layout_client_entries = {
+            f"_layout-{ref.id}": str(ref.svelte_path) for ref in self._all_layouts
+        }
+        global_css_path = templates / "_global.css"
+        self._has_global_css = global_css_path.is_file()
+        global_css_entry = {"_global": str(global_css_path)} if self._has_global_css else {}
 
         # Discover app/remote/*.py (+ auth providers') remote functions and
         # emit their dist/client/_remote/<name>.{js,d.ts} stubs, exactly like
@@ -85,11 +103,25 @@ class DevOrchestrator:
             if fns
         }
 
+        # SSR entry points: composed tree file when a route has a layout
+        # chain, else the raw leaf -- same rule as BuildPipeline.build().
+        # Without this, the SSR bundle is always the bare leaf regardless of
+        # layout_chain, so a route with a real layout never renders its
+        # <RootLayout>/<ResourceLayout> wrapper at all under `fymo dev`.
+        ssr_entries = [
+            {"name": r.name, "entryPath": str(generate_ssr_tree(r, self.cache_dir) or r.entry_path)}
+            for r in self._routes
+        ]
+
         config = {
             "projectRoot": str(self.project_root),
             "distDir": str(self.dist_dir),
-            "routes": [{"name": r.name, "entryPath": str(r.entry_path)} for r in self._routes],
-            "clientEntries": {n: str(p) for n, p in client_entries.items()},
+            "routes": ssr_entries,
+            "clientEntries": {
+                **{n: str(p) for n, p in client_entries.items()},
+                **layout_client_entries,
+                **global_css_entry,
+            },
         }
         self._proc = subprocess.Popen(
             ["node", str(self.dev_script), json.dumps(config)],
@@ -151,51 +183,25 @@ class DevOrchestrator:
             return
         outputs = self._latest_metafile.get("outputs", {})
 
-        project_root_abs = self.project_root.resolve()
-        dist_dir_abs = self.dist_dir.resolve()
+        route_assets, layout_assets, global_css_out = match_esbuild_outputs(
+            client_outputs=outputs,
+            routes=self._routes,
+            all_layouts=self._all_layouts,
+            project_root=self.project_root,
+            dist_dir=self.dist_dir,
+            has_global_css=self._has_global_css,
+        )
 
-        def to_rel_dist(out_path: str):
-            p = Path(out_path)
-            if not p.is_absolute():
-                p = project_root_abs / p
-            try:
-                return p.resolve().relative_to(dist_dir_abs).as_posix()
-            except ValueError:
-                return None
-
-        client_by_route = {}
-        css_by_route = {}
-        chunks = []
-        for out_path, info in outputs.items():
-            rel = to_rel_dist(out_path)
-            if rel is None:
-                continue
-            entry = info.get("entryPoint")
-            if entry:
-                for r in self._routes:
-                    if Path(entry).name == f"{r.name}.client.js":
-                        if rel.endswith(".js"):
-                            client_by_route[r.name] = rel
-                            css_bundle = info.get("cssBundle")
-                            if css_bundle:
-                                css_rel = to_rel_dist(css_bundle)
-                                if css_rel:
-                                    css_by_route[r.name] = css_rel
-            elif Path(out_path).name.startswith("chunk-") and rel.endswith(".js"):
-                chunks.append(rel)
-
-        routes = {}
-        for r in self._routes:
-            if r.name in client_by_route:
-                routes[r.name] = RouteAssets(
-                    ssr=f"ssr/{r.name}.mjs",
-                    client=client_by_route[r.name],
-                    css=css_by_route.get(r.name),
-                    preload=chunks,
-                )
-        if routes:
+        # Lenient by design (unlike BuildPipeline's strict BuildError): a
+        # route or layout's output can be transiently absent mid-rebuild
+        # while watching, and the next successful rebuild event will catch
+        # it up. Only require at least one route to be ready before writing
+        # anything at all, matching this method's prior behavior.
+        if route_assets:
             Manifest(
-                routes=routes,
+                routes=route_assets,
                 build_time=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 remote_modules=self._remote_assets,
+                layouts=layout_assets,
+                global_css=global_css_out,
             ).write(self.dist_dir / "manifest.json")

--- a/fymo/build/entry_generator.py
+++ b/fymo/build/entry_generator.py
@@ -211,7 +211,9 @@ SHELL_TEMPLATE = """\
   }}
 
   function onLeafError(error) {{
-    if (typeof console !== 'undefined') console.error('[fymo] leaf render error:', error);
+    if (typeof console !== 'undefined') {{
+      console.error('[fymo] leaf render error:', error && error.stack || error && error.message || error);
+    }}
   }}
 </script>
 

--- a/fymo/build/js/hydration_check.mjs
+++ b/fymo/build/js/hydration_check.mjs
@@ -1,0 +1,229 @@
+// Real-hydration regression check: loads a live page's actual SSR HTML into
+// jsdom, then executes the actual compiled client bundle against it the same
+// way a real browser would -- letting Svelte's real hydrate() run against
+// real DOM APIs -- and reports any console errors/warnings raised.
+//
+// This exists because every hydration bug found in this codebase so far
+// (the dev_orchestrator layout-fields bug, and the SSR/shell static-vs-
+// dynamic component-tag bug) was invisible to the existing test suite: all
+// of it talks to the WSGI app directly and asserts on HTML strings, which
+// proves the server produced *some* markup but proves nothing about whether
+// a browser can hydrate it. jsdom is not a full browser (no real layout/
+// paint), but it runs the real Svelte runtime's real hydrate() call against
+// real DOM APIs, which is exactly where both prior bugs actually fired --
+// so it closes that blind spot without pulling in a full browser-automation
+// dependency (Playwright et al.).
+//
+// jsdom cannot execute `<script type="module">` tags at all (a longstanding,
+// documented jsdom limitation -- it does not implement the module
+// resolution/linking algorithm), which every fymo client bootstrap uses. So
+// instead of letting jsdom auto-run scripts, this script parses the HTML
+// with script execution disabled, finds the module script's `src`, maps it
+// to the real file already sitting in `<distDir>/client/...` on disk, and
+// `import()`s that file directly through Node's own ESM loader (so its
+// relative sibling-chunk imports resolve normally on the real filesystem),
+// with jsdom's `window`/`document` installed as ambient globals so the
+// bundle's browser-assuming top-level code (`document.getElementById(...)`,
+// etc.) works exactly as it would in a real page.
+//
+// CLI usage: node hydration_check.mjs <url> <distDir> [timeoutMs]
+// Prints one JSON line: {"ok": bool, "errors": [...], "warnings": [...]}
+//
+// Also importable as a library (`import { checkHydration } from
+// './hydration_check.mjs'`) for callers that want to check more than one
+// route without paying subprocess-startup cost per route. checkHydration is
+// safe to call more than once in the same process: every global it touches
+// on `globalThis` is either a fresh addition (deleted afterward) or a
+// pre-existing value it saves and restores explicitly (see DOM_OVERRIDES
+// below) -- nothing leaks into the next call or the rest of the process.
+
+import { JSDOM } from 'jsdom';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+/**
+ * @param {string} url page URL to fetch and hydrate
+ * @param {string} distDir local filesystem path to the app's dist/ directory
+ * @param {number} [timeoutMs]
+ * @returns {Promise<{ok: boolean, errors: string[], warnings: string[]}>}
+ */
+export async function checkHydration(url, distDir, timeoutMs = 5000) {
+  const errors = [];
+  const warnings = [];
+
+  const res = await fetch(url);
+  const html = await res.text();
+
+  // runScripts is intentionally omitted (scripts never auto-execute) --
+  // we run the module bundle ourselves below.
+  const dom = new JSDOM(html, { url, resources: 'usable', pretendToBeVisual: true });
+  const { window } = dom;
+
+  const moduleScript = window.document.querySelector('script[type="module"][src]');
+  if (!moduleScript) {
+    window.close();
+    return { ok: false, errors: [`no <script type="module"> found in ${url}`], warnings: [] };
+  }
+
+  // The src is an absolute path like "/dist/client/posts.HASH.js" -- fymo
+  // serves everything under distDir's parent at that same "/dist/..."
+  // prefix, so strip the leading "/dist" segment and resolve what remains
+  // against the real distDir on disk.
+  const srcPath = moduleScript.getAttribute('src');
+  const relPath = srcPath.replace(/^\/dist\//, '');
+  const localPath = path.join(distDir, relPath);
+
+  // Install browser globals the bundle's top-level code assumes exist.
+  // Svelte's internals reference a broad set of DOM classes/constructors
+  // (Element, Comment, Text, Node, Event, ...) directly as globals, not
+  // just `window`/`document` -- copy every own property jsdom exposes on
+  // `window`, mirroring what `jsdom-global`-style shims do, rather than
+  // hand-picking a subset that will keep needing new entries as Svelte's
+  // internals evolve. Restored after so a second call in this same process
+  // (or anything else running here) never sees this call's globals.
+  const previousKeys = new Set(Object.getOwnPropertyNames(globalThis));
+
+  // The bundle references the ambient `console` identifier, which resolves
+  // to globalThis.console -- Node's own console object, not jsdom's
+  // window.console (a distinct object). `console` already exists on
+  // globalThis, so the copy loop below (which skips anything already
+  // present) never touches it; patch Node's real console directly instead,
+  // and restore the original methods afterward.
+  const originalConsoleError = console.error;
+  const originalConsoleWarn = console.warn;
+  console.error = (...args) => errors.push(args.map(String).join(' '));
+  console.warn = (...args) => warnings.push(args.map(String).join(' '));
+
+  // Node.js has its own native, spec-compliant implementations of several
+  // Web-standard classes (Event, EventTarget, CustomEvent, AbortController,
+  // ...) -- but they are a SEPARATE class hierarchy from jsdom's own DOM
+  // implementation. Every jsdom-created node (an Element, a real DOM event
+  // dispatched by `dispatchEvent`, ...) is an instance of *jsdom's*
+  // EventTarget/Event, not Node's. The generic "skip if already in
+  // globalThis" rule below would leave Node's version in place for these
+  // names, silently breaking any `instanceof Event`/`instanceof
+  // EventTarget` check the bundle's code (or Svelte's own internals) makes
+  // against a real jsdom object. Force jsdom's version to win for exactly
+  // this set of overlapping DOM/Web-standard names; nothing else Node
+  // predefines (Object, Array, Promise, process, setTimeout, ...) belongs
+  // on this list, since those aren't part of the DOM object graph the
+  // bundle under test walks.
+  const DOM_OVERRIDES = new Set([
+    'Event', 'EventTarget', 'CustomEvent', 'MessageEvent', 'ErrorEvent',
+    'ProgressEvent', 'AbortController', 'AbortSignal',
+  ]);
+  // Unlike the generic copy loop below (which only ever ADDS keys that
+  // weren't on globalThis before, and so can be undone by just deleting
+  // them), these names already exist on Node's globalThis -- overriding
+  // them REPLACES a value that must come back afterward, or Node's own
+  // Event/EventTarget would stay silently swapped out for jsdom's version
+  // for the rest of this process, corrupting every check after this call
+  // (including a second route checked via a second checkHydration() call).
+  const previousDomOverrideValues = new Map();
+  for (const key of DOM_OVERRIDES) {
+    if (key in window) {
+      previousDomOverrideValues.set(key, globalThis[key]);
+      globalThis[key] = window[key];
+    }
+  }
+
+  for (const key of Object.getOwnPropertyNames(window)) {
+    if (key === 'window' || key === 'self' || key === 'top' || key === 'parent') continue;
+    if (DOM_OVERRIDES.has(key)) continue; // already force-copied above
+    // Skip anything else Node already provides globally (Object, Array,
+    // Promise, Symbol, JSON, Math, process, setTimeout, ...). These exist
+    // in both environments; overwriting Node's own copies -- especially by
+    // binding constructors like `Object` to `window`, which silently
+    // strips their static methods -- corrupts the process's own JS
+    // runtime, not just the page under test. Only DOM-only globals Node
+    // lacks (Element, Document, HTMLElement, ...) get copied.
+    if (key in globalThis) continue;
+    try {
+      const value = window[key];
+      // Methods (addEventListener, requestAnimationFrame, ...) must stay
+      // bound to `window` -- calling them unbound breaks jsdom's internal
+      // `this`-based bookkeeping. Constructors (Node, Element, Event, ...)
+      // must NOT be bound -- `Function.prototype.bind` returns a wrapper
+      // with no `.prototype` of its own, which silently breaks every
+      // `SomeClass.prototype` access (observed: Svelte's internals reading
+      // `Node.prototype` to grab property descriptors, getting `undefined`
+      // back once `Node` was a bound wrapper). DOM/JS convention is that
+      // constructors are PascalCase and methods are camelCase, which is a
+      // reliable enough signal here (this is test tooling, not shipped
+      // code) to tell the two apart without a large explicit allow-list.
+      const isConstructor = typeof value === 'function' && /^[A-Z]/.test(key);
+      globalThis[key] = typeof value === 'function' && !isConstructor ? value.bind(window) : value;
+    } catch {
+      // Some window properties (e.g. certain getters) can't be copied as
+      // plain assignments -- safe to skip, they're not things Svelte's
+      // internals reference as bare identifiers.
+    }
+  }
+  globalThis.window = window;
+  globalThis.document = window.document;
+
+  window.addEventListener('error', (e) => errors.push(`window error: ${e.message}`));
+  window.addEventListener('unhandledrejection', (e) => {
+    errors.push(`unhandled rejection: ${(e.reason && e.reason.message) || e.reason}`);
+  });
+
+  try {
+    await import(pathToFileURL(localPath).href);
+  } catch (e) {
+    errors.push(`bundle import threw: ${e && (e.stack || e.message || e)}`);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (!window.__fymoBooted && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  // Let any microtask-queued console output (e.g. <svelte:boundary>'s
+  // onerror, which Svelte defers) flush after boot.
+  await new Promise((r) => setTimeout(r, 100));
+
+  const booted = !!window.__fymoBooted;
+  if (!booted) errors.push(`client bundle never set window.__fymoBooted within ${timeoutMs}ms`);
+
+  console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
+  window.close();
+  // The generic copy loop only ever ADDS keys that weren't on globalThis
+  // before, so undoing it is just deleting those additions -- no
+  // pre-existing global's value was ever touched there. The DOM_OVERRIDES
+  // are the one exception (see above): they replaced a real prior value,
+  // so they need an explicit write-back, not a delete.
+  for (const key of Object.getOwnPropertyNames(globalThis)) {
+    if (!previousKeys.has(key)) {
+      try { delete globalThis[key]; } catch { /* non-configurable, leave it */ }
+    }
+  }
+  for (const [key, value] of previousDomOverrideValues) {
+    globalThis[key] = value;
+  }
+
+  return { ok: errors.length === 0 && booted, errors, warnings };
+}
+
+// CLI entrypoint -- only runs when this file is executed directly (`node
+// hydration_check.mjs ...`), not when imported by another module (e.g. a
+// test harness calling checkHydration() directly).
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const url = process.argv[2];
+  const distDir = process.argv[3];
+  const timeoutMs = Number(process.argv[4] ?? 5000);
+
+  if (!url || !distDir) {
+    console.error('usage: node hydration_check.mjs <url> <distDir> [timeoutMs]');
+    process.exit(2);
+  }
+
+  checkHydration(url, distDir, timeoutMs)
+    .then((result) => {
+      console.log(JSON.stringify(result));
+      process.exit(result.ok ? 0 : 1);
+    })
+    .catch((e) => {
+      console.log(JSON.stringify({ ok: false, errors: [`checker crashed: ${e && (e.stack || e.message)}`], warnings: [] }));
+      process.exit(1);
+    });
+}

--- a/fymo/build/manifest_matching.py
+++ b/fymo/build/manifest_matching.py
@@ -1,0 +1,144 @@
+"""Shared esbuild-metafile -> manifest-asset matching.
+
+Used by both `BuildPipeline` (`fymo build`) and `DevOrchestrator`
+(`fymo dev`) so the two build entry points can't drift the way
+`DevOrchestrator`'s manifest writing once did: it was never updated when
+the layout system's fields (`layout_chain`, `uses_layout_shell`, `layouts`,
+`global_css`) were added to `BuildPipeline`, so `fymo dev` kept silently
+writing pre-layout-system manifests (empty `layout_chain` for every route)
+long after `fymo build` was already correct -- a route with a real layout
+chain would get a layout-aware client bundle (from `entry_generator.py`,
+which reads `route.layout_chain` directly) but flat, non-nested SSR props
+(from `template_renderer.py`, which reads the manifest), crashing the
+client at hydration time (`Cannot read properties of undefined
+(reading 'root')`) since the two disagreed on the prop shape.
+"""
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from fymo.build.manifest import LayoutAssets, LayoutRefAsset, RouteAssets
+
+
+def match_esbuild_outputs(
+    client_outputs: Dict[str, Any],
+    routes: List[Any],
+    all_layouts: List[Any],
+    project_root: Path,
+    dist_dir: Path,
+    has_global_css: bool,
+) -> Tuple[Dict[str, RouteAssets], Dict[str, LayoutAssets], Optional[str]]:
+    """Walk an esbuild client metafile's `outputs` and match each output
+    back to the route, layout, or global-css entry point that produced it.
+
+    Returns (route_assets, layout_assets, global_css_path). A route or
+    layout with no matching output is simply absent from the returned
+    dicts -- callers decide their own policy for that (BuildPipeline raises
+    a hard BuildError; DevOrchestrator skips writing the manifest and waits
+    for the next rebuild, since a route's output can be transiently absent
+    mid-rebuild while watching).
+    """
+    dist_dir_abs = dist_dir.resolve()
+    project_root_abs = project_root.resolve()
+
+    def abs_out(out_path: str) -> Path:
+        p = Path(out_path)
+        if p.is_absolute():
+            return p
+        return (project_root_abs / p).resolve()
+
+    client_by_route: Dict[str, str] = {}
+    css_by_route: Dict[str, str] = {}
+    layout_client: Dict[str, str] = {}
+    layout_css: Dict[str, str] = {}
+    global_css_out: Optional[str] = None
+
+    for out_path, info in client_outputs.items():
+        entry_point = info.get("entryPoint")
+        if entry_point is None:
+            continue
+        abs_path = abs_out(out_path)
+        try:
+            rel_to_dist = abs_path.relative_to(dist_dir_abs)
+        except ValueError:
+            continue
+        entry_name = Path(entry_point).name
+        if not str(rel_to_dist).endswith(".js") and not str(rel_to_dist).endswith(".css"):
+            continue
+
+        matched_route = next((r for r in routes if entry_name == f"{r.name}.client.js"), None)
+        if matched_route is not None:
+            client_by_route[matched_route.name] = str(rel_to_dist).replace("\\", "/")
+            css_bundle = info.get("cssBundle")
+            if css_bundle:
+                try:
+                    css_rel = abs_out(css_bundle).relative_to(dist_dir_abs)
+                    css_by_route[matched_route.name] = str(css_rel).replace("\\", "/")
+                except ValueError:
+                    pass
+            continue
+
+        # Layout entries are keyed in clientEntries as "_layout-<id>" but
+        # their source file is the raw _layout.svelte (no per-route stub
+        # like routes get from entry_generator.py), so esbuild's metafile
+        # `entryPoint` is the .svelte source path -- its basename never
+        # matches "_layout-<id>.js". `ref.id` is an unsanitized directory
+        # name (see discovery.py), so it can itself contain "." -- e.g.
+        # resource dirs "a" and "a.b" both -- which would make a
+        # string-prefix match on the hashed output filename ambiguous.
+        # Match by path identity instead: resolve entry_point the same way
+        # abs_out() resolves other paths here, and compare it to
+        # ref.svelte_path, mirroring the route branch's identity match.
+        if not str(rel_to_dist).endswith(".js"):
+            matched_layout = None
+        else:
+            entry_point_abs = abs_out(entry_point)
+            matched_layout = next(
+                (ref for ref in all_layouts if entry_point_abs == ref.svelte_path.resolve()),
+                None,
+            )
+        if matched_layout is not None:
+            layout_client[matched_layout.id] = str(rel_to_dist).replace("\\", "/")
+            css_bundle = info.get("cssBundle")
+            if css_bundle:
+                try:
+                    css_rel = abs_out(css_bundle).relative_to(dist_dir_abs)
+                    layout_css[matched_layout.id] = str(css_rel).replace("\\", "/")
+                except ValueError:
+                    pass
+            continue
+
+        if has_global_css and entry_name == "_global.css" and str(rel_to_dist).endswith(".css"):
+            global_css_out = str(rel_to_dist).replace("\\", "/")
+
+    chunks: List[str] = []
+    for p in client_outputs:
+        if Path(p).name.startswith("chunk-") and p.endswith(".js"):
+            try:
+                rel = abs_out(p).relative_to(dist_dir_abs)
+                chunks.append(str(rel).replace("\\", "/"))
+            except ValueError:
+                pass
+
+    route_assets = {
+        r.name: RouteAssets(
+            ssr=f"ssr/{r.name}.mjs",
+            client=client_by_route[r.name],
+            css=css_by_route.get(r.name),
+            preload=chunks,
+            layout_chain=[
+                LayoutRefAsset(level=ref.level, id=ref.id, controller_module=ref.controller_module)
+                for ref in r.layout_chain
+            ],
+            uses_layout_shell=bool(r.layout_chain),
+        )
+        for r in routes
+        if r.name in client_by_route
+    }
+
+    layout_assets = {
+        ref.id: LayoutAssets(client=layout_client[ref.id], css=layout_css.get(ref.id))
+        for ref in all_layouts
+        if ref.id in layout_client
+    }
+
+    return route_assets, layout_assets, global_css_out

--- a/fymo/build/pipeline.py
+++ b/fymo/build/pipeline.py
@@ -11,7 +11,8 @@ from fymo.build.discovery import discover_routes, discover_all_layouts
 from fymo.build.entry_generator import write_client_entries
 from fymo.build.composition_generator import generate_ssr_tree
 from fymo.build.hygiene import check_directory_hygiene, format_hygiene_error
-from fymo.build.manifest import Manifest, RouteAssets, RemoteModuleAssets, LayoutRefAsset, LayoutAssets
+from fymo.build.manifest import Manifest, RemoteModuleAssets
+from fymo.build.manifest_matching import match_esbuild_outputs
 from fymo.remote.discovery import discover_remote_modules
 from fymo.remote.codegen import emit_module, emit_runtime
 
@@ -179,112 +180,25 @@ class BuildPipeline:
     ) -> Manifest:
         all_layouts = all_layouts or []
         client_meta = esbuild_result.get("client", {}).get("outputs", {})
-        dist_dir_abs = self.dist_dir.resolve()
-        project_root_abs = self.project_root.resolve()
 
-        def abs_out(out_path: str) -> Path:
-            p = Path(out_path)
-            if p.is_absolute():
-                return p
-            return (project_root_abs / p).resolve()
+        route_assets, layouts_assets, global_css_out = match_esbuild_outputs(
+            client_outputs=client_meta,
+            routes=routes,
+            all_layouts=all_layouts,
+            project_root=self.project_root,
+            dist_dir=self.dist_dir,
+            has_global_css=has_global_css,
+        )
 
-        client_by_route = {}
-        css_by_route = {}
-        layout_client = {}
-        layout_css = {}
-        global_css_out = None
-        for out_path, info in client_meta.items():
-            entry_point = info.get("entryPoint")
-            if entry_point is None:
-                continue
-            abs_path = abs_out(out_path)
-            try:
-                rel_to_dist = abs_path.relative_to(dist_dir_abs)
-            except ValueError:
-                continue
-            entry_name = Path(entry_point).name
-            if not str(rel_to_dist).endswith(".js") and not str(rel_to_dist).endswith(".css"):
-                continue
-
-            matched_route = next((r for r in routes if entry_name == f"{r.name}.client.js"), None)
-            if matched_route is not None:
-                client_by_route[matched_route.name] = str(rel_to_dist).replace("\\", "/")
-                css_bundle = info.get("cssBundle")
-                if css_bundle:
-                    try:
-                        css_rel = abs_out(css_bundle).relative_to(dist_dir_abs)
-                        css_by_route[matched_route.name] = str(css_rel).replace("\\", "/")
-                    except ValueError:
-                        pass
-                continue
-
-            # Layout entries are keyed in clientEntries as "_layout-<id>" but
-            # their source file is the raw _layout.svelte (no per-route stub
-            # like routes get from entry_generator.py), so esbuild's metafile
-            # `entryPoint` is the .svelte source path -- its basename never
-            # matches "_layout-<id>.js". `ref.id` is an unsanitized directory
-            # name (see discovery.py), so it can itself contain "." -- e.g.
-            # resource dirs "a" and "a.b" both -- which would make a
-            # string-prefix match on the hashed output filename ambiguous
-            # (out_name.startswith(f"_layout-{ref.id}.")). Match by path
-            # identity instead: resolve entry_point the same way abs_out()
-            # resolves other paths here, and compare it to ref.svelte_path,
-            # mirroring the route branch's identity match on entry_name.
-            if not str(rel_to_dist).endswith(".js"):
-                matched_layout = None
-            else:
-                entry_point_abs = abs_out(entry_point)
-                matched_layout = next(
-                    (ref for ref in all_layouts if entry_point_abs == ref.svelte_path.resolve()),
-                    None,
-                )
-            if matched_layout is not None:
-                layout_client[matched_layout.id] = str(rel_to_dist).replace("\\", "/")
-                css_bundle = info.get("cssBundle")
-                if css_bundle:
-                    try:
-                        css_rel = abs_out(css_bundle).relative_to(dist_dir_abs)
-                        layout_css[matched_layout.id] = str(css_rel).replace("\\", "/")
-                    except ValueError:
-                        pass
-                continue
-
-            if has_global_css and entry_name == "_global.css" and str(rel_to_dist).endswith(".css"):
-                global_css_out = str(rel_to_dist).replace("\\", "/")
-
-        chunks = []
-        for p in client_meta:
-            if Path(p).name.startswith("chunk-") and p.endswith(".js"):
-                try:
-                    rel = abs_out(p).relative_to(dist_dir_abs)
-                    chunks.append(str(rel).replace("\\", "/"))
-                except ValueError:
-                    pass
-
-        route_assets = {}
+        # fymo build is strict: any route or layout esbuild didn't produce
+        # output for is a hard failure, not a silent omission (unlike
+        # fymo dev, which tolerates this transiently mid-rebuild).
         for r in routes:
-            if r.name not in client_by_route:
+            if r.name not in route_assets:
                 raise BuildError(f"esbuild produced no client output for route '{r.name}'")
-            route_assets[r.name] = RouteAssets(
-                ssr=f"ssr/{r.name}.mjs",
-                client=client_by_route[r.name],
-                css=css_by_route.get(r.name),
-                preload=chunks,
-                layout_chain=[
-                    LayoutRefAsset(level=ref.level, id=ref.id, controller_module=ref.controller_module)
-                    for ref in r.layout_chain
-                ],
-                uses_layout_shell=bool(r.layout_chain),
-            )
-
         for ref in all_layouts:
-            if ref.id not in layout_client:
+            if ref.id not in layouts_assets:
                 raise BuildError(f"esbuild produced no client output for layout '{ref.id}'")
-
-        layouts_assets = {
-            ref.id: LayoutAssets(client=layout_client[ref.id], css=layout_css.get(ref.id))
-            for ref in all_layouts
-        }
 
         return Manifest(
             routes=route_assets,

--- a/fymo/core/middleware.py
+++ b/fymo/core/middleware.py
@@ -76,13 +76,49 @@ class _TokenBucket:
         return False
 
 
+#: How often (in seconds) `RateLimiter.check` opportunistically sweeps idle
+#: buckets. A dedicated background thread isn't worth it for this -- request
+#: traffic itself drives the sweep, and a 60s cadence bounds the sweep's own
+#: overhead to well under the cost of the token-bucket check it rides along
+#: with.
+_SWEEP_INTERVAL_SECONDS = 60.0
+
+
 class RateLimiter:
-    """Per-(IP, rule) token bucket rate limiter, in-process."""
+    """Per-(IP, rule) token bucket rate limiter, in-process.
+
+    `_buckets` is otherwise unbounded: every distinct (client_ip, rule)
+    pair seen gets its own entry that nothing ever removes, so a
+    long-running process fielding traffic from many distinct IPs (the
+    normal case for anything public-facing) leaks memory for as long as it
+    runs. `check` opportunistically sweeps idle buckets to bound this.
+    """
 
     def __init__(self, config: RateLimitConfig):
         self.config = config
         self._buckets: Dict[Tuple[str, str], _TokenBucket] = {}
         self._lock = threading.Lock()
+        self._last_sweep = time.monotonic()
+
+    def _sweep_idle_buckets(self, now: float) -> None:
+        """Drop buckets that have fully refilled since their last request.
+
+        A fully-refilled bucket carries no state a brand-new one wouldn't
+        also have (both start at `capacity` tokens), so evicting it doesn't
+        change any client-visible behavior -- the next request for that key
+        just lazily recreates an identical bucket. Buckets with partial
+        state (a client currently being throttled, or one that hasn't been
+        idle long enough to fully refill) are left alone, since dropping
+        those WOULD reset their limit early. Must be called with `_lock`
+        held.
+        """
+        stale = [
+            key
+            for key, bucket in self._buckets.items()
+            if bucket.tokens + (now - bucket.last_refill) * bucket.rate >= bucket.capacity
+        ]
+        for key in stale:
+            del self._buckets[key]
 
     def client_ip(self, environ: dict) -> str:
         if self.config.trust_proxy:
@@ -119,6 +155,11 @@ class RateLimiter:
         scope_key = (ip, rule_key)
 
         with self._lock:
+            now = time.monotonic()
+            if now - self._last_sweep >= _SWEEP_INTERVAL_SECONDS:
+                self._sweep_idle_buckets(now)
+                self._last_sweep = now
+
             bucket = self._buckets.get(scope_key)
             if bucket is None or bucket.capacity != rpm:
                 bucket = _TokenBucket(capacity=rpm, rate=rpm / 60.0)
@@ -341,7 +382,14 @@ class MiddlewareSettings:
                 continue
 
         rate_limit_config = RateLimitConfig(
-            enabled=bool(rl.get("enabled", True)),
+            # Defaults to enabled in production, disabled in dev -- a single
+            # developer's browser tabs, soft-nav clicks, and page reloads all
+            # share one token bucket (same REMOTE_ADDR) for the whole life of
+            # `fymo dev`, so the production-sane default of 60/min is easy to
+            # exhaust during ordinary local testing. Still fully overridable
+            # either direction via an explicit `rate_limit.enabled` in
+            # fymo.yml, in prod or in dev.
+            enabled=bool(rl.get("enabled", not dev)),
             default_rpm=int(rl.get("requests_per_minute", 60)),
             path_rules=path_rules,
             trust_proxy=bool(rl.get("trust_proxy", False)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,213 @@
       "devDependencies": {
         "esbuild": "^0.25.9",
         "esbuild-svelte": "^0.9.0",
+        "jsdom": "^29.1.1",
         "svelte-preprocess": "^6.0.0",
         "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -461,6 +666,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -551,6 +774,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -560,11 +793,59 @@
         "node": ">=6"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/devalue": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
       "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
@@ -640,6 +921,26 @@
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -649,11 +950,62 @@
         "@types/estree": "^1.0.6"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.18",
@@ -662,6 +1014,69 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/svelte": {
@@ -745,6 +1160,59 @@
         }
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -758,6 +1226,81 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zimmerframe": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "esbuild": "^0.25.9",
     "esbuild-svelte": "^0.9.0",
+    "jsdom": "^29.1.1",
     "svelte-preprocess": "^6.0.0",
     "typescript": "^5.5.0"
   },

--- a/tests/build/test_composition_generator.py
+++ b/tests/build/test_composition_generator.py
@@ -29,7 +29,6 @@ def test_writes_tree_file_for_root_only_chain(tmp_path: Path):
     assert "import Leaf from" in content
     assert "ResourceLayout" not in content
     assert "<RootLayout" in content
-    assert "<Leaf" in content
     assert "layoutProps.root" in content
     assert "leafProps" in content
     # Structural parity with the client shell (entry_generator.py's
@@ -41,6 +40,21 @@ def test_writes_tree_file_for_root_only_chain(tmp_path: Path):
     assert "{#if false}" in content
     assert "{:else}" in content
     assert "{/if}" in content
+    # Regression guard: the leaf MUST be referenced via a $state-bound
+    # "CurrentLeaf" tag, not the static "Leaf" import, directly as the
+    # component tag. Svelte's compiler only emits the dynamic-component
+    # codegen (a `$.component()` wrapper with its own hydration marker
+    # comment) for tags bound to something other than a plain import/`let`
+    # (kind != 'normal') -- the client shell's `CurrentLeaf` is `$state(...)`,
+    # so it always compiles to that dynamic form. A static `<Leaf .../>` tag
+    # here compiles WITHOUT that marker, so the server's HTML is missing the
+    # comment the client's compiled `$.component()` call requires at
+    # hydration time -- a real bug (`svelte.dev/e/hydration_mismatch`,
+    # verified live in a browser) this test would otherwise miss entirely,
+    # since it's invisible to a plain WSGI/curl check.
+    assert "<CurrentLeaf" in content
+    assert "let CurrentLeaf = $state(Leaf);" in content
+    assert "<Leaf" not in content
 
 
 def test_writes_tree_file_for_root_and_resource_chain(tmp_path: Path):
@@ -68,8 +82,6 @@ def test_writes_tree_file_for_root_and_resource_chain(tmp_path: Path):
     assert "import ResourceLayout from" in content
     assert "import Leaf from" in content
     assert "<RootLayout" in content
-    assert "<ResourceLayout" in content
-    assert "<Leaf" in content
     # Structural parity with the client shell: resource-layout slot is wrapped
     # in {#if}/{:else}/{/if} (literal `true` since this route has a resource
     # layout), and the leaf is rendered via the shared leafSlot snippet inside
@@ -80,15 +92,28 @@ def test_writes_tree_file_for_root_and_resource_chain(tmp_path: Path):
     assert "{:else}" in content
     assert "{/if}" in content
     assert content.count("{@render leafSlot()}") == 2
+    # Regression guard (see test_writes_tree_file_for_root_only_chain for the
+    # full rationale): both the leaf AND the resource layout must be
+    # referenced via $state-bound "Current*" tags, matching the client
+    # shell's dynamic-component binding kind -- a static tag reference here
+    # compiles without the hydration marker comment the client's compiled
+    # `$.component()` call expects, causing a real hydration_mismatch.
+    assert "<CurrentLeaf" in content
+    assert "<CurrentResourceLayout" in content
+    assert "let CurrentLeaf = $state(Leaf);" in content
+    assert "let CurrentResourceLayout = $state(ResourceLayout);" in content
+    assert "<Leaf" not in content
+    assert "<ResourceLayout" not in content
     # Root must nest outside resource, resource outside the leaf-slot render,
     # in the composed tree section (i.e. after the leafSlot snippet
-    # definition -- <Leaf itself lives inside that snippet's own body, which
-    # is defined once and referenced via {@render leafSlot()}, so ordering
-    # is checked against the render call, not the snippet's internal markup).
+    # definition -- CurrentLeaf itself lives inside that snippet's own body,
+    # which is defined once and referenced via {@render leafSlot()}, so
+    # ordering is checked against the render call, not the snippet's internal
+    # markup).
     tree_section = content.split("{/snippet}")[-1]
     assert (
         tree_section.index("<RootLayout")
-        < tree_section.index("<ResourceLayout")
+        < tree_section.index("<CurrentResourceLayout")
         < tree_section.index("{@render leafSlot()}")
     )
 

--- a/tests/build/test_dev_orchestrator.py
+++ b/tests/build/test_dev_orchestrator.py
@@ -1,11 +1,14 @@
 """DevOrchestrator.start() must apply the same directory-hygiene check as
 BuildPipeline.build() -- `fymo dev` reads the live source tree just like
 `fymo build` does, so a misplaced file should be caught there too."""
+import json
+import time
 from pathlib import Path
 
 import pytest
 
 from fymo.build.dev_orchestrator import DevOrchestrator
+from fymo.build.manifest import Manifest, LayoutRefAsset, RouteAssets
 
 
 def test_start_fails_on_svelte_file_in_controllers(example_app: Path):
@@ -28,3 +31,76 @@ def test_hygiene_check_runs_even_without_node_on_path(example_app: Path, monkeyp
     monkeypatch.setattr("fymo.build.dev_orchestrator.shutil.which", lambda cmd: None)
     with pytest.raises(RuntimeError, match="app/controllers/oops.svelte"):
         DevOrchestrator(example_app).start()
+
+
+def test_write_manifest_populates_layout_fields_from_synthetic_metafile(example_app: Path):
+    """Fast, no real esbuild: proves _write_manifest()'s wiring to
+    match_esbuild_outputs() is correct, independent of a real subprocess
+    build. (The real end-to-end test below is what actually would have
+    caught the original bug -- this one guards the wiring specifically.)"""
+    orch = DevOrchestrator(example_app)
+    orch._routes = [
+        type("R", (), {
+            "name": "home",
+            "layout_chain": [type("Ref", (), {"level": "root", "id": "_root", "controller_module": None})()],
+        })(),
+    ]
+    orch._all_layouts = [
+        type("Ref", (), {"id": "_root", "svelte_path": example_app / "app" / "templates" / "_layout.svelte"})(),
+    ]
+    (example_app / "app" / "templates" / "_layout.svelte").write_text(
+        "<script>\n  let { children } = $props();\n</script>\n{@render children()}\n"
+    )
+    orch._has_global_css = False
+    orch._latest_metafile = {
+        "outputs": {
+            "dist/client/home.HASH1.js": {"entryPoint": "home.client.js"},
+            "dist/client/_layout-_root.HASH2.js": {
+                "entryPoint": str(example_app / "app" / "templates" / "_layout.svelte"),
+            },
+        }
+    }
+    orch._write_manifest()
+
+    manifest = Manifest.read(example_app / "dist" / "manifest.json")
+    assert manifest is not None
+    assert manifest.routes["home"].uses_layout_shell is True
+    assert manifest.routes["home"].layout_chain == [
+        LayoutRefAsset(level="root", id="_root", controller_module=None)
+    ]
+    assert "_root" in manifest.layouts
+
+
+def test_real_dev_session_writes_correct_layout_manifest(blog_app: Path, node_available):
+    """End-to-end: the actual bug. Runs a real `fymo dev` session (via
+    DevOrchestrator directly, not the CLI) against blog_app -- which has a
+    real root _layout.svelte -- and confirms the manifest it writes has
+    uses_layout_shell=True / a populated layout_chain, matching what
+    BuildPipeline.build() would write for the exact same source tree.
+    Before this fix, DevOrchestrator always wrote layout_chain=[] regardless
+    of the real source, which is what caused the client bootstrap (which
+    correctly saw the layout chain via entry_generator.py) to crash trying
+    to read `.root` off undefined `layoutProps`."""
+    orch = DevOrchestrator(blog_app)
+    try:
+        orch.start()
+        manifest_path = blog_app / "dist" / "manifest.json"
+        deadline = time.time() + 30
+        while time.time() < deadline and not manifest_path.exists():
+            time.sleep(0.1)
+        assert manifest_path.exists(), "dev build did not produce a manifest in 30s"
+
+        # Wait a little longer for the layout entry specifically -- routes
+        # and layouts can land in different rebuild events.
+        deadline = time.time() + 10
+        manifest = Manifest.read(manifest_path)
+        while time.time() < deadline and "_root" not in manifest.layouts:
+            time.sleep(0.2)
+            manifest = Manifest.read(manifest_path)
+
+        assert manifest.routes["index"].uses_layout_shell is True
+        assert any(ref.level == "root" and ref.id == "_root" for ref in manifest.routes["index"].layout_chain)
+        assert manifest.routes["posts"].uses_layout_shell is True
+        assert "_root" in manifest.layouts
+    finally:
+        orch.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,22 @@ def blog_app(tmp_path: Path) -> Path:
     auth enabled — needed for tests that exercise remote-module discovery
     (todo_app has neither). Same node_modules-symlink treatment as
     example_app: read-only, shared across test runs.
+
+    `FymoApp.__init__` (fymo/core/server.py) inserts `project_root` onto
+    `sys.path` so `app.*` is importable, but never removes it or clears
+    `sys.modules` afterward. Since every blog_app copy uses the same
+    top-level package name ("app"), a second test in the same pytest
+    process that uses this fixture with a *different* tmp_path would
+    otherwise silently reuse the first test's cached `app.data.db` (etc.)
+    module -- e.g. `seed_test_post()` would insert its row into the FIRST
+    test's SQLite file, not the current test's, and the current test's own
+    server would then see an empty database with no error at all, just a
+    confusing 404. Clean up both `sys.path` and the cached `app.*` modules
+    after each test using this fixture, matching the pattern already used
+    by the local `blog_app` overrides in test_soft_nav.py and
+    test_layout_system_e2e.py.
     """
+    import sys
     dest = tmp_path / "blog_app"
     shutil.copytree(
         BLOG_APP, dest,
@@ -68,7 +83,13 @@ def blog_app(tmp_path: Path) -> Path:
         (dest / "node_modules").symlink_to(nm)
     else:
         pytest.skip("examples/blog_app/node_modules not found — run npm install in examples/blog_app/")
-    return dest
+    dest_str = str(dest)
+    yield dest
+    if dest_str in sys.path:
+        sys.path.remove(dest_str)
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -123,6 +123,68 @@ def test_trust_proxy_ignores_xff_when_disabled():
     assert rl.check(_env(ip="10.0.0.1", xff="DIFFERENT"))[0] is False
 
 
+# ---------------- Bucket eviction (unbounded-growth fix) ----------------
+
+
+def test_idle_fully_refilled_buckets_are_swept():
+    """A long-running process fielding traffic from many distinct IPs must
+    not accumulate one bucket per IP forever -- idle (fully-refilled)
+    buckets get dropped so memory stays bounded to recently-active clients."""
+    rl = RateLimiter(RateLimitConfig(enabled=True, default_rpm=60))
+    rl.check(_env(ip="1.1.1.1"))
+    key_a = ("1.1.1.1", "")
+    assert key_a in rl._buckets
+
+    # Simulate: plenty of time has passed since both this bucket's last
+    # request and the limiter's last sweep, so the bucket is fully refilled
+    # (idle) and the next check() call is due to sweep.
+    rl._buckets[key_a].last_refill -= 1000
+    rl._last_sweep -= 1000
+
+    rl.check(_env(ip="2.2.2.2"))  # triggers the sweep as a side effect
+
+    assert key_a not in rl._buckets  # idle bucket dropped
+    assert ("2.2.2.2", "") in rl._buckets  # the just-created one stays
+
+
+def test_actively_throttled_buckets_survive_sweep():
+    """A bucket that's currently rate-limiting a client (partial/zero
+    tokens) must NOT be dropped by the sweep -- that would silently reset
+    the client's limit early, defeating the point of the limiter."""
+    rl = RateLimiter(RateLimitConfig(enabled=True, default_rpm=1))
+    rl.check(_env(ip="1.1.1.1"))  # consumes the only token
+    assert rl.check(_env(ip="1.1.1.1"))[0] is False  # now throttled
+
+    key_a = ("1.1.1.1", "")
+    assert rl._buckets[key_a].tokens < 1.0
+
+    # Force the sweep to run, but WITHOUT enough elapsed time for the
+    # throttled bucket to refill (unlike the idle-bucket test above).
+    rl._last_sweep -= 1000
+
+    rl.check(_env(ip="2.2.2.2"))
+
+    assert key_a in rl._buckets  # still throttled, not reset early
+    assert rl.check(_env(ip="1.1.1.1"))[0] is False
+
+
+def test_sweep_does_not_run_before_interval_elapses():
+    """The sweep only runs once per _SWEEP_INTERVAL_SECONDS -- it rides
+    along with normal request traffic rather than needing its own thread,
+    so it must not do the (cheap but non-zero) full-dict scan on every
+    single request."""
+    from fymo.core.middleware import _SWEEP_INTERVAL_SECONDS
+
+    rl = RateLimiter(RateLimitConfig(enabled=True, default_rpm=60))
+    rl.check(_env(ip="1.1.1.1"))
+    last_sweep_before = rl._last_sweep
+
+    rl.check(_env(ip="2.2.2.2"))  # well within the interval
+
+    assert rl._last_sweep == last_sweep_before
+    assert _SWEEP_INTERVAL_SECONDS > 0
+
+
 # ---------------- Body cap ----------------
 
 
@@ -253,6 +315,36 @@ def test_settings_from_yaml_complete():
 def test_settings_disabled_rate_limit():
     s = MiddlewareSettings.from_yaml(
         limits={"rate_limit": {"enabled": False}}, security={},
+    )
+    assert s.rate_limit_config.enabled is False
+
+
+def test_rate_limit_disabled_by_default_in_dev():
+    """A single developer's browser tabs/soft-nav clicks/reloads all share
+    one token bucket for the whole `fymo dev` process life -- the
+    production-sane 60/min default is easy to exhaust during ordinary local
+    testing, so dev mode must not rate-limit unless explicitly asked to."""
+    s = MiddlewareSettings.from_yaml(limits={}, security={}, dev=True)
+    assert s.rate_limit_config.enabled is False
+
+
+def test_rate_limit_enabled_by_default_in_prod():
+    s = MiddlewareSettings.from_yaml(limits={}, security={}, dev=False)
+    assert s.rate_limit_config.enabled is True
+
+
+def test_rate_limit_explicit_enabled_true_wins_even_in_dev():
+    """An explicit `rate_limit.enabled: true` in fymo.yml must still be
+    honored in dev -- e.g. someone deliberately testing the limiter locally."""
+    s = MiddlewareSettings.from_yaml(
+        limits={"rate_limit": {"enabled": True}}, security={}, dev=True,
+    )
+    assert s.rate_limit_config.enabled is True
+
+
+def test_rate_limit_explicit_enabled_false_wins_even_in_prod():
+    s = MiddlewareSettings.from_yaml(
+        limits={"rate_limit": {"enabled": False}}, security={}, dev=False,
     )
     assert s.rate_limit_config.enabled is False
 

--- a/tests/integration/test_hydration_real.py
+++ b/tests/integration/test_hydration_real.py
@@ -1,0 +1,153 @@
+"""Real-hydration regression test.
+
+Builds blog_app for real, serves it on a real TCP port, and runs the actual
+compiled client bundle against the actual SSR HTML via hydration_check.mjs
+(fymo/build/js/hydration_check.mjs) -- a small jsdom-based script that
+executes Svelte's real hydrate() call against real DOM APIs, the same way a
+real browser would.
+
+This exists because every hydration bug found in this codebase so far (the
+dev_orchestrator layout-fields bug, and the SSR/shell static-vs-dynamic
+component-tag bug -- see composition_generator.py's SSR_TREE_TEMPLATE) was
+invisible to the rest of the test suite: everything else talks to the WSGI
+app in-process and asserts on HTML strings or manifest fields, which proves
+the server produced *some* markup but proves nothing about whether a
+browser can actually hydrate it. This test closes that blind spot without
+depending on a full browser-automation stack (Playwright et al.).
+"""
+import json
+import socket
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+HYDRATION_CHECK_JS = REPO_ROOT / "fymo" / "build" / "js" / "hydration_check.mjs"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _run_hydration_check(url: str, dist_dir: Path) -> dict:
+    proc = subprocess.run(
+        ["node", str(HYDRATION_CHECK_JS), url, str(dist_dir)],
+        capture_output=True, text=True, timeout=30,
+    )
+    lines = proc.stdout.strip().splitlines()
+    if not lines:
+        pytest.fail(f"hydration_check.mjs produced no output.\nstderr: {proc.stderr}")
+    try:
+        return json.loads(lines[-1])
+    except json.JSONDecodeError:
+        pytest.fail(f"hydration_check.mjs produced non-JSON output.\nstdout: {proc.stdout}\nstderr: {proc.stderr}")
+
+
+@pytest.mark.usefixtures("node_available")
+def test_layout_shell_routes_hydrate_cleanly(blog_app: Path, monkeypatch):
+    """Both the root-layout-only "index" route and the "posts"
+    resource-detail route -- the two routes actually affected by the
+    SSR/shell dynamic-component-tag mismatch -- must hydrate with zero
+    console errors/warnings against a real, freshly-built app."""
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=blog_app).build(dev=False)
+
+    monkeypatch.chdir(blog_app)
+    from tests.integration._seed_helpers import seed_test_post
+    seed_test_post()
+
+    from fymo import create_app
+    app = create_app(blog_app, dev=False)
+
+    from fymo.server.dev import make_dev_server
+    port = _free_port()
+    server = make_dev_server("127.0.0.1", port, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        dist_dir = blog_app / "dist"
+        for route_path in ("/", "/posts/welcome-to-fymo"):
+            result = _run_hydration_check(f"http://127.0.0.1:{port}{route_path}", dist_dir)
+            assert result["errors"] == [], f"{route_path}: {result}"
+            assert result["warnings"] == [], f"{route_path}: {result}"
+            assert result["ok"] is True, f"{route_path}: {result}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        if app.sidecar:
+            app.sidecar.stop()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_hydration_check_reusable_across_calls_in_one_process(blog_app: Path, monkeypatch):
+    """hydration_check.mjs's `checkHydration` is also importable as a
+    library function (not just a one-shot CLI), for callers that want to
+    check more than one route without a subprocess per route. Prove that
+    calling it twice in the same Node process doesn't leak state: it
+    globally overrides Node's own `Event`/`EventTarget` classes with
+    jsdom's (so `instanceof` checks against jsdom-created DOM objects work
+    -- Node has its own separate, non-DOM implementations of those same
+    names), which MUST be restored after each call or the second call (or
+    anything else sharing that process) would silently corrupt every
+    `instanceof Event`/`EventTarget` check for the rest of the process."""
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=blog_app).build(dev=False)
+
+    monkeypatch.chdir(blog_app)
+    from tests.integration._seed_helpers import seed_test_post
+    seed_test_post()
+
+    from fymo import create_app
+    app = create_app(blog_app, dev=False)
+
+    from fymo.server.dev import make_dev_server
+    port = _free_port()
+    server = make_dev_server("127.0.0.1", port, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        dist_dir = blog_app / "dist"
+        script = f"""
+import {{ checkHydration }} from {json.dumps(str(HYDRATION_CHECK_JS))};
+
+const nodeEventBefore = globalThis.Event;
+const nodeEventTargetBefore = globalThis.EventTarget;
+
+const r1 = await checkHydration({json.dumps(f"http://127.0.0.1:{port}/")}, {json.dumps(str(dist_dir))});
+const eventRestoredAfterRun1 = globalThis.Event === nodeEventBefore;
+const eventTargetRestoredAfterRun1 = globalThis.EventTarget === nodeEventTargetBefore;
+
+const r2 = await checkHydration({json.dumps(f"http://127.0.0.1:{port}/posts/welcome-to-fymo")}, {json.dumps(str(dist_dir))});
+const eventRestoredAfterRun2 = globalThis.Event === nodeEventBefore;
+const eventTargetRestoredAfterRun2 = globalThis.EventTarget === nodeEventTargetBefore;
+
+console.log(JSON.stringify({{
+  r1, r2,
+  eventRestoredAfterRun1, eventTargetRestoredAfterRun1,
+  eventRestoredAfterRun2, eventTargetRestoredAfterRun2,
+  errorArraysAreDistinctObjects: r1.errors !== r2.errors,
+}}));
+"""
+        proc = subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert proc.returncode == 0, f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+        result = json.loads(proc.stdout.strip().splitlines()[-1])
+
+        assert result["r1"]["ok"] is True, result["r1"]
+        assert result["r2"]["ok"] is True, result["r2"]
+        assert result["eventRestoredAfterRun1"] is True
+        assert result["eventTargetRestoredAfterRun1"] is True
+        assert result["eventRestoredAfterRun2"] is True
+        assert result["eventTargetRestoredAfterRun2"] is True
+        assert result["errorArraysAreDistinctObjects"] is True
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        if app.sidecar:
+            app.sidecar.stop()

--- a/tests/integration/test_layout_system_e2e.py
+++ b/tests/integration/test_layout_system_e2e.py
@@ -51,16 +51,21 @@ def test_full_layout_system_end_to_end(blog_app: Path):
     from fymo.build.manifest import Manifest
     manifest = Manifest.read(blog_app / "dist" / "manifest.json")
 
-    # 1. Manifest shape: root layout applies to every route. Task 11's
-    #    migration only added examples/blog_app/app/templates/_layout.svelte
-    #    (a root layout) -- there is no posts/_layout.svelte or
-    #    tags/_layout.svelte, so every route's layout_chain has exactly one
-    #    "root" entry and no "resource" entry.
+    # 1. Manifest shape: root layout applies to every route. blog_app also
+    #    has app/templates/posts/_layout.svelte (a resource layout, added to
+    #    give the reactive-swap machinery real, exercised coverage rather
+    #    than only synthetic unit-test coverage) -- so "posts" has both a
+    #    "root" and a "resource" entry, while "index"/"tags" (no resource
+    #    layout of their own) have only "root".
     assert "_root" in manifest.layouts
-    for route_name in ("index", "posts", "tags"):
+    assert "posts" in manifest.layouts
+    for route_name in ("index", "tags"):
         route = manifest.routes[route_name]
         assert route.uses_layout_shell is True
         assert [ref.level for ref in route.layout_chain] == ["root"]
+    posts_route = manifest.routes["posts"]
+    assert posts_route.uses_layout_shell is True
+    assert [ref.level for ref in posts_route.layout_chain] == ["root", "resource"]
 
     # 2. Full-page SSR includes Nav (from the layout) exactly once.
     # FymoApp is itself the WSGI callable (implements __call__) -- there is
@@ -72,16 +77,18 @@ def test_full_layout_system_end_to_end(blog_app: Path):
     html = out.decode("utf-8")
     assert html.count("<nav") == 1
 
-    # 3. Soft-nav to a post reports usesLayoutShell + omits resourceLayout
-    #    (no posts/_layout.svelte in this migration), and rootLayoutProps
-    #    is present ({} since the root layout has no controller).
+    # 3. Soft-nav to a post reports usesLayoutShell + a real resourceLayout
+    #    (posts/_layout.svelte), and rootLayoutProps is present ({} since
+    #    the root layout has no controller).
     from tests.integration._seed_helpers import seed_test_post
     seed_test_post()
     status, out = _wsgi_get(app, "/_fymo/data/posts/welcome-to-fymo")
     payload = json.loads(out)
     decoded = devalue.parse(payload["result"])
     assert decoded["leaf"]["usesLayoutShell"] is True
-    assert decoded["leaf"]["resourceLayout"] is None
+    assert decoded["leaf"]["resourceLayout"] is not None
+    assert decoded["leaf"]["resourceLayout"]["id"] == "posts"
+    assert decoded["leaf"]["resourceLayout"]["module"].startswith("/dist/client/_layout-posts.")
     assert decoded["leaf"]["rootLayoutProps"] == {}
 
     # 4. The generated client shell for "index" actually contains the


### PR DESCRIPTION
## Summary

- **Root cause fix**: SSR and the client shell disagreed on whether the leaf/resource-layout component tag was static or `$state`-bound dynamic, so Svelte compiled them differently — the server's HTML was missing a hydration marker the client's compiled code required. Result: every route using the layout shell crashed at hydration (`hydration_mismatch` + a caught `HYDRATION_ERROR`), discarding the entire server-rendered page for the "Something went wrong" fallback, in both `fymo dev` and `fymo build`.
- **`fymo dev` manifest bug**: `DevOrchestrator._write_manifest()` never learned about the layout system and always wrote `layout_chain=[]`, while the client bootstrap it served was already layout-aware — a separate crash (`Cannot read properties of undefined (reading 'root')`) preceding the one above. Fixed by extracting the esbuild-manifest-matching logic shared by `fymo build`/`fymo dev` into `manifest_matching.py` so the two can't drift again.
- **New regression coverage**: `fymo/build/js/hydration_check.mjs`, a jsdom-based script that actually executes the real compiled client bundle against real DOM APIs and reports console errors — closing a real blind spot, since every hydration bug here was invisible to WSGI/HTML-string-level tests. Wired into pytest.
- **blog_app**: added a real resource-level layout for `posts` (previously only root-level layouts existed), giving the reactive layout-swap machinery live coverage instead of only synthetic unit tests.
- **Rate limiting**: disabled by default in `fymo dev` (a single dev's browser tabs/reloads share one bucket and exhaust the prod-sane 60/min default), still fully overridable via `fymo.yml`. Also fixed `RateLimiter._buckets` growing unbounded in long-running processes — idle/fully-refilled buckets are now swept.
- Along the way: fixed a `tests/conftest.py` fixture that never cleaned up `sys.path`/`sys.modules`, which could silently corrupt a second test's database in the same file.

## Test plan

- [x] Full suite: 573 passed, 10 skipped
- [x] Reverted the core fix and confirmed the new tests fail with a real assertion; restored and confirmed they pass (proving the tests actually gate the regression, not just pass vacuously)
- [x] Verified live in a real browser (Chrome), not just curl/pytest: direct page load, soft-nav into a post (first-ever exercise of `swapResourceLayout`), and soft-nav back out — all clean, under both `fymo dev` and a real `fymo build`
- [x] Independent adversarial code review pass (fresh agent, no prior context) on the full diff; one real gap it surfaced (jsdom global-shimming not overriding Node's own `Event`/`EventTarget`) was fixed and covered with a dedicated test proving no state leaks across repeated calls in one process