### PR TITLE
Write and enforce the app/ directory contract; @task decorator for jobs

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,55 @@
+# The `app/` directory contract
+
+This is a short, factual reference for what each `app/` subdirectory is for.
+It's a seed doc, not the full docs site (see issue #14 for that). When in
+doubt, `fymo/build/hygiene.py` and `fymo/core/app_discovery.py` are the
+source of truth; this page just writes down what they already enforce (or,
+for `app/lib` and `app/support`, what they warn about) so it isn't only
+tribal knowledge.
+
+| Directory | Language | Purpose |
+|---|---|---|
+| `app/controllers` | Python | Page controllers, one module per route, exposing `getContext()`/`getDoc()` to the matching template. |
+| `app/templates` | Svelte / TS | The page components the router renders, one file per route (plus `_layout.svelte` files and `_global.css`). |
+| `app/components` | Svelte / TS | Reusable UI components shared across templates. |
+| `app/remote` | Python | Functions callable from the browser via the generated `$remote` client. Public, type-annotated top-level functions are exposed by default; mark with `@remote` (`fymo.remote.remote`) to opt into `remote.explicit_optin` mode. |
+| `app/jobs` | Python | Background task registry, submitted through a `JobProvider`. Every non-underscore top-level function becomes a submittable task; mark task entry points with `@task` (`fymo.jobs.task`) to say so explicitly (see below). |
+| `app/broadcasts` | Python | SSE channel definitions, discovered the same way as `app/jobs`. |
+| `app/lib` | TypeScript / Svelte | The `$lib/*` alias target (see `tsconfig.json`). TypeScript-only, there is no Python here, because nothing under `app/lib` ever runs server-side. |
+| `app/support` | Python | Shared server-side utilities that don't fit any of the above: a database connection helper, auth env config, media path helpers, and similar cross-cutting code imported by controllers/remote/jobs modules. |
+
+## `app/controllers` and `app/templates`/`app/components` are hard build errors
+
+`fymo build` and `fymo dev` both run `check_directory_hygiene()`
+(`fymo/build/hygiene.py`) before anything else: a `.svelte` file under
+`app/controllers/`, or a `.py` file under `app/templates/`/`app/components/`,
+fails the build. Nothing silently ignores the misplaced file: Python never
+imports a stray `.svelte`, and esbuild never bundles a stray `.py`, so
+without this check the file would just do nothing instead of erroring where
+a developer would notice.
+
+## `app/lib` is a warning, not an error
+
+A `.py` file under `app/lib/` is almost always a sign the code belongs in
+`app/support/` instead. `app/lib` is the `$lib/*` alias target for
+TypeScript/Svelte imports, and Python there never gets bundled or run. Unlike
+the checks above, this is a build-time **warning**, not a hard failure: it
+doesn't block `fymo build` or `fymo dev`, it just prints a suggestion to move
+the file to `app/support/`.
+
+## `@task` and `app/jobs`
+
+`app/jobs/*.py` files are meant to be thin task registries: a handful of
+submittable entry points, not a place implementation piles up. Because every
+non-underscore top-level function in `app/jobs/*.py` becomes a submittable
+task, helpers that shouldn't be submittable have to be underscore-prefixed
+to stay private, which is easy to forget, and easy for a file to grow past
+the point where "thin registry" is still true.
+
+`@task` (`from fymo.jobs import task`) marks a function as an intentional
+task entry point. It doesn't change what gets discovered: an undecorated
+top-level function is still registered exactly as before, for backward
+compatibility, but an undecorated one now also logs a one-line deprecation
+warning suggesting `@task` be added. Real implementation that a task calls
+into belongs in `app/support/`, not underscore-prefixed helpers living next
+to the task in the same module.

--- a/fymo/build/hygiene.py
+++ b/fymo/build/hygiene.py
@@ -45,3 +45,31 @@ def format_hygiene_error(violations: List[str]) -> str:
         "\n\napp/controllers/ is Python-only; app/templates/ and app/components/ "
         "are frontend-only."
     )
+
+
+# app/lib soft check.
+#
+# Deliberately separate from check_directory_hygiene()/format_hygiene_error()
+# above: those are hard build failures, this is not. app/lib/ is the
+# $lib/* tsconfig alias target, TypeScript/Svelte-only by convention, but a
+# stray .py file there doesn't mechanically break the build the way a
+# misplaced .svelte/.py does elsewhere (esbuild simply never touches it), so
+# there's no reason to block the build over it. It's still worth flagging:
+# app/support/ is the intended home for that code, and a .py file sitting
+# unreachable in app/lib/ is easy to miss otherwise.
+
+def check_lib_directory_warnings(project_root: Path) -> List[str]:
+    """Return a list of human-readable warning messages for .py files found
+    under app/lib/ (empty if none). Never raises and never fails a build;
+    callers are expected to print these and continue."""
+    warnings: List[str] = []
+
+    lib_dir = project_root / "app" / "lib"
+    if lib_dir.is_dir():
+        for f in sorted(lib_dir.rglob("*.py")):
+            warnings.append(
+                f"{f.relative_to(project_root)}: .py file inside app/lib/ "
+                f"(app/lib/ is TypeScript/Svelte-only, consider moving it to app/support/)"
+            )
+
+    return warnings

--- a/fymo/build/prepare.py
+++ b/fymo/build/prepare.py
@@ -23,10 +23,15 @@ from fymo.broadcast.codegen import emit_broadcast_client
 from fymo.build.composition_generator import generate_ssr_tree
 from fymo.build.discovery import discover_routes, discover_all_layouts
 from fymo.build.entry_generator import write_client_entries
-from fymo.build.hygiene import check_directory_hygiene, format_hygiene_error
+from fymo.build.hygiene import (
+    check_directory_hygiene,
+    check_lib_directory_warnings,
+    format_hygiene_error,
+)
 from fymo.build.manifest import RemoteModuleAssets
 from fymo.remote.codegen import emit_module, emit_runtime
 from fymo.remote.discovery import discover_remote_modules
+from fymo.utils.colors import Color
 
 
 class BuildError(RuntimeError):
@@ -95,6 +100,13 @@ def prepare_build_config(project_root: Path, dist_dir: Path, cache_dir: Path, de
     hygiene_violations = check_directory_hygiene(project_root)
     if hygiene_violations:
         raise BuildError(format_hygiene_error(hygiene_violations))
+
+    # Soft check, same point in the sequence as the hard one above but never
+    # raises; see check_lib_directory_warnings' docstring for why app/lib/
+    # doesn't get the hard-error treatment. Printed for both `fymo build` and
+    # `fymo dev` since both call prepare_build_config.
+    for warning in check_lib_directory_warnings(project_root):
+        Color.print_warning(warning)
 
     if shutil.which("node") is None:
         raise BuildError("node not found on PATH" if dev else "node executable not found on PATH")

--- a/fymo/cli/commands/init.py
+++ b/fymo/cli/commands/init.py
@@ -26,6 +26,11 @@ def initialize_project():
     # Create basic structure
     (current_dir / 'app' / 'controllers').mkdir(parents=True, exist_ok=True)
     (current_dir / 'app' / 'templates').mkdir(parents=True, exist_ok=True)
-    
+
+    # app/support/: Python-only home for shared server-side utilities, same
+    # rationale as `fymo new`'s scaffold (see fymo/cli/commands/new.py).
+    (current_dir / 'app' / 'support').mkdir(parents=True, exist_ok=True)
+    (current_dir / 'app' / 'support' / '__init__.py').write_text('"""Shared server-side utilities"""')
+
     Color.print_success("Fymo initialized successfully!")
     Color.print_info("Next steps: Create your controllers and templates in the app/ directory")

--- a/fymo/cli/commands/new.py
+++ b/fymo/cli/commands/new.py
@@ -35,6 +35,7 @@ def create_project(name: str, template: str = 'default'):
         'app/models',
         'app/lib',
         'app/components',
+        'app/support',
         'app/static/css',
         'app/static/js',
         'app/static/images',
@@ -170,7 +171,14 @@ if __name__ == "__main__":
     
     # app/__init__.py
     (project_path / 'app' / '__init__.py').write_text('"""Application package"""')
-    
+
+    # app/support/__init__.py: Python-only home for shared server-side
+    # utilities (db connection helpers, env config, etc.) that don't belong
+    # in app/lib/ (TypeScript/Svelte-only) or any of the other app/
+    # subpackages. Needs __init__.py like the other app/ subpackages so it
+    # imports as app.support.* from day one.
+    (project_path / 'app' / 'support' / '__init__.py').write_text('"""Shared server-side utilities"""')
+
     # app/controllers/home.py
     home_controller = """\"\"\"Home controller\"\"\"
 

--- a/fymo/jobs/__init__.py
+++ b/fymo/jobs/__init__.py
@@ -23,7 +23,15 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from fymo.jobs.decorators import task
+
 logger = logging.getLogger("fymo.jobs")
+
+__all__ = [
+    "JobRunner", "set_shared_runner", "get_shared_runner", "reset_shared_runner",
+    "set_job_provider", "get_job_provider", "init_job_provider", "reset_job_provider",
+    "task",
+]
 
 
 class JobRunner:

--- a/fymo/jobs/decorators.py
+++ b/fymo/jobs/decorators.py
@@ -1,0 +1,27 @@
+"""Explicit marker for app/jobs/*.py task entry points.
+
+Mirrors fymo.remote.decorators.remote: every non-underscore top-level
+function in app/jobs/*.py already becomes a submittable task (see
+fymo.jobs.discovery), so there's no opt-in/opt-out mode here the way
+`remote.explicit_optin` gives app/remote/*.py, @task changes nothing about
+what gets discovered. It exists so a developer can say "this is a real task
+entry point" out loud, which is what makes discover_job_tasks's deprecation
+warning for undecorated functions actionable instead of just noise.
+"""
+from typing import Callable, TypeVar
+
+F = TypeVar("F", bound=Callable)
+
+
+def task(fn: F) -> F:
+    """Mark a function as an explicit background job task.
+
+    Returns the function unchanged (no wrapping), it only stamps
+    `__fymo_task__ = True` so discover_job_tasks can tell an intentional
+    task entry point from a bare function that happens to be public and
+    top-level. An undecorated function is still discovered and registered
+    identically (backward compat); the marker only silences the
+    deprecation-style warning discover_job_tasks logs for undecorated ones.
+    """
+    fn.__fymo_task__ = True
+    return fn

--- a/fymo/jobs/discovery.py
+++ b/fymo/jobs/discovery.py
@@ -11,10 +11,13 @@ must be unique across modules, same as broadcast channel names.
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Callable, Dict
 
 from fymo.core.app_discovery import discover_app_functions
+
+logger = logging.getLogger("fymo.jobs")
 
 
 class DuplicateTaskError(Exception):
@@ -42,6 +45,23 @@ def discover_job_tasks(project_root: Path) -> Dict[str, Callable]:
     `app.remote.*` — unlike fymo.remote.discovery, which leaves this step
     to its caller (BuildPipeline), this function doesn't require callers
     to remember it.
+
+    A function without the `@task` marker (fymo.jobs.task) is still
+    registered exactly as before. This is intentionally not a breaking
+    change, every existing app/jobs module keeps working unmodified, but it
+    logs a one-line warning suggesting `@task` be added, since an
+    undecorated top-level function becoming submittable is easy to do by
+    accident in a module meant to stay a thin task registry.
     """
     found = discover_app_functions(project_root, "jobs", _on_duplicate)
-    return {name: fn for name, (_module, fn) in found.items()}
+    tasks: Dict[str, Callable] = {}
+    for name, (module_stem, fn) in found.items():
+        if not getattr(fn, "__fymo_task__", False):
+            logger.warning(
+                "app/jobs/%s.py: %r has no @task marker (fymo.jobs.task); "
+                "it is still registered as a task for backward compatibility, "
+                "but consider adding @task to make it explicit",
+                module_stem, name,
+            )
+        tasks[name] = fn
+    return tasks

--- a/tests/build/test_dev_orchestrator.py
+++ b/tests/build/test_dev_orchestrator.py
@@ -33,6 +33,21 @@ def test_hygiene_check_runs_even_without_node_on_path(example_app: Path, monkeyp
         DevOrchestrator(example_app).start()
 
 
+def test_start_warns_but_succeeds_on_py_file_in_lib(example_app: Path, node_available, capsys):
+    """Locked decision: app/lib/ is a warning, not a build failure. start()
+    must not raise, unlike the hard-error cases above."""
+    (example_app / "app" / "lib").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "lib" / "oops.py").write_text("x = 1\n")
+    orch = DevOrchestrator(example_app)
+    try:
+        orch.start()
+    finally:
+        orch.stop()
+    out = capsys.readouterr().out
+    assert "app/lib/oops.py" in out
+    assert "app/support" in out
+
+
 def test_write_manifest_populates_layout_fields_from_synthetic_metafile(example_app: Path):
     """Fast, no real esbuild: proves _write_manifest()'s wiring to
     match_esbuild_outputs() is correct, independent of a real subprocess

--- a/tests/build/test_hygiene.py
+++ b/tests/build/test_hygiene.py
@@ -5,7 +5,11 @@ esbuild never bundles a stray .py) -- which is exactly why it needs an
 explicit check instead of relying on something erroring on its own."""
 from pathlib import Path
 
-from fymo.build.hygiene import check_directory_hygiene, format_hygiene_error
+from fymo.build.hygiene import (
+    check_directory_hygiene,
+    check_lib_directory_warnings,
+    format_hygiene_error,
+)
 
 
 def test_clean_project_has_no_violations(tmp_path: Path):
@@ -86,3 +90,63 @@ def test_format_hygiene_error_lists_every_violation():
     assert "app/templates/oops.py: bad" in msg
     assert "Python-only" in msg
     assert "frontend-only" in msg
+
+
+# check_lib_directory_warnings (soft, not a build error)
+
+
+def test_no_app_lib_dir_produces_no_warnings(tmp_path: Path):
+    assert check_lib_directory_warnings(tmp_path) == []
+
+
+def test_app_lib_with_only_ts_files_produces_no_warnings(tmp_path: Path):
+    (tmp_path / "app" / "lib").mkdir(parents=True)
+    (tmp_path / "app" / "lib" / "auth.ts").write_text("export const x = 1;\n")
+
+    assert check_lib_directory_warnings(tmp_path) == []
+
+
+def test_py_file_in_app_lib_produces_a_warning(tmp_path: Path):
+    (tmp_path / "app" / "lib").mkdir(parents=True)
+    (tmp_path / "app" / "lib" / "oops.py").write_text("x = 1\n")
+
+    warnings = check_lib_directory_warnings(tmp_path)
+    assert len(warnings) == 1
+    assert "app/lib/oops.py" in warnings[0]
+    assert "app/support" in warnings[0]
+
+
+def test_py_file_nested_in_app_lib_subdir_is_caught(tmp_path: Path):
+    (tmp_path / "app" / "lib" / "nested").mkdir(parents=True)
+    (tmp_path / "app" / "lib" / "nested" / "oops.py").write_text("x = 1\n")
+
+    warnings = check_lib_directory_warnings(tmp_path)
+    assert len(warnings) == 1
+    assert "app/lib/nested/oops.py" in warnings[0]
+
+
+def test_multiple_py_files_in_app_lib_all_reported(tmp_path: Path):
+    (tmp_path / "app" / "lib").mkdir(parents=True)
+    (tmp_path / "app" / "lib" / "a.py").write_text("x = 1\n")
+    (tmp_path / "app" / "lib" / "b.py").write_text("x = 1\n")
+
+    assert len(check_lib_directory_warnings(tmp_path)) == 2
+
+
+def test_check_lib_directory_warnings_does_not_affect_hard_errors(tmp_path: Path):
+    """The warning check and the existing hard-error check are independent:
+    a .py file in app/lib/ must not show up in check_directory_hygiene()'s
+    result, and a hard-error violation elsewhere must not show up in the
+    warning check's result."""
+    (tmp_path / "app" / "lib").mkdir(parents=True)
+    (tmp_path / "app" / "lib" / "oops.py").write_text("x = 1\n")
+    (tmp_path / "app" / "controllers").mkdir(parents=True)
+    (tmp_path / "app" / "controllers" / "oops.svelte").write_text("<div></div>")
+
+    hard_violations = check_directory_hygiene(tmp_path)
+    assert len(hard_violations) == 1
+    assert "app/controllers/oops.svelte" in hard_violations[0]
+
+    soft_warnings = check_lib_directory_warnings(tmp_path)
+    assert len(soft_warnings) == 1
+    assert "app/lib/oops.py" in soft_warnings[0]

--- a/tests/build/test_pipeline.py
+++ b/tests/build/test_pipeline.py
@@ -233,6 +233,20 @@ def test_build_fails_on_py_file_in_templates(example_app: Path, node_available):
         BuildPipeline(example_app).build(dev=False)
 
 
+def test_build_warns_but_succeeds_on_py_file_in_lib(example_app: Path, node_available, capsys):
+    """Locked decision: app/lib/ is a warning, not a build failure, unlike
+    the hard-error checks above."""
+    (example_app / "app" / "lib").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "lib" / "oops.py").write_text("x = 1\n")
+
+    result = BuildPipeline(example_app).build(dev=False)
+
+    assert result.ok
+    out = capsys.readouterr().out
+    assert "app/lib/oops.py" in out
+    assert "app/support" in out
+
+
 def test_hygiene_check_runs_even_without_node_on_path(example_app: Path, monkeypatch):
     """The violation must be reported even when node isn't available at all
     -- proves this is a fast, up-front filesystem check that doesn't depend

--- a/tests/build/test_prepare.py
+++ b/tests/build/test_prepare.py
@@ -27,6 +27,36 @@ def test_hygiene_violation_raises_before_node_check(example_app: Path, monkeypat
         prepare_build_config(example_app, dist_dir, cache_dir, dev=False)
 
 
+@pytest.mark.usefixtures("node_available")
+def test_py_file_in_app_lib_warns_but_does_not_fail_build(example_app: Path, capsys):
+    """Locked decision: unlike app/controllers, app/templates, and
+    app/components, a .py file in app/lib/ is a warning, not a build
+    failure. It must not raise, and prepare_build_config must still return
+    a usable BuildConfig."""
+    (example_app / "app" / "lib").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "lib" / "oops.py").write_text("x = 1\n")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+
+    config = prepare_build_config(example_app, dist_dir, cache_dir, dev=False)
+
+    assert isinstance(config, BuildConfig)
+    out = capsys.readouterr().out
+    assert "app/lib/oops.py" in out
+    assert "app/support" in out
+
+
+@pytest.mark.usefixtures("node_available")
+def test_no_app_lib_py_file_produces_no_warning(example_app: Path, capsys):
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+
+    prepare_build_config(example_app, dist_dir, cache_dir, dev=False)
+
+    out = capsys.readouterr().out
+    assert "app/lib" not in out
+
+
 def test_read_yaml_section_missing_file_returns_empty_dict(tmp_path: Path):
     assert read_yaml_section(tmp_path, "auth") == {}
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -15,6 +15,16 @@ def test_init_scaffolds_fymo_yml_with_build_block(tmp_path: Path, monkeypatch):
     assert "build:" in content
 
 
+def test_init_scaffolds_app_support_dir_with_init(tmp_path: Path, monkeypatch):
+    """Same rationale as `fymo new`, see
+    tests/cli/test_new.py::test_scaffolds_app_support_dir_with_init."""
+    monkeypatch.chdir(tmp_path)
+    initialize_project()
+    support_dir = tmp_path / "app" / "support"
+    assert support_dir.is_dir()
+    assert (support_dir / "__init__.py").is_file()
+
+
 def test_init_and_new_scaffold_byte_identical_fymo_yml(tmp_path: Path, monkeypatch):
     """`fymo new <name>` and `fymo init` (run inside a directory named
     <name>) must produce byte-identical fymo.yml files for the same

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -12,6 +12,18 @@ def test_scaffolds_app_lib_and_app_components_dirs(tmp_path: Path, monkeypatch):
     assert (tmp_path / "myapp" / "app" / "components").is_dir()
 
 
+def test_scaffolds_app_support_dir_with_init(tmp_path: Path, monkeypatch):
+    """app/support/ is the Python-only home for shared server-side utilities
+    that don't fit controllers/remote/jobs/broadcasts/lib, see
+    docs/conventions.md. It needs __init__.py like the other app/
+    subpackages so it's importable as app.support.* right away."""
+    monkeypatch.chdir(tmp_path)
+    create_project("myapp")
+    support_dir = tmp_path / "myapp" / "app" / "support"
+    assert support_dir.is_dir()
+    assert (support_dir / "__init__.py").is_file()
+
+
 def test_scaffolds_tsconfig_with_lib_components_and_remote_aliases(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     create_project("myapp")

--- a/tests/jobs/test_task_decorator.py
+++ b/tests/jobs/test_task_decorator.py
@@ -1,0 +1,88 @@
+"""`@task` marker for app/jobs/*.py functions.
+
+Backward compat is required: an undecorated top-level function must keep
+being discovered and registered exactly as before, this is NOT a breaking
+change. The only behavior difference is a one-line deprecation-style log
+warning for undecorated functions, suggesting `@task` be added.
+"""
+import logging
+from pathlib import Path
+
+from fymo.jobs import task
+from fymo.jobs.discovery import discover_job_tasks
+
+
+def _scaffold(tmp_path: Path, module_source: str) -> Path:
+    jobs_dir = tmp_path / "app" / "jobs"
+    jobs_dir.mkdir(parents=True)
+    (tmp_path / "app" / "__init__.py").write_text("")
+    (jobs_dir / "__init__.py").write_text("")
+    (jobs_dir / "runs.py").write_text(module_source)
+    return tmp_path
+
+
+def test_task_decorator_marks_function_and_returns_it_unchanged():
+    def fn(x: int) -> int:
+        return x
+
+    marked = task(fn)
+
+    assert marked is fn
+    assert marked.__fymo_task__ is True
+
+
+def test_task_decorated_function_is_discovered_and_registered(tmp_path: Path):
+    project = _scaffold(
+        tmp_path,
+        "from fymo.jobs import task\n"
+        "@task\n"
+        "def do_work(x):\n    return x * 2\n",
+    )
+    tasks = discover_job_tasks(project)
+    assert set(tasks.keys()) == {"do_work"}
+    assert tasks["do_work"](21) == 42
+
+
+def test_undecorated_function_is_still_discovered_and_registered(tmp_path: Path):
+    """Backward compat: a bare top-level function must keep working exactly
+    as it did before @task existed."""
+    project = _scaffold(tmp_path, "def do_work(x):\n    return x * 2\n")
+    tasks = discover_job_tasks(project)
+    assert set(tasks.keys()) == {"do_work"}
+    assert tasks["do_work"](21) == 42
+
+
+def test_undecorated_function_logs_a_deprecation_warning(tmp_path: Path, caplog):
+    project = _scaffold(tmp_path, "def do_work(x):\n    return x * 2\n")
+    with caplog.at_level(logging.WARNING, logger="fymo.jobs"):
+        discover_job_tasks(project)
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("do_work" in m and "@task" in m for m in messages)
+
+
+def test_task_decorated_function_does_not_log_a_warning(tmp_path: Path, caplog):
+    project = _scaffold(
+        tmp_path,
+        "from fymo.jobs import task\n"
+        "@task\n"
+        "def do_work(x):\n    return x * 2\n",
+    )
+    with caplog.at_level(logging.WARNING, logger="fymo.jobs"):
+        discover_job_tasks(project)
+    assert caplog.records == []
+
+
+def test_mixed_module_only_warns_for_the_undecorated_function(tmp_path: Path, caplog):
+    project = _scaffold(
+        tmp_path,
+        "from fymo.jobs import task\n"
+        "@task\n"
+        "def marked(x):\n    return x\n"
+        "def unmarked(x):\n    return x\n",
+    )
+    with caplog.at_level(logging.WARNING, logger="fymo.jobs"):
+        tasks = discover_job_tasks(project)
+    assert set(tasks.keys()) == {"marked", "unmarked"}
+    messages = [r.getMessage() for r in caplog.records]
+    assert len(messages) == 1
+    assert "unmarked" in messages[0]

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #11

## Summary

- `docs/conventions.md` (new): documents what belongs in `app/controllers`, `app/templates`, `app/components`, `app/remote`, `app/broadcasts`, `app/jobs`, `app/lib` (TS/Svelte-only), `app/support` (Python helpers not owned by another subsystem).
- `check_lib_directory_warnings()` (`fymo/build/hygiene.py`): warns (does not fail the build) on `.py` files under `app/lib/`, since it mechanically does nothing there (esbuild never touches it) but is easy to leave stranded.
- `@task` decorator (`fymo/jobs/decorators.py`): mirrors `@remote`, sets `__fymo_task__`, backward-compatible (undecorated functions still register with a warning, not a hard failure, since jobs weren't part of #8's opt-in enforcement scope).
- `fymo new`/`init` scaffold `app/support/`.

## Test plan

- [x] Full suite green
- [x] Warning verified to fire (and not fail the build) for a `.py` file placed under `app/lib/`
- [x] `@task` verified backward-compatible against undecorated existing job functions
- [x] Independent adversarial task review + final whole-branch review, no Critical/Important findings