### PR TITLE
Broadcast channels: dogfood the auth guard, real payload validation

### DIFF
--- a/examples/blog_app/app/broadcasts/posts.py
+++ b/examples/blog_app/app/broadcasts/posts.py
@@ -1,0 +1,30 @@
+"""Broadcast channels for the blog: live comment/reaction activity on a
+post, pushed to anyone reading that post's page.
+
+Reference example for the app/broadcasts/*.py convention: the function
+signature is the subscribe args, the return annotation is the payload
+`publish()` is checked against in dev mode, and the body is the
+subscribe-time authorization guard, run for real on every SSE subscribe
+(see fymo/broadcast/sse.py's _run_guard).
+"""
+from typing import Literal, NotRequired, TypedDict
+
+from app.data.db import get_db
+from app.remote.posts import Comment, ReactionCounts
+from fymo.remote import NotFound
+
+
+class PostActivity(TypedDict):
+    kind: Literal["comment_added", "reaction_updated"]
+    comment: NotRequired[Comment]
+    reactions: NotRequired[ReactionCounts]
+
+
+def post_activity(slug: str) -> PostActivity:
+    # Deny subscribing to a post that isn't there (typo'd slug, deleted
+    # post) rather than silently opening a channel nothing will ever
+    # publish to. Everything else is open: posts are public, so anyone
+    # reading a post may watch its comment/reaction activity live, same
+    # visibility as get_comments()/get_reactions() already have.
+    if not get_db().fetchone("SELECT 1 FROM posts WHERE slug = ?", [slug]):
+        raise NotFound(f"post '{slug}' not found")

--- a/examples/blog_app/app/remote/posts.py
+++ b/examples/blog_app/app/remote/posts.py
@@ -1,4 +1,5 @@
 """Remote functions for the blog: reads + comment/reaction mutations."""
+import logging
 from datetime import datetime, timezone
 from typing import TypedDict, Literal
 from pydantic import BaseModel, Field
@@ -6,6 +7,8 @@ from pydantic import BaseModel, Field
 from fymo.remote import current_uid, NotFound
 from fymo.auth import require_auth, current_user
 from app.data.db import get_db
+
+logger = logging.getLogger("blog_app")
 
 
 class Post(TypedDict):
@@ -62,6 +65,17 @@ def get_post(slug: str) -> Post:
     return row
 
 
+def _publish_activity(slug: str, kind: str, **payload) -> None:
+    # Fire-and-forget: a subscriber missing this event isn't broken, they
+    # just fall back to whatever polling/refresh already covers the page,
+    # so a broadcast failure must never fail the mutation that triggered it.
+    try:
+        from fymo.broadcast import publish
+        publish("post_activity", slug=slug, data={"kind": kind, **payload})
+    except Exception:
+        logger.warning("post_activity broadcast failed for %s", slug, exc_info=True)
+
+
 def get_comments(slug: str) -> list[Comment]:
     return get_db().fetchall(
         "SELECT id, name, body, created_at FROM comments WHERE post_slug = ? ORDER BY created_at DESC",
@@ -79,9 +93,11 @@ def create_comment(slug: str, input: NewComment) -> Comment:
         "INSERT INTO comments (post_slug, uid, name, body, created_at) VALUES (?, ?, ?, ?, ?)",
         [slug, uid, author, input.body, datetime.now(timezone.utc).isoformat()],
     )
-    return get_db().fetchone(
+    comment = get_db().fetchone(
         "SELECT id, name, body, created_at FROM comments WHERE id = ?", [cid]
     )
+    _publish_activity(slug, "comment_added", comment=comment)
+    return comment
 
 
 def get_reactions(slug: str) -> ReactionCounts:
@@ -112,4 +128,6 @@ def toggle_reaction(slug: str, kind: ReactionKind) -> ReactionCounts:
             "INSERT INTO reactions (post_slug, uid, kind) VALUES (?, ?, ?)",
             [slug, uid, kind],
         )
-    return get_reactions(slug)
+    reactions = get_reactions(slug)
+    _publish_activity(slug, "reaction_updated", reactions=reactions)
+    return reactions

--- a/fymo/broadcast/__init__.py
+++ b/fymo/broadcast/__init__.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import logging
 import threading
+import typing
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
@@ -27,6 +29,13 @@ __all__ = [
     "init_broadcasts",
     "reset_broadcasts",
 ]
+
+logger = logging.getLogger("fymo.broadcast")
+
+# Dev mode: when True, publish() checks `data` against the channel's
+# TypedDict return annotation and logs a warning on mismatch. Off by
+# default (matches fymo.remote.router._dev_mode); set by fymo.core.server.
+_dev_mode: bool = False
 
 
 def channel_key(module: str, channel: str, args: Dict[str, Any]) -> str:
@@ -98,6 +107,44 @@ def init_broadcasts(project_root: Path, provider_config: Any) -> Any:
     return provider
 
 
+def _warn_payload_mismatch(channel: str, type_name: str, detail: str) -> None:
+    logger.warning(
+        "broadcast %r: published data does not match declared payload type %s: %s",
+        channel, type_name, detail,
+    )
+
+
+def _validate_payload(channel: str, fn: Callable, data: Any) -> None:
+    """Dev-only DX check: does `data` match the channel's declared return
+    type? Only understands TypedDict returns (the documented convention for
+    channel payloads); anything else (no annotation, `dict`, `...`-body
+    default style) is left unvalidated, same as production. Never raises;
+    a bad payload still gets delivered, this only helps a developer notice
+    the drift between what a channel promises and what it actually sends.
+    """
+    try:
+        hints = typing.get_type_hints(fn)
+    except Exception:
+        return  # unresolvable forward ref etc., not worth failing publish over
+    return_type = hints.get("return")
+    if return_type is None or not typing.is_typeddict(return_type):
+        return
+
+    type_name = getattr(return_type, "__name__", str(return_type))
+    if not isinstance(data, dict):
+        _warn_payload_mismatch(channel, type_name, f"expected an object, got {type(data).__name__}")
+        return
+
+    required = getattr(return_type, "__required_keys__", set())
+    optional = getattr(return_type, "__optional_keys__", set())
+    missing = required - data.keys()
+    if missing:
+        _warn_payload_mismatch(channel, type_name, f"missing required key(s) {sorted(missing)}")
+    extra = data.keys() - required - optional
+    if extra:
+        _warn_payload_mismatch(channel, type_name, f"unrecognized key(s) {sorted(extra)}")
+
+
 def publish(channel: str, data: Any = None, **args: Any) -> None:
     """Publish `data` to everyone currently subscribed to `channel` with
     exactly these args. Fire-and-forget: no subscribers, no delivery, no
@@ -110,6 +157,8 @@ def publish(channel: str, data: Any = None, **args: Any) -> None:
     if channel not in channels:
         raise ValueError(f"unknown broadcast channel: {channel!r}")
     module, fn = channels[channel]
+    if _dev_mode:
+        _validate_payload(channel, fn, data)
     bound = inspect.signature(fn).bind(**args)
     bound.apply_defaults()
     key = channel_key(module, channel, dict(bound.arguments))

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -91,6 +91,11 @@ class FymoApp:
         from fymo.remote import router as _remote_router
         _remote_router._dev_mode = self.dev
 
+        # Same flag into broadcasts: gates publish()'s payload-vs-TypedDict
+        # DX check, a warning-only aid that must add zero overhead in prod.
+        import fymo.broadcast as _broadcast_module
+        _broadcast_module._dev_mode = self.dev
+
         # Resolve and install the HMAC secret used to sign fymo_uid cookies.
         # Done eagerly at startup so production misconfiguration fails fast
         # instead of on the first remote call.

--- a/tests/broadcast/test_publish_validation.py
+++ b/tests/broadcast/test_publish_validation.py
@@ -1,0 +1,127 @@
+"""Dev-mode payload validation in publish(): a channel's return-type
+TypedDict is the contract for `data`; a mismatch is a warning, never a
+block. publish() must still deliver and never raise on a bad payload."""
+from pathlib import Path
+
+import pytest
+
+from fymo.broadcast import init_broadcasts, publish, reset_broadcasts, set_broadcast_provider
+import fymo.broadcast as broadcast_mod
+from fymo.broadcast.providers.base import BaseBroadcastProvider
+
+
+class CapturingProvider(BaseBroadcastProvider):
+    id = "capturing"
+
+    def __init__(self):
+        self.published = []
+
+    def publish(self, key, payload):
+        self.published.append((key, payload))
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_broadcasts()
+    yield
+    reset_broadcasts()
+    broadcast_mod._dev_mode = False
+
+
+@pytest.fixture
+def typed_channel(tmp_path: Path):
+    """A channel whose return annotation is a TypedDict with one required
+    and one optional key, enough to exercise missing/extra key checks."""
+    bdir = tmp_path / "app" / "broadcasts"
+    bdir.mkdir(parents=True)
+    (tmp_path / "app" / "__init__.py").touch()
+    (bdir / "__init__.py").touch()
+    (bdir / "runs.py").write_text(
+        "from typing import TypedDict, NotRequired\n"
+        "\n"
+        "class RunStatus(TypedDict):\n"
+        "    status: str\n"
+        "    error: NotRequired[str]\n"
+        "\n"
+        "def run_status(run_id: str) -> RunStatus:\n"
+        "    ...\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def untyped_channel(tmp_path: Path):
+    """A channel with no TypedDict return annotation, matching today's
+    default `-> dict:` / `...` body style. Must never be validated."""
+    bdir = tmp_path / "app" / "broadcasts"
+    bdir.mkdir(parents=True)
+    (tmp_path / "app" / "__init__.py").touch()
+    (bdir / "__init__.py").touch()
+    (bdir / "runs.py").write_text("def run_status(run_id: str) -> dict:\n    ...\n")
+    return tmp_path
+
+
+def _publish_matching(run_id="r1"):
+    publish("run_status", run_id=run_id, data={"status": "passed"})
+
+
+def _publish_missing_required(run_id="r1"):
+    publish("run_status", run_id=run_id, data={"error": "boom"})
+
+
+def _publish_extra_key(run_id="r1"):
+    publish("run_status", run_id=run_id, data={"status": "passed", "bogus": 1})
+
+
+def test_dev_mode_matching_payload_produces_no_warning(typed_channel, caplog):
+    broadcast_mod._dev_mode = True
+    init_broadcasts(typed_channel, None)
+    set_broadcast_provider(CapturingProvider())
+    with caplog.at_level("WARNING", logger="fymo.broadcast"):
+        _publish_matching()
+    assert caplog.records == []
+
+
+def test_dev_mode_missing_required_key_warns_with_channel_and_key(typed_channel, caplog):
+    broadcast_mod._dev_mode = True
+    init_broadcasts(typed_channel, None)
+    set_broadcast_provider(CapturingProvider())
+    with caplog.at_level("WARNING", logger="fymo.broadcast"):
+        _publish_missing_required()
+    assert len(caplog.records) == 1
+    message = caplog.records[0].message
+    assert "run_status" in message
+    assert "status" in message
+
+
+def test_dev_mode_extra_key_warns_with_channel_and_key(typed_channel, caplog):
+    broadcast_mod._dev_mode = True
+    init_broadcasts(typed_channel, None)
+    set_broadcast_provider(CapturingProvider())
+    with caplog.at_level("WARNING", logger="fymo.broadcast"):
+        _publish_extra_key()
+    assert len(caplog.records) == 1
+    message = caplog.records[0].message
+    assert "run_status" in message
+    assert "bogus" in message
+
+
+def test_prod_mode_mismatched_payload_produces_no_warning_and_does_not_raise(typed_channel, caplog):
+    broadcast_mod._dev_mode = False
+    init_broadcasts(typed_channel, None)
+    p = CapturingProvider()
+    set_broadcast_provider(p)
+    with caplog.at_level("WARNING", logger="fymo.broadcast"):
+        _publish_missing_required()
+        _publish_extra_key()
+    assert caplog.records == []
+    assert len(p.published) == 2  # still delivered, validation never blocks
+
+
+def test_untyped_channel_is_never_validated_even_in_dev_mode(untyped_channel, caplog):
+    broadcast_mod._dev_mode = True
+    init_broadcasts(untyped_channel, None)
+    set_broadcast_provider(CapturingProvider())
+    with caplog.at_level("WARNING", logger="fymo.broadcast"):
+        publish("run_status", run_id="r1", data={"anything": "goes", "no": "contract"})
+    assert caplog.records == []

--- a/tests/integration/test_blog_broadcast.py
+++ b/tests/integration/test_blog_broadcast.py
@@ -1,0 +1,79 @@
+"""Blog example: the post_activity broadcast channel is the reference
+example for a real guard body: deny via NotFound when the post doesn't
+exist, allow (open channel) otherwise. Exercised at the WSGI level, same
+approach as tests/broadcast/test_sse.py, but against the real
+app/broadcasts/posts.py shipped in examples/blog_app rather than a
+synthetic stub."""
+import sys
+from pathlib import Path
+
+import pytest
+
+from fymo.broadcast import init_broadcasts, reset_broadcasts, set_broadcast_provider
+from fymo.broadcast.providers.base import BaseBroadcastProvider
+from fymo.broadcast.sse import handle_broadcast
+from fymo.remote import identity
+
+
+class FakeProvider(BaseBroadcastProvider):
+    id = "fake"
+
+    def __init__(self, events=()):
+        self._events = list(events)
+        self.listened_keys = []
+
+    def listen(self, key, ready=None, **kwargs):
+        self.listened_keys.append(key)
+        if ready is not None:
+            ready.set()
+        yield from self._events
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    identity.set_secret(b"test-secret-32-bytes-loooooooong")
+    reset_broadcasts()
+    yield
+    reset_broadcasts()
+
+
+def _environ(path: str, query: str = "") -> dict:
+    return {"PATH_INFO": path, "QUERY_STRING": query, "REQUEST_METHOD": "GET"}
+
+
+def _call(environ):
+    provider = FakeProvider()
+    set_broadcast_provider(provider)
+    captured = {}
+
+    def start_response(status, headers):
+        captured["status"] = status
+        captured["headers"] = dict(headers)
+
+    body = handle_broadcast(environ, start_response)
+    return captured, body, provider
+
+
+def test_channel_is_discovered_from_the_real_example(blog_app: Path):
+    channels = init_broadcasts(blog_app, None)
+    from fymo.broadcast import get_channels
+    module, fn = get_channels()["post_activity"]
+    assert module == "posts"
+    assert fn.__name__ == "post_activity"
+
+
+def test_subscribing_to_a_missing_post_is_rejected(blog_app: Path):
+    init_broadcasts(blog_app, None)
+    captured, body, provider = _call(_environ("/_fymo/broadcast/posts/post_activity", "slug=does-not-exist"))
+    assert captured["status"].startswith("403")
+    assert provider.listened_keys == []  # guard ran and rejected before any LISTEN
+
+
+def test_subscribing_to_a_real_post_is_allowed(blog_app: Path):
+    from tests.integration._seed_helpers import seed_test_post
+    seed_test_post("welcome-to-fymo")
+    init_broadcasts(blog_app, None)
+    captured, body, provider = _call(_environ("/_fymo/broadcast/posts/post_activity", "slug=welcome-to-fymo"))
+    assert captured["status"] == "200 OK"
+    list(body)  # drain the generator so listen() actually runs
+    assert len(provider.listened_keys) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #9

## Summary

- `fymo/broadcast/sse.py`'s `_run_guard` (broadcast channel functions run for real on every SSE subscribe, with `current_user()` available via `request_scope`, denying on raise or `return False`) already existed since 0.6.0 but had zero real usage in the shipped example, making it easy to write a channel that never actually calls it.
- `examples/blog_app/app/broadcasts/posts.py` adds `post_activity(slug)`, a real guarded channel.
- `examples/blog_app/app/remote/posts.py` wires `_publish_activity()` into `create_comment`/`toggle_reaction`, giving the guard end-to-end exercised coverage instead of only synthetic unit tests.

## Test plan

- [x] Full suite green
- [x] Guard behavior verified against both an authorized and unauthorized subscribe attempt
- [x] Independent adversarial task review + final whole-branch review, no Critical/Important findings