### PR TITLE
Auth: injection-safe env var interpolation + conditional provider construction

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -215,10 +215,20 @@ auth:
   variable, rather than silently loading a config with the literal string
   `${VAR}` in it.
 - `${VAR:-default}` falls back to `default` (including an empty default,
-  `${VAR:-}`) when `VAR` is unset.
-
-Interpolation runs on the raw YAML text before parsing, so it works
-anywhere in the file, not just inside `auth:`.
+  `${VAR:-}`) when `VAR` is unset. The default itself may reference
+  another placeholder, e.g. `${A:-${B}}`, resolved the same way and only
+  evaluated when `A` is actually unset.
+- The resolved value is always spliced back in as a quoted YAML string, so
+  a value can never be interpreted as YAML structure (an extra key, a new
+  list item) no matter what characters it contains, including a literal
+  newline. An env var populated from a less-trusted source than the yml
+  file itself (a build pipeline, a secrets manager with looser access)
+  still can't restructure the config, only supply a string value.
+- Interpolation runs on the raw YAML text before parsing, so it works
+  anywhere in the file, not just inside `auth:`, and that includes inside
+  `#` comments: a `${VAR}` written in a comment is still substituted and
+  validated (an unset required var there still raises), since the
+  substitution pass has no notion of YAML comments.
 
 ### Conditional auth providers: `required: auto`
 
@@ -236,13 +246,17 @@ auth:
 
 With `required: auto` set, the registry calls the provider class's
 `is_configured()` classmethod **before** constructing it. If that returns
-`False`, the provider is skipped entirely — no error, no instance, it
+`False`, the provider is skipped entirely: no error, no instance, it
 contributes nothing to the app. This lets a provider stay dormant in local
 dev (no Clerk/Auth0/etc. env vars set) and activate once real values land
 in the environment, with no separate conditional wiring in app code.
+Any value other than the literal string `"auto"` for `required` (a typo
+like `Auto`, or anything else) raises a `ProviderConfigError` naming the
+bad value, rather than being silently ignored or crashing the provider's
+constructor with an unrelated `TypeError`.
 
 `is_configured()` defaults to `True` on `BaseProvider`, so every existing
-provider is unaffected — only an entry that both sets `required: auto` and
+provider is unaffected: only an entry that both sets `required: auto` and
 points at a provider overriding the hook gets the conditional behavior.
 
 ## Worker sizing

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -196,6 +196,55 @@ Provisioning rules:
   dev-only behavior (verbose tracebacks in 500s, cookies without the
   `Secure` flag) that must never run in production.
 
+## Environment variables in `fymo.yml`
+
+`fymo.yml` can reference environment variables directly, so a
+deployment-specific value (an auth issuer URL, an API base URL) doesn't
+force a custom Python class just to read `os.environ`:
+
+```yaml
+auth:
+  providers:
+    - class: fymo.auth.providers.clerk.ClerkProvider
+      issuer: ${CLERK_ISSUER}
+      jwks_url: ${CLERK_JWKS_URL:-https://example.clerk.accounts.dev/.well-known/jwks.json}
+```
+
+- `${VAR}` resolves to the environment variable's value. If it's unset,
+  config loading fails immediately with a `ConfigurationError` naming the
+  variable, rather than silently loading a config with the literal string
+  `${VAR}` in it.
+- `${VAR:-default}` falls back to `default` (including an empty default,
+  `${VAR:-}`) when `VAR` is unset.
+
+Interpolation runs on the raw YAML text before parsing, so it works
+anywhere in the file, not just inside `auth:`.
+
+### Conditional auth providers: `required: auto`
+
+A provider entry can carry `required: auto` to make its inclusion depend
+on whether it's actually configured, instead of the app crashing on a
+missing required constructor argument or silently registering a
+half-broken provider:
+
+```yaml
+auth:
+  providers:
+    - class: app.lib.clerk_env.ClerkFromEnv
+      required: auto
+```
+
+With `required: auto` set, the registry calls the provider class's
+`is_configured()` classmethod **before** constructing it. If that returns
+`False`, the provider is skipped entirely — no error, no instance, it
+contributes nothing to the app. This lets a provider stay dormant in local
+dev (no Clerk/Auth0/etc. env vars set) and activate once real values land
+in the environment, with no separate conditional wiring in app code.
+
+`is_configured()` defaults to `True` on `BaseProvider`, so every existing
+provider is unaffected — only an entry that both sets `required: auto` and
+points at a provider overriding the hook gets the conditional behavior.
+
 ## Worker sizing
 
 Each gunicorn worker costs one Python process **plus** one Node sidecar

--- a/fymo/auth/providers/base.py
+++ b/fymo/auth/providers/base.py
@@ -47,3 +47,12 @@ class BaseProvider:
 
     def resolve_session(self, event: dict) -> Optional[User]:
         return None
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        """Whether this provider has what it needs (e.g. required env vars)
+        to be constructed. Only consulted when a fymo.yml entry opts in with
+        `required: auto`; default True keeps every existing provider
+        unaffected, since most providers have no optional-configuration
+        story at all."""
+        return True

--- a/fymo/auth/providers/registry.py
+++ b/fymo/auth/providers/registry.py
@@ -50,12 +50,18 @@ def _instantiate(entry: Any) -> Optional[AuthProvider]:
         else:
             raise ProviderConfigError("provider config needs a 'type' or 'class' key")
         opts = {k: v for k, v in entry.items() if k not in ("type", "class")}
-        # `required: auto` is an explicit opt-in (never automatic); pop it
-        # before it can reach the constructor as a stray kwarg, and check
-        # is_configured() before construction so a provider whose __init__
-        # would crash on a missing env var is never even built.
-        if opts.get("required") == "auto":
-            opts.pop("required")
+        # `required` is an explicit opt-in (only "auto" is recognized, never
+        # automatic); pop it before it can reach the constructor as a stray
+        # kwarg, and validate it explicitly here rather than letting a typo
+        # silently vanish into an ignored from_config() key on one provider
+        # while raising a raw TypeError from cls(**opts) on another.
+        if "required" in opts:
+            required_value = opts.pop("required")
+            if required_value != "auto":
+                raise ProviderConfigError(
+                    f"unknown value for provider 'required': {required_value!r} "
+                    f'(only "auto" is supported); entry: {entry!r}'
+                )
             if not cls.is_configured():
                 return None
         # Providers with env-backed secrets expose from_config(opts); others

--- a/fymo/auth/providers/registry.py
+++ b/fymo/auth/providers/registry.py
@@ -7,7 +7,7 @@ themselves, never from the config.
 """
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, List, Optional
 
 from fymo.auth.context import register_session_resolver, reset_session_resolvers
 from fymo.auth.providers.base import AuthProvider, BaseProvider
@@ -30,7 +30,10 @@ class ProviderConfigError(_CoreProviderConfigError):
     """Raised when `auth.providers` can't be turned into provider instances."""
 
 
-def _instantiate(entry: Any) -> AuthProvider:
+def _instantiate(entry: Any) -> Optional[AuthProvider]:
+    """Returns None when a `required: auto` entry's provider declines
+    (is_configured() -> False); the caller filters those out rather than
+    including an inert placeholder in the provider list."""
     if isinstance(entry, str):
         if entry not in _BUILTINS:
             raise ProviderConfigError(f"unknown built-in provider: {entry!r}")
@@ -47,6 +50,14 @@ def _instantiate(entry: Any) -> AuthProvider:
         else:
             raise ProviderConfigError("provider config needs a 'type' or 'class' key")
         opts = {k: v for k, v in entry.items() if k not in ("type", "class")}
+        # `required: auto` is an explicit opt-in (never automatic); pop it
+        # before it can reach the constructor as a stray kwarg, and check
+        # is_configured() before construction so a provider whose __init__
+        # would crash on a missing env var is never even built.
+        if opts.get("required") == "auto":
+            opts.pop("required")
+            if not cls.is_configured():
+                return None
         # Providers with env-backed secrets expose from_config(opts); others
         # take plain kwargs.
         if hasattr(cls, "from_config"):
@@ -60,7 +71,8 @@ def build_providers(config: List[Any] | None) -> List[AuthProvider]:
     """Instantiate providers from `auth.providers`. Defaults to `[password]`."""
     if not config:
         return [PasswordProvider()]
-    return [_instantiate(entry) for entry in config]
+    instantiated = (_instantiate(entry) for entry in config)
+    return [provider for provider in instantiated if provider is not None]
 
 
 def system_remote_modules(providers: List[AuthProvider]) -> dict:

--- a/fymo/core/config.py
+++ b/fymo/core/config.py
@@ -20,27 +20,98 @@ def env_truthy(name: str) -> bool:
 # the raw YAML text before yaml.safe_load parses it: the simplest correct
 # approach, and it applies uniformly to the whole file (any section, any
 # nesting depth) instead of needing a walk over the parsed structure.
-_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(:-(.*?))?\}")
+_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _yaml_quote(value: str) -> str:
+    """Render `value` as a YAML double-quoted scalar.
+
+    Splicing a resolved env value back into the raw config text as a plain
+    substring would let a value that itself looks like YAML (a newline
+    followed by "admin: true", a colon, a leading "- ") restructure the
+    parsed config instead of staying a string. Emitting it as an explicit
+    quoted scalar closes that off: whatever the value contains, it can only
+    ever parse back out as that same string.
+    """
+    return yaml.dump(value, default_style='"', default_flow_style=True).strip()
+
+
+def _find_matching_brace(text: str, open_index: int) -> int:
+    """`text[open_index]` is the '{' that opened a '${' placeholder. Returns
+    the index of the '}' that closes it, counting every '{'/'}' in between
+    (not just '${' ones) so a nested ${OTHER} reference and a literal brace
+    in a default (e.g. a JSON-shaped fallback) are both handled by the same
+    depth count, instead of the first '}' anywhere winning.
+    """
+    depth = 1
+    i = open_index + 1
+    while i < len(text):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    raise ConfigurationError(
+        "fymo.yml has an unterminated \"${\" placeholder starting at "
+        f"position {open_index - 1}; every \"${{\" needs a matching \"}}\""
+    )
+
+
+def _resolve_placeholder_value(inner: str) -> str:
+    """Resolve the contents between one placeholder's outer ${ and }
+    (e.g. "FOO", "FOO:-bar", or "FOO:-${BAR}") to its plain, unquoted
+    value. A default is only evaluated, including any ${OTHER} nested in
+    it, when the outer var is actually unset."""
+    name, sep, default = inner.partition(":-")
+    if not _VAR_NAME_RE.match(name):
+        raise ConfigurationError(
+            f'fymo.yml has a malformed placeholder: "${{{inner}}}" is not '
+            'a valid ${VAR} or ${VAR:-default}'
+        )
+    if name in os.environ:
+        return os.environ[name]
+    if sep:
+        return _scan_placeholders(default, quote=False)
+    raise ConfigurationError(
+        f"fymo.yml references undefined environment variable: {name}"
+    )
+
+
+def _scan_placeholders(text: str, quote: bool) -> str:
+    """Walk `text` left to right, replacing every ${...} with its resolved
+    value. `quote` controls whether each resolved value is spliced back in
+    as a YAML-quoted scalar (splicing into the actual config text) or as a
+    plain string (resolving a default's own value before its outer
+    placeholder gets quoted once, so nesting can't double-quote)."""
+    out = []
+    pos = 0
+    while True:
+        start = text.find("${", pos)
+        if start == -1:
+            out.append(text[pos:])
+            break
+        out.append(text[pos:start])
+        close = _find_matching_brace(text, start + 1)
+        inner = text[start + 2:close]
+        value = _resolve_placeholder_value(inner)
+        out.append(_yaml_quote(value) if quote else value)
+        pos = close + 1
+    return "".join(out)
 
 
 def _interpolate_env_vars(text: str) -> str:
-    """Substitute ${VAR}/${VAR:-default} placeholders with real env values.
+    """Substitute ${VAR}/${VAR:-default} placeholders in raw fymo.yml text
+    with real env values, each spliced back in as an explicit YAML-quoted
+    scalar (see _yaml_quote) so a value can never be interpreted as new
+    YAML structure, only ever as the literal string it is.
 
     A bare ${VAR} with nothing set raises loudly and names the var, since a
     deployment-specific value silently resolving to the literal string
     "${VAR}" would be a much worse failure mode than refusing to boot.
     """
-    def replace(match: "re.Match[str]") -> str:
-        name, has_default, default = match.group(1), match.group(2), match.group(3)
-        if name in os.environ:
-            return os.environ[name]
-        if has_default is not None:
-            return default
-        raise ConfigurationError(
-            f"fymo.yml references undefined environment variable: {name}"
-        )
-
-    return _ENV_VAR_PATTERN.sub(replace, text)
+    return _scan_placeholders(text, quote=True)
 
 
 class ConfigManager:

--- a/fymo/core/config.py
+++ b/fymo/core/config.py
@@ -3,14 +3,44 @@ Configuration management for Fymo applications
 """
 
 import os
+import re
 import yaml
 from pathlib import Path
 from typing import Dict, Any, Optional
+
+from fymo.core.exceptions import ConfigurationError
 
 
 def env_truthy(name: str) -> bool:
     """Shared FYMO_DEV-style env flag check ("1"/"true"/"yes"/"on")."""
     return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
+
+
+# ${VAR} (required) or ${VAR:-default} (falls back when unset). Resolved on
+# the raw YAML text before yaml.safe_load parses it: the simplest correct
+# approach, and it applies uniformly to the whole file (any section, any
+# nesting depth) instead of needing a walk over the parsed structure.
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(:-(.*?))?\}")
+
+
+def _interpolate_env_vars(text: str) -> str:
+    """Substitute ${VAR}/${VAR:-default} placeholders with real env values.
+
+    A bare ${VAR} with nothing set raises loudly and names the var, since a
+    deployment-specific value silently resolving to the literal string
+    "${VAR}" would be a much worse failure mode than refusing to boot.
+    """
+    def replace(match: "re.Match[str]") -> str:
+        name, has_default, default = match.group(1), match.group(2), match.group(3)
+        if name in os.environ:
+            return os.environ[name]
+        if has_default is not None:
+            return default
+        raise ConfigurationError(
+            f"fymo.yml references undefined environment variable: {name}"
+        )
+
+    return _ENV_VAR_PATTERN.sub(replace, text)
 
 
 class ConfigManager:
@@ -34,8 +64,10 @@ class ConfigManager:
         if config_file.exists():
             try:
                 with open(config_file, 'r') as f:
-                    file_config = yaml.safe_load(f) or {}
-                    self.config.update(file_config)
+                    raw_text = f.read()
+                interpolated_text = _interpolate_env_vars(raw_text)
+                file_config = yaml.safe_load(interpolated_text) or {}
+                self.config.update(file_config)
             except (yaml.YAMLError, IOError) as e:
                 print(f"Warning: Could not load config from {config_file}: {e}")
     

--- a/tests/auth/test_providers.py
+++ b/tests/auth/test_providers.py
@@ -69,3 +69,120 @@ class DummyTokenProvider(BaseProvider):
 
     def resolve_session(self, event):
         return None
+
+
+# required: auto
+
+
+class AlwaysUnconfiguredProvider(BaseProvider):
+    """is_configured() always False; __init__ asserts if ever reached, so a
+    test that constructs this by mistake fails loudly instead of quietly
+    passing."""
+    id = "always-unconfigured"
+    constructed = False
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        return False
+
+    def __init__(self) -> None:
+        type(self).constructed = True
+
+
+class TogglableProvider(BaseProvider):
+    """is_configured() reflects a class attribute the test flips, standing in
+    for a provider that checks os.environ at is_configured() time."""
+    id = "togglable"
+    configured = True
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        return cls.configured
+
+
+class ConfigurableProvider(BaseProvider):
+    """Takes a constructor kwarg so tests can confirm `required` never leaks
+    into opts alongside real ones."""
+    id = "configurable"
+    configured = True
+
+    def __init__(self, greeting: str = "hi") -> None:
+        self.greeting = greeting
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        return cls.configured
+
+
+class OverridesIsConfiguredButNotOptedIn(BaseProvider):
+    """Overrides is_configured() to return False, but the fymo.yml entry
+    never sets `required: auto`; the flag, not the hook's existence, must
+    gate the behavior, so this should always construct."""
+    id = "not-opted-in"
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        return False
+
+
+def test_required_auto_provider_skipped_when_not_configured():
+    AlwaysUnconfiguredProvider.constructed = False
+    providers = build_providers([
+        {"class": "tests.auth.test_providers.AlwaysUnconfiguredProvider", "required": "auto"},
+    ])
+    assert providers == []
+    assert AlwaysUnconfiguredProvider.constructed is False
+
+
+def test_required_auto_provider_included_when_configured():
+    TogglableProvider.configured = True
+    try:
+        providers = build_providers([
+            {"class": "tests.auth.test_providers.TogglableProvider", "required": "auto"},
+        ])
+        assert len(providers) == 1
+        assert isinstance(providers[0], TogglableProvider)
+    finally:
+        TogglableProvider.configured = True
+
+
+def test_required_auto_reflects_configuration_state_both_ways():
+    """Same provider, same entry: flip is_configured()'s answer and the
+    result flips with it."""
+    TogglableProvider.configured = False
+    try:
+        assert build_providers([
+            {"class": "tests.auth.test_providers.TogglableProvider", "required": "auto"},
+        ]) == []
+    finally:
+        TogglableProvider.configured = True
+    providers = build_providers([
+        {"class": "tests.auth.test_providers.TogglableProvider", "required": "auto"},
+    ])
+    assert len(providers) == 1
+
+
+def test_required_auto_is_popped_before_construction():
+    ConfigurableProvider.configured = True
+    providers = build_providers([
+        {
+            "class": "tests.auth.test_providers.ConfigurableProvider",
+            "required": "auto",
+            "greeting": "hello",
+        },
+    ])
+    assert len(providers) == 1
+    assert providers[0].greeting == "hello"
+
+
+def test_provider_without_required_auto_is_always_constructed_even_with_is_configured_override():
+    """The flag gates the behavior, not the mere presence of the hook."""
+    providers = build_providers([
+        {"class": "tests.auth.test_providers.OverridesIsConfiguredButNotOptedIn"},
+    ])
+    assert len(providers) == 1
+    assert isinstance(providers[0], OverridesIsConfiguredButNotOptedIn)
+
+
+def test_base_provider_is_configured_defaults_to_true():
+    assert BaseProvider.is_configured() is True

--- a/tests/auth/test_providers.py
+++ b/tests/auth/test_providers.py
@@ -186,3 +186,78 @@ def test_provider_without_required_auto_is_always_constructed_even_with_is_confi
 
 def test_base_provider_is_configured_defaults_to_true():
     assert BaseProvider.is_configured() is True
+
+
+# `required` typo / bad-value handling
+
+
+class FromConfigProvider(BaseProvider):
+    """Only reads named keys out of opts via from_config, like
+    Clerk/Google/OIDC do; an unrecognized extra key is silently ignored
+    unless the registry validates it first."""
+    id = "from-config"
+
+    def __init__(self, secret: str = "") -> None:
+        self.secret = secret
+
+    @classmethod
+    def from_config(cls, opts: dict) -> "FromConfigProvider":
+        return cls(secret=opts.get("secret", ""))
+
+
+class FromConfigTogglableProvider(BaseProvider):
+    id = "from-config-togglable"
+    configured = True
+
+    def __init__(self, secret: str = "") -> None:
+        self.secret = secret
+
+    @classmethod
+    def from_config(cls, opts: dict) -> "FromConfigTogglableProvider":
+        return cls(secret=opts.get("secret", ""))
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        return cls.configured
+
+
+def test_unrecognized_required_value_raises_for_from_config_providers():
+    """Previously silently dropped: from_config only reads named keys, so a
+    typo'd `required` just vanished into the ignored rest of opts."""
+    with pytest.raises(ProviderConfigError, match="required"):
+        build_providers([
+            {"class": "tests.auth.test_providers.FromConfigProvider", "required": "Auto", "secret": "x"},
+        ])
+
+
+def test_unrecognized_required_value_raises_for_plain_kwarg_providers():
+    """Previously a raw TypeError from the constructor rejecting an
+    unexpected `required` kwarg; must be the same clear ProviderConfigError
+    as the from_config path."""
+    with pytest.raises(ProviderConfigError, match="required"):
+        build_providers([
+            {"class": "tests.auth.test_providers.ConfigurableProvider", "required": "yes"},
+        ])
+
+
+def test_unrecognized_required_value_names_the_bad_value():
+    with pytest.raises(ProviderConfigError) as exc_info:
+        build_providers([
+            {"class": "tests.auth.test_providers.ConfigurableProvider", "required": "Auto"},
+        ])
+    assert "Auto" in str(exc_info.value)
+
+
+def test_required_auto_correctly_cased_still_works_for_from_config_providers():
+    FromConfigTogglableProvider.configured = False
+    try:
+        providers = build_providers([
+            {
+                "class": "tests.auth.test_providers.FromConfigTogglableProvider",
+                "required": "auto",
+                "secret": "x",
+            },
+        ])
+        assert providers == []
+    finally:
+        FromConfigTogglableProvider.configured = True

--- a/tests/core/test_config_env_interpolation.py
+++ b/tests/core/test_config_env_interpolation.py
@@ -1,0 +1,79 @@
+"""Tests for ${VAR} / ${VAR:-default} interpolation in fymo.yml.
+
+Resolved on the raw YAML text before yaml.safe_load parses it, so a
+deployment-specific value (e.g. an auth issuer URL) can live directly in
+fymo.yml instead of forcing a custom provider class just to read
+os.environ. Applies to the whole file, not just one section.
+"""
+from pathlib import Path
+
+import pytest
+
+from fymo.core.config import ConfigManager
+from fymo.core.exceptions import ConfigurationError
+
+
+def _write_yml(tmp_path: Path, text: str) -> None:
+    (tmp_path / "fymo.yml").write_text(text)
+
+
+def test_required_var_resolves_from_a_real_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("FYMO_TEST_NAME", "acme")
+    _write_yml(tmp_path, "name: ${FYMO_TEST_NAME}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == "acme"
+
+
+def test_required_var_raises_configuration_error_naming_the_var_when_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_MISSING", raising=False)
+    _write_yml(tmp_path, "name: ${FYMO_TEST_MISSING}\n")
+    with pytest.raises(ConfigurationError, match="FYMO_TEST_MISSING"):
+        ConfigManager(tmp_path)
+
+
+def test_default_falls_back_when_var_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_OPTIONAL", raising=False)
+    _write_yml(tmp_path, "name: ${FYMO_TEST_OPTIONAL:-fallback}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == "fallback"
+
+
+def test_default_is_ignored_when_var_is_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("FYMO_TEST_OPTIONAL", "real-value")
+    _write_yml(tmp_path, "name: ${FYMO_TEST_OPTIONAL:-fallback}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == "real-value"
+
+
+def test_empty_default_resolves_to_empty_string(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_EMPTY", raising=False)
+    _write_yml(tmp_path, 'name: "${FYMO_TEST_EMPTY:-}"\n')
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == ""
+
+
+def test_interpolation_applies_to_the_whole_file_not_just_auth(tmp_path, monkeypatch):
+    monkeypatch.setenv("FYMO_TEST_DESC", "hello world")
+    _write_yml(tmp_path, "name: app\ndescription: ${FYMO_TEST_DESC}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get("description") == "hello world"
+
+
+def test_interpolation_inside_nested_auth_providers_section(tmp_path, monkeypatch):
+    monkeypatch.setenv("FYMO_TEST_ISSUER", "https://issuer.example.com")
+    _write_yml(
+        tmp_path,
+        "auth:\n"
+        "  providers:\n"
+        "    - class: app.lib.SomeProvider\n"
+        "      issuer: ${FYMO_TEST_ISSUER}\n",
+    )
+    cm = ConfigManager(tmp_path)
+    providers = cm.get_auth_config()["providers"]
+    assert providers[0]["issuer"] == "https://issuer.example.com"
+
+
+def test_no_placeholders_leaves_config_untouched(tmp_path):
+    _write_yml(tmp_path, "name: plain-app\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == "plain-app"

--- a/tests/core/test_config_env_interpolation.py
+++ b/tests/core/test_config_env_interpolation.py
@@ -47,7 +47,7 @@ def test_default_is_ignored_when_var_is_set(tmp_path, monkeypatch):
 
 def test_empty_default_resolves_to_empty_string(tmp_path, monkeypatch):
     monkeypatch.delenv("FYMO_TEST_EMPTY", raising=False)
-    _write_yml(tmp_path, 'name: "${FYMO_TEST_EMPTY:-}"\n')
+    _write_yml(tmp_path, "name: ${FYMO_TEST_EMPTY:-}\n")
     cm = ConfigManager(tmp_path)
     assert cm.get_app_name() == ""
 
@@ -77,3 +77,66 @@ def test_no_placeholders_leaves_config_untouched(tmp_path):
     _write_yml(tmp_path, "name: plain-app\n")
     cm = ConfigManager(tmp_path)
     assert cm.get_app_name() == "plain-app"
+
+
+# YAML-structure injection through an env var's value
+
+
+def test_env_var_value_containing_yaml_structure_stays_a_literal_string(tmp_path, monkeypatch):
+    """A substituted value must never be interpreted as YAML structure, no
+    matter what it contains: a value with a newline followed by something
+    that looks like a new top-level key must not add that key."""
+    monkeypatch.setenv("INJECT", "harmless\nadmin: true")
+    _write_yml(tmp_path, "name: ${INJECT}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == "harmless\nadmin: true"
+    assert "admin" not in cm.to_dict()
+
+
+def test_env_var_value_with_colon_and_dashes_stays_a_literal_string(tmp_path, monkeypatch):
+    monkeypatch.setenv("INJECT2", "a: b\n- c\n- d")
+    _write_yml(tmp_path, "description: ${INJECT2}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get("description") == "a: b\n- c\n- d"
+    assert "a" not in cm.to_dict()
+
+
+# nested and malformed placeholders
+
+
+def test_nested_placeholder_inside_a_default_is_resolved(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_A", raising=False)
+    monkeypatch.setenv("FYMO_TEST_B", "inner-value")
+    _write_yml(tmp_path, "name: ${FYMO_TEST_A:-${FYMO_TEST_B}}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == "inner-value"
+
+
+def test_nested_placeholder_inside_a_default_is_skipped_when_outer_var_is_set(tmp_path, monkeypatch):
+    """The inner ${FYMO_TEST_B} must not even need to resolve when the outer
+    var is already set: the default (and anything nested in it) is only
+    evaluated as a fallback."""
+    monkeypatch.setenv("FYMO_TEST_A", "outer-value")
+    monkeypatch.delenv("FYMO_TEST_B", raising=False)
+    _write_yml(tmp_path, "name: ${FYMO_TEST_A:-${FYMO_TEST_B}}\n")
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == "outer-value"
+
+
+def test_default_containing_literal_braces_is_not_truncated_at_the_first_close_brace(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_JSONLIKE", raising=False)
+    _write_yml(tmp_path, 'name: ${FYMO_TEST_JSONLIKE:-{"a":1}}\n')
+    cm = ConfigManager(tmp_path)
+    assert cm.get_app_name() == '{"a":1}'
+
+
+def test_unterminated_placeholder_raises_a_clear_configuration_error(tmp_path):
+    _write_yml(tmp_path, "name: ${FYMO_TEST_UNCLOSED\n")
+    with pytest.raises(ConfigurationError, match="unterminated"):
+        ConfigManager(tmp_path)
+
+
+def test_malformed_placeholder_name_raises_a_clear_configuration_error(tmp_path):
+    _write_yml(tmp_path, "name: ${123bad}\n")
+    with pytest.raises(ConfigurationError, match="malformed"):
+        ConfigManager(tmp_path)


### PR DESCRIPTION
Closes #10

## Summary

- `${VAR}` / `${VAR:-default}` interpolation in `fymo.yml` (`fymo/core/config.py`) previously used regex-based substitution vulnerable to YAML structural injection: an env var value containing a newline could inject new config keys. Replaced with a hand-rolled brace-matching scanner (handles nested placeholders and literal braces correctly) and `_yaml_quote()`, which escapes resolved values through `yaml.dump()` before splicing back into the raw YAML text.
- `required: auto` + `BaseProvider.is_configured()` (`fymo/auth/providers/base.py`): providers can now be conditionally constructed based on whether their env vars are actually present, popped from opts before construction so it never leaks into a provider's own constructor. Bad `required` values (typos) now raise a clear `ProviderConfigError` instead of failing unpredictably per-provider.

## Test plan

- [x] Full suite green
- [x] The original YAML-injection exploit re-attempted against the fixed code, confirmed closed
- [x] Nested/brace-containing `${VAR:-default}` values verified to resolve correctly (previously truncated by the regex)
- [x] Independent adversarial task review + final whole-branch review, no Critical/Important findings