### PR TITLE
Secure-by-default remote exposure: enforce explicit opt-in at build time

### DIFF
--- a/examples/blog_app/app/remote/posts.py
+++ b/examples/blog_app/app/remote/posts.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from typing import TypedDict, Literal
 from pydantic import BaseModel, Field
 
-from fymo.remote import current_uid, NotFound
+from fymo.remote import current_uid, NotFound, remote
 from fymo.auth import require_auth, current_user
 from app.data.db import get_db
 
@@ -46,12 +46,14 @@ class NewComment(BaseModel):
     body: str = Field(min_length=1, max_length=1000)
 
 
+@remote
 def get_posts() -> list[PostSummary]:
     return get_db().fetchall(
         "SELECT slug, title, summary, tags, published_at FROM posts ORDER BY published_at DESC"
     )
 
 
+@remote
 def get_post(slug: str) -> Post:
     row = get_db().fetchone(
         "SELECT slug, title, summary, content_html, tags, published_at FROM posts WHERE slug = ?",
@@ -62,6 +64,7 @@ def get_post(slug: str) -> Post:
     return row
 
 
+@remote
 def get_comments(slug: str) -> list[Comment]:
     return get_db().fetchall(
         "SELECT id, name, body, created_at FROM comments WHERE post_slug = ? ORDER BY created_at DESC",
@@ -69,6 +72,7 @@ def get_comments(slug: str) -> list[Comment]:
     )
 
 
+@remote
 @require_auth
 def create_comment(slug: str, input: NewComment) -> Comment:
     # Author comes from the authenticated session, never client input. Display
@@ -84,6 +88,7 @@ def create_comment(slug: str, input: NewComment) -> Comment:
     )
 
 
+@remote
 def get_reactions(slug: str) -> ReactionCounts:
     rows = get_db().fetchall(
         "SELECT kind, COUNT(*) AS n FROM reactions WHERE post_slug = ? GROUP BY kind",
@@ -95,6 +100,7 @@ def get_reactions(slug: str) -> ReactionCounts:
     return counts
 
 
+@remote
 def toggle_reaction(slug: str, kind: ReactionKind) -> ReactionCounts:
     uid = current_uid()
     db = get_db()

--- a/examples/blog_app/fymo.yml
+++ b/examples/blog_app/fymo.yml
@@ -11,6 +11,12 @@ routes:
 auth:
   enabled: true
 
+# Every function in app/remote/posts.py is marked @remote (see that file).
+# With explicit_optin on, that's what actually makes them reachable over the
+# wire, rather than file placement alone deciding it.
+remote:
+  explicit_optin: true
+
 build:
   output_dir: dist
   minify: false

--- a/fymo/build/hygiene.py
+++ b/fymo/build/hygiene.py
@@ -8,6 +8,8 @@ in a template/component directory -- which is exactly what makes it easy
 to miss without an explicit check: the file just silently does nothing,
 instead of erroring where a developer would notice.
 """
+import importlib
+import sys
 from pathlib import Path
 from typing import List
 
@@ -44,4 +46,85 @@ def format_hygiene_error(violations: List[str]) -> str:
         "Directory hygiene violation(s) found:\n" + bullet_list +
         "\n\napp/controllers/ is Python-only; app/templates/ and app/components/ "
         "are frontend-only."
+    )
+
+
+def check_remote_exposure_hygiene(project_root: Path, remote_config: "dict | None") -> List[str]:
+    """Return one violation per app/remote/*.py function that implicit-mode
+    discovery would expose to the browser but that carries no `@remote`
+    marker (issue #8: file placement alone used to be the only thing
+    deciding browser-callability, and a real app got that wrong: an
+    internal storage helper landed in app/remote/ with no auth guard and
+    turned out to be reachable over the wire).
+
+    A no-op (returns []) when `remote.explicit_optin` is true, since in that
+    mode an unmarked function is already excluded from the manifest and
+    the router by `discovery.is_exposed_remote_fn`, so there's nothing
+    silently exposed to warn about. Also a no-op when `remote.allow_implicit`
+    is true, the documented-unsafe escape hatch for apps that aren't ready
+    to migrate yet.
+
+    Imports every app/remote/*.py module to apply the exact same exposure
+    rule discovery uses at codegen time (`is_exposed_remote_fn` with
+    explicit_optin=False, i.e. "what would ship if opt-in were off"), so
+    this can never drift from what the manifest/router actually expose.
+    """
+    remote_config = remote_config or {}
+    if remote_config.get("explicit_optin", False):
+        return []
+    if remote_config.get("allow_implicit", False):
+        return []
+
+    remote_dir = project_root / "app" / "remote"
+    if not remote_dir.is_dir():
+        return []
+
+    from fymo.remote.discovery import _ensure_parent_packages, is_exposed_remote_fn
+
+    violations: List[str] = []
+    project_root_str = str(project_root)
+    added = project_root_str not in sys.path
+    if added:
+        sys.path.insert(0, project_root_str)
+    try:
+        _ensure_parent_packages(project_root)
+        for py in sorted(remote_dir.glob("*.py")):
+            if py.name == "__init__.py" or py.stem.startswith("_"):
+                continue
+            module_name = py.stem
+            full = f"app.remote.{module_name}"
+            if full in sys.modules:
+                mod = importlib.reload(sys.modules[full])
+            else:
+                mod = importlib.import_module(full)
+            for name, obj in vars(mod).items():
+                if name.startswith("_"):
+                    continue
+                # explicit_optin=False here on purpose: this asks "would
+                # implicit mode expose this", not "is it exposed right now".
+                if not is_exposed_remote_fn(obj, full, explicit_optin=False):
+                    continue
+                if getattr(obj, "__fymo_remote__", False):
+                    continue
+                violations.append(
+                    f"{py.relative_to(project_root)}: {name} is browser-callable "
+                    f"under implicit mode but has no @remote marker "
+                    f"(add @remote or rename it with a leading underscore to keep it private)"
+                )
+    finally:
+        if added and project_root_str in sys.path:
+            sys.path.remove(project_root_str)
+
+    return violations
+
+
+def format_remote_exposure_error(violations: List[str]) -> str:
+    bullet_list = "\n".join(f"  - {v}" for v in violations)
+    return (
+        "Unmarked remote function(s) would be exposed under implicit mode:\n" + bullet_list +
+        "\n\nEvery public function in app/remote/*.py is browser-callable by default "
+        "when remote.explicit_optin is false. Add @remote (from fymo.remote) to each "
+        "function above that's meant to be an endpoint, or rename it with a leading "
+        "underscore to keep it a private helper. To silence this check without fixing "
+        "it (unsafe, temporary), set remote.allow_implicit: true in fymo.yml."
     )

--- a/fymo/build/prepare.py
+++ b/fymo/build/prepare.py
@@ -23,7 +23,12 @@ from fymo.broadcast.codegen import emit_broadcast_client
 from fymo.build.composition_generator import generate_ssr_tree
 from fymo.build.discovery import discover_routes, discover_all_layouts
 from fymo.build.entry_generator import write_client_entries
-from fymo.build.hygiene import check_directory_hygiene, format_hygiene_error
+from fymo.build.hygiene import (
+    check_directory_hygiene,
+    check_remote_exposure_hygiene,
+    format_hygiene_error,
+    format_remote_exposure_error,
+)
 from fymo.build.manifest import RemoteModuleAssets
 from fymo.remote.codegen import emit_module, emit_runtime
 from fymo.remote.discovery import discover_remote_modules
@@ -96,6 +101,19 @@ def prepare_build_config(project_root: Path, dist_dir: Path, cache_dir: Path, de
     if hygiene_violations:
         raise BuildError(format_hygiene_error(hygiene_violations))
 
+    # Read once, reused below for discover_remote_modules too: both need the
+    # same `remote:` section, and re-reading fymo.yml a second time would
+    # risk the two calls drifting if the file changes mid-build.
+    remote_config = read_yaml_section(project_root, "remote")
+
+    # Also a pure-Python check (imports app/remote/*.py but does not touch
+    # node/esbuild), so it runs alongside directory hygiene rather than
+    # waiting on the node check below: a developer shipping an unguarded
+    # endpoint should hear about it even on a machine without node installed.
+    remote_exposure_violations = check_remote_exposure_hygiene(project_root, remote_config)
+    if remote_exposure_violations:
+        raise BuildError(format_remote_exposure_error(remote_exposure_violations))
+
     if shutil.which("node") is None:
         raise BuildError("node not found on PATH" if dev else "node executable not found on PATH")
 
@@ -135,7 +153,7 @@ def prepare_build_config(project_root: Path, dist_dir: Path, cache_dir: Path, de
         remote_modules = discover_remote_modules(
             project_root,
             auth_config=read_yaml_section(project_root, "auth"),
-            remote_config=read_yaml_section(project_root, "remote"),
+            remote_config=remote_config,
         )
     except ValueError as e:
         if dev:
@@ -148,6 +166,13 @@ def prepare_build_config(project_root: Path, dist_dir: Path, cache_dir: Path, de
     if remote_modules:
         emit_runtime(remote_out)
         for module_name, fns in remote_modules.items():
+            # A module can now discover to zero functions, e.g. under
+            # explicit_optin with every function in the file left unmarked,
+            # a private-helpers-only module. emit_module indexes fns.values()
+            # for the shared module_hash, which is undefined with nothing in
+            # it, so skip rather than emit a pointless empty client module.
+            if not fns:
+                continue
             emit_module(module_name, fns, remote_out)
 
     # Codegen for app/broadcasts/*.py -- dist/client/_broadcast/<name>.{js,d.ts}

--- a/fymo/cli/commands/_scaffold.py
+++ b/fymo/cli/commands/_scaffold.py
@@ -22,6 +22,13 @@ routes:
   resources:
     - posts
 
+# Remote functions (app/remote/*.py) require an explicit @remote marker to
+# be browser-callable: file placement alone is not enough. Flip to false
+# only if migrating an older project that relies on implicit exposure, and
+# consider remote.allow_implicit: true as a temporary bridge instead.
+remote:
+  explicit_optin: true
+
 # Build configuration
 build:
   output_dir: dist

--- a/tests/build/test_prepare.py
+++ b/tests/build/test_prepare.py
@@ -1,10 +1,25 @@
 """Tests for the shared pre-esbuild build-configuration preparation used by
 both `fymo build` (BuildPipeline) and `fymo dev` (DevOrchestrator)."""
+import sys
 from pathlib import Path
 
 import pytest
 
 from fymo.build.prepare import BuildConfig, BuildError, prepare_build_config, read_yaml_section
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_app_modules():
+    """Tests below import app.remote.* modules (via prepare_build_config's
+    remote discovery, which inserts/removes project_root on sys.path but
+    never clears sys.modules). Without this, a cached `app.remote.versions`
+    from one test's tmp_path leaks into a later test elsewhere in the suite
+    that also uses the conventional `app.remote.posts` module name: same
+    pollution risk documented on the `blog_app` fixture in conftest.py."""
+    yield
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
 
 
 def test_hygiene_violation_raises_build_error(example_app: Path):
@@ -41,6 +56,64 @@ def test_read_yaml_section_returns_requested_key(tmp_path: Path):
     assert read_yaml_section(tmp_path, "auth") == {"enabled": True}
     assert read_yaml_section(tmp_path, "remote") == {"explicit_optin": True}
     assert read_yaml_section(tmp_path, "missing") == {}
+
+
+def test_unmarked_remote_function_raises_build_error(example_app: Path):
+    """Issue #8: with explicit_optin left at its default (false) and no
+    allow_implicit escape hatch, an unmarked app/remote/*.py function must
+    fail the build naming the specific function. Same ordering promise as
+    directory hygiene: caught before node/esbuild."""
+    (example_app / "app" / "remote").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "remote" / "__init__.py").write_text("")
+    (example_app / "app" / "remote" / "versions.py").write_text(
+        "def insert_version(x: str) -> str: return x\n"
+    )
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    with pytest.raises(BuildError, match="insert_version"):
+        prepare_build_config(example_app, dist_dir, cache_dir, dev=False)
+
+
+def test_allow_implicit_escape_hatch_lets_unmarked_function_build(example_app: Path, monkeypatch):
+    """remote.allow_implicit: true preserves today's behavior for apps not
+    ready to migrate. The build must succeed, not just skip the hygiene
+    error."""
+    (example_app / "app" / "remote").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "remote" / "__init__.py").write_text("")
+    (example_app / "app" / "remote" / "versions.py").write_text(
+        "def insert_version(x: str) -> str: return x\n"
+    )
+    (example_app / "fymo.yml").write_text(
+        (example_app / "fymo.yml").read_text() + "\nremote:\n  allow_implicit: true\n"
+    )
+    monkeypatch.setattr("fymo.build.prepare.shutil.which", lambda cmd: "/usr/bin/node")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    config = prepare_build_config(example_app, dist_dir, cache_dir, dev=True)
+    assert isinstance(config, BuildConfig)
+
+
+def test_explicit_optin_true_lets_unmarked_function_build_with_no_warning(example_app: Path, monkeypatch):
+    """With explicit_optin true, an unmarked function is a private helper:
+    not exposed, but also not a hygiene violation. The build must succeed
+    cleanly, and the function must not appear in the remote assets."""
+    (example_app / "app" / "remote").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "remote" / "__init__.py").write_text("")
+    (example_app / "app" / "remote" / "versions.py").write_text(
+        "def insert_version(x: str) -> str: return x\n"
+    )
+    (example_app / "fymo.yml").write_text(
+        (example_app / "fymo.yml").read_text() + "\nremote:\n  explicit_optin: true\n"
+    )
+    monkeypatch.setattr("fymo.build.prepare.shutil.which", lambda cmd: "/usr/bin/node")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    config = prepare_build_config(example_app, dist_dir, cache_dir, dev=True)
+    assert isinstance(config, BuildConfig)
+    # No exposed functions in versions.py at all under explicit_optin -> the
+    # module contributes nothing to remote_assets (see prepare's `if not
+    # fns: continue`), so it must not appear as a key.
+    assert "versions" not in config.remote_assets
 
 
 @pytest.mark.usefixtures("node_available")

--- a/tests/build/test_remote_exposure_hygiene.py
+++ b/tests/build/test_remote_exposure_hygiene.py
@@ -1,0 +1,176 @@
+"""Build-time enforcement of explicit remote exposure (issue #8).
+
+File placement alone in app/remote/*.py used to be a security decision:
+every public typed top-level function was browser-callable by default. A
+real app got this wrong: an internal storage helper sat next to real
+endpoints with no auth guard and turned out to be callable over the wire.
+
+`remote.explicit_optin` already lets a project require `@remote` on
+anything it wants exposed (see fymo/remote/decorators.py and
+discovery.is_exposed_remote_fn), but with the flag left at its default
+(False) nothing told a developer they were shipping implicit exposure.
+This module's check closes that gap: when explicit_optin is off, the build
+fails and names every function that IS exposed under implicit mode but
+carries no `@remote` marker, so a developer can mark it or move it before
+it ships. `remote.allow_implicit: true` is the documented-unsafe escape
+hatch for apps not ready to migrate.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+from fymo.build.hygiene import check_remote_exposure_hygiene, format_remote_exposure_error
+
+
+def _scaffold(tmp_path: Path, files: dict[str, str]) -> Path:
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return tmp_path
+
+
+def _cleanup_app_modules() -> None:
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
+
+
+MARKED_AND_UNMARKED = (
+    "from fymo.remote import remote\n"
+    "@remote\n"
+    "def get_posts() -> list: return []\n"
+    "def insert_version(x: str) -> str: return x\n"
+)
+
+ALL_MARKED = (
+    "from fymo.remote import remote\n"
+    "@remote\n"
+    "def get_posts() -> list: return []\n"
+    "@remote\n"
+    "def get_post(slug: str) -> dict: return {}\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    _cleanup_app_modules()
+
+
+def test_no_app_remote_dir_has_no_violations(tmp_path: Path):
+    assert check_remote_exposure_hygiene(tmp_path, {}) == []
+
+
+def test_unmarked_function_is_a_violation_under_default_config(tmp_path: Path):
+    """explicit_optin defaults to False and allow_implicit is unset: the
+    permissive-but-unsafe combination this check exists to catch."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {})
+    finally:
+        sys.path.remove(str(project))
+
+    assert len(violations) == 1
+    assert "app/remote/versions.py" in violations[0]
+    assert "insert_version" in violations[0]
+    assert "get_posts" not in violations[0]
+
+
+def test_all_marked_functions_have_no_violations(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": ALL_MARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_allow_implicit_escape_hatch_silences_the_check(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {"allow_implicit": True})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_explicit_optin_true_skips_the_check_entirely(tmp_path: Path):
+    """When explicit_optin is on, an unmarked function is simply not exposed
+    (private helper): there's nothing to warn about in this mode."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {"explicit_optin": True})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_multiple_unmarked_functions_across_modules_all_reported(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+        "app/remote/jobs.py": "def run_job(id: str) -> str: return id\n",
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {})
+    finally:
+        sys.path.remove(str(project))
+
+    assert len(violations) == 2
+    joined = "\n".join(violations)
+    assert "insert_version" in joined
+    assert "run_job" in joined
+
+
+def test_underscore_prefixed_helpers_are_not_flagged(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": (
+            "def _private_helper(x: str) -> str: return x\n"
+        ),
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_format_remote_exposure_error_names_the_functions():
+    msg = format_remote_exposure_error([
+        "app/remote/versions.py: insert_version is browser-callable "
+        "but has no @remote marker"
+    ])
+    assert "insert_version" in msg
+    assert "app/remote/versions.py" in msg
+    assert "allow_implicit" in msg

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -40,6 +40,17 @@ def test_new_and_init_scaffold_identical_fymo_yml(tmp_path):
     assert "sample_app" in content
 
 
+def test_new_scaffold_defaults_to_explicit_remote_optin(tmp_path):
+    """Issue #8: fresh projects should require @remote to expose a function,
+    not fall back to implicit file-placement exposure. Existing projects are
+    unaffected: this only changes what NEW projects generate."""
+    from fymo.cli.commands._scaffold import render_fymo_yml
+    import yaml
+    content = render_fymo_yml("sample_app")
+    data = yaml.safe_load(content)
+    assert data["remote"]["explicit_optin"] is True
+
+
 def test_new_does_not_scaffold_dead_config_routes(tmp_path, monkeypatch):
     """new.py used to ship config/routes.py into every project, but the
     router only ever reads it when fymo.yml is ABSENT — and new.py always

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,23 @@ def _fymo_secret_for_tests() -> None:
     os.environ.setdefault("FYMO_SECRET", "test-secret-please-do-not-use-in-prod-32b!")
 
 
+@pytest.fixture(autouse=True)
+def _reset_remote_router_globals():
+    """`FymoApp.__init__` (fymo/core/server.py) writes `_explicit_optin` and
+    `_dev_mode` directly onto the `fymo.remote.router` module: real
+    per-project config, not something a test fixture owns, so nothing
+    restores it the way `monkeypatch.setattr` would. Any test that builds a
+    FymoApp over a project with `remote.explicit_optin: true` (e.g. the
+    blog_app fixture) leaves that global at True for every test that runs
+    afterward in the same process, silently 404ing unmarked functions in
+    unrelated tests that assume today's default. Reset after every test
+    regardless of how it was set."""
+    yield
+    from fymo.remote import router as _remote_router
+    _remote_router._explicit_optin = False
+    _remote_router._dev_mode = False
+
+
 @pytest.fixture
 def example_app(tmp_path: Path) -> Path:
     """Copy of examples/todo_app into an isolated tmp dir.

--- a/tests/integration/test_remote_codegen_e2e.py
+++ b/tests/integration/test_remote_codegen_e2e.py
@@ -13,6 +13,8 @@ def test_build_emits_remote_artifacts(example_app: Path):
     remote_dir.mkdir(parents=True, exist_ok=True)
     (remote_dir / "__init__.py").write_text("")
     (remote_dir / "test_mod.py").write_text(
+        "from fymo.remote import remote\n"
+        "@remote\n"
         "def hello(name: str) -> str:\n    return f'hi {name}'\n"
     )
 

--- a/tests/integration/test_remote_e2e.py
+++ b/tests/integration/test_remote_e2e.py
@@ -14,6 +14,8 @@ def test_remote_call_through_fymoapp(example_app: Path, monkeypatch):
     remote_dir.mkdir(parents=True, exist_ok=True)
     (remote_dir / "__init__.py").write_text("")
     (remote_dir / "greeter.py").write_text(
+        "from fymo.remote import remote\n"
+        "@remote\n"
         "def hello(name: str) -> str:\n    return f'hi {name}'\n"
     )
 

--- a/tests/integration/test_remote_import.py
+++ b/tests/integration/test_remote_import.py
@@ -11,6 +11,8 @@ def test_remote_import_resolves(example_app: Path):
     remote.mkdir(parents=True, exist_ok=True)
     (remote / "__init__.py").write_text("")
     (remote / "greeter.py").write_text(
+        "from fymo.remote import remote\n"
+        "@remote\n"
         "def hello(name: str) -> str:\n    return f'hi {name}'\n"
     )
 

--- a/tests/integration/test_request_flow.py
+++ b/tests/integration/test_request_flow.py
@@ -160,7 +160,11 @@ def test_client_entry_calls_resolve_remote_props(example_app, monkeypatch):
     remote = example_app / "app" / "remote"
     remote.mkdir(parents=True, exist_ok=True)
     (remote / "__init__.py").write_text("")
-    (remote / "x.py").write_text("def fn(s: str) -> str: return s\n")
+    (remote / "x.py").write_text(
+        "from fymo.remote import remote\n"
+        "@remote\n"
+        "def fn(s: str) -> str: return s\n"
+    )
 
     BuildPipeline(project_root=example_app).build(dev=False)
 


### PR DESCRIPTION
Closes #8

## Summary

- Any function sitting in `app/remote/*.py` used to be auto-exposed as a callable HTTP endpoint just by existing there. Now it must opt in with `@remote` (`fymo/remote/decorators.py`).
- `remote.explicit_optin: true` is the new scaffold default (`fymo new`/`init`), and a build-time hygiene check (`check_remote_exposure_hygiene` in `fymo/build/hygiene.py`) hard-fails the build for any un-decorated module-owned function, naming it.
- `is_exposed_remote_fn()` (the shared ownership/opt-in check used by both router dispatch and the hygiene check) is now `inspect.isfunction`-gated, closing a real dispatch gap where classes/callable objects in `app/remote/` could be invoked via a crafted request.
- `examples/blog_app` migrated: 6 functions decorated, `explicit_optin: true` set.

## Test plan

- [x] Full suite green
- [x] Hygiene check verified to fail the build on an un-decorated function, naming it
- [x] `isfunction` gating verified against a hand-crafted request targeting a class in `app/remote/`
- [x] Independent adversarial task review + final whole-branch review, no Critical/Important findings