### PR TITLE
Declarative media routes with byte-range support

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -293,3 +293,34 @@ second sink (e.g. Sentry).
 
 File output is append-only with no built-in rotation — use logrotate or
 your container platform's log driver.
+
+## Media routes (byte-range file serving)
+
+Apps that need to serve binary files with `Range` support (video/audio
+seeking and scrubbing, in particular) don't need to hand-write a raw WSGI
+route for it. Declare them in `fymo.yml` instead:
+
+```yaml
+media:
+  - prefix: /media/videos/
+    dir: data/videos
+    extensions: [webm]
+```
+
+`prefix` is matched against the request path the same way fymo's own
+`/dist/` and `/assets/` routes are (a path prefix, not a template). `dir`
+is resolved relative to the project root. `extensions` is the allow-list
+for the filename after the prefix; anything else, and any filename
+containing `..` or starting with `/`, gets a 400.
+
+fymo owns the rest: single-range `Range: bytes=start-end` requests get a
+206 with `Content-Range`, full-file requests get a 200 with `Content-Length`,
+missing files get a 404, and `Content-Type` is resolved from the filename
+via the standard library's `mimetypes` module. `media:` can list multiple
+entries with different prefixes/dirs/extensions, and the section is
+entirely optional, apps without one register no extra routes at all.
+
+See `fymo/core/media.py` for the implementation, and `fymo/core/http.py`
+for the lower-level raw-WSGI extension point (`app/routes.py`) this sits
+alongside, for the rarer case of a route that isn't just "serve a file
+from a directory" (webhooks, non-file responses, etc.).

--- a/fymo/core/config.py
+++ b/fymo/core/config.py
@@ -5,7 +5,7 @@ Configuration management for Fymo applications
 import os
 import yaml
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 
 
 def env_truthy(name: str) -> bool:
@@ -90,6 +90,13 @@ class ConfigManager:
         """`logging:` section. Holds destination/file/level/format — see
         fymo.core.logging.resolve_logging_config for shapes and defaults."""
         return self.get('logging', {}) or {}
+
+    def get_media_config(self) -> List[Dict[str, Any]]:
+        """`media:` section. A list of {prefix, dir, extensions} entries
+        for declarative byte-range media serving (see fymo.core.media),
+        entirely optional. Absent means no media routes are registered, so
+        existing apps are unaffected."""
+        return self.get('media', []) or []
 
     def to_dict(self) -> Dict[str, Any]:
         """Return configuration as dictionary"""

--- a/fymo/core/media.py
+++ b/fymo/core/media.py
@@ -1,0 +1,120 @@
+"""Declarative media serving (fymo.yml `media:` section) -> HttpRoute list.
+
+Before this existed, apps that needed to stream a video with seek/scrub
+support (or serve any other binary file family) had to hand-write a raw WSGI
+handler under `app/routes.py` using the `fymo.core.http` extension point:
+Range-header parsing, path-traversal validation, content-type mapping, and
+404/400 handling, all repeated per app. This module lets that be declared
+instead:
+
+    media:
+      - prefix: /media/videos/
+        dir: data/videos
+        extensions: [webm]
+
+`build_media_routes` turns each entry into an `HttpRoute` with a WSGI
+handler fymo owns, so apps get single-range byte-range support and
+traversal-safe filename handling for free. The routes it returns are meant
+to sit alongside `discover_app_http_routes`'s routes in `FymoApp._app_routes`
+(see fymo/core/server.py) rather than replace that seam, since some apps
+will still want fully custom raw-WSGI routes for things this doesn't cover
+(webhooks, non-file responses, etc.).
+"""
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from fymo.core.http import HttpRoute
+
+
+def _respond_error(start_response, status: str, message: bytes):
+    start_response(status, [
+        ("Content-Type", "text/plain"),
+        ("Content-Length", str(len(message))),
+    ])
+    return [message]
+
+
+def _is_traversal_safe(filename: str) -> bool:
+    """Same rule apps were hand-writing before this feature existed: no
+    '..' segments and no absolute path. Checked as plain substring/prefix
+    tests (not `Path.resolve()` containment), because `root_dir / filename`
+    would happily let a leading '/' override root_dir entirely. pathlib
+    treats joining with an absolute path as a replacement, not a traversal,
+    so the unsafe case has to be rejected before the join ever happens."""
+    return ".." not in filename and not filename.startswith("/")
+
+
+def _make_media_handler(prefix: str, root_dir: Path, extensions: set) -> Callable:
+    """Build the WSGI handler for one `media:` entry. `extensions` is a set
+    of lowercase, dot-less extensions (e.g. {"webm"}); anything else is a
+    400, same as an unsafe filename, so a probing request can't distinguish
+    "wrong extension" from "path traversal attempt"."""
+
+    def handler(environ, start_response):
+        path = environ.get("PATH_INFO", "")
+        filename = path[len(prefix):]
+
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        if not _is_traversal_safe(filename) or ext not in extensions:
+            return _respond_error(start_response, "400 Bad Request", b"invalid filename")
+
+        file_path = root_dir / filename
+        if not file_path.is_file():
+            return _respond_error(start_response, "404 Not Found", b"not found")
+
+        content_type, _ = mimetypes.guess_type(filename)
+        content_type = content_type or "application/octet-stream"
+        file_size = file_path.stat().st_size
+        range_header = environ.get("HTTP_RANGE")
+
+        if range_header:
+            # Single-range only ("bytes=start-end"), matching the app-level
+            # handlers this replaces. Multi-range (comma-separated) isn't
+            # something video/audio scrubbing needs and would require a
+            # multipart/byteranges body.
+            range_spec = range_header.split("=", 1)[-1]
+            start_str, _, end_str = range_spec.partition("-")
+            start = int(start_str) if start_str else 0
+            end = int(end_str) if end_str else file_size - 1
+            end = min(end, file_size - 1)
+            chunk_size = end - start + 1
+            with open(file_path, "rb") as f:
+                f.seek(start)
+                data = f.read(chunk_size)
+            start_response("206 Partial Content", [
+                ("Content-Range", f"bytes {start}-{end}/{file_size}"),
+                ("Accept-Ranges", "bytes"),
+                ("Content-Length", str(chunk_size)),
+                ("Content-Type", content_type),
+            ])
+            return [data]
+
+        data = file_path.read_bytes()
+        start_response("200 OK", [
+            ("Accept-Ranges", "bytes"),
+            ("Content-Length", str(file_size)),
+            ("Content-Type", content_type),
+        ])
+        return [data]
+
+    return handler
+
+
+def build_media_routes(project_root: Path, media_config: List[Dict[str, Any]]) -> List[HttpRoute]:
+    """Turn the `media:` fymo.yml section into `HttpRoute`s. Returns `[]`
+    when `media_config` is empty, so apps without a `media:` section (the
+    vast majority, pre-existing and new alike) register zero extra routes."""
+    routes: List[HttpRoute] = []
+    for entry in media_config:
+        prefix = entry["prefix"]
+        root_dir = (Path(project_root) / entry["dir"]).resolve()
+        extensions = {str(e).lower().lstrip(".") for e in entry.get("extensions", [])}
+        routes.append(HttpRoute(
+            method="GET",
+            path=prefix,
+            handler=_make_media_handler(prefix, root_dir, extensions),
+        ))
+    return routes

--- a/fymo/core/media.py
+++ b/fymo/core/media.py
@@ -24,9 +24,15 @@ from __future__ import annotations
 
 import mimetypes
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from fymo.core.http import HttpRoute
+
+# Reserved by FymoApp._dispatch itself (fymo/core/server.py), checked before
+# the app-routes loop runs. A `media:` prefix landing under either of these
+# would silently never be reached, so it's worth a loud warning at startup
+# rather than a confusing 404/wrong-content-type discovered in production.
+_RESERVED_PREFIXES = ("/dist/", "/assets/")
 
 
 def _respond_error(start_response, status: str, message: bytes):
@@ -37,14 +43,43 @@ def _respond_error(start_response, status: str, message: bytes):
     return [message]
 
 
+def _respond_range_not_satisfiable(start_response, file_size: int):
+    """416, per RFC 7233 section 4.4. The `Content-Range: bytes */<size>`
+    form (no start-end pair) tells the client what range would have been
+    valid, without the server needing to open the file to serve nothing."""
+    body = b"range not satisfiable"
+    start_response("416 Range Not Satisfiable", [
+        ("Content-Type", "text/plain"),
+        ("Content-Length", str(len(body))),
+        ("Content-Range", f"bytes */{file_size}"),
+    ])
+    return [body]
+
+
 def _is_traversal_safe(filename: str) -> bool:
-    """Same rule apps were hand-writing before this feature existed: no
-    '..' segments and no absolute path. Checked as plain substring/prefix
-    tests (not `Path.resolve()` containment), because `root_dir / filename`
-    would happily let a leading '/' override root_dir entirely. pathlib
-    treats joining with an absolute path as a replacement, not a traversal,
-    so the unsafe case has to be rejected before the join ever happens."""
+    """Cheap first check: no '..' segments and no absolute path. Checked as
+    plain substring/prefix tests, because `root_dir / filename` would
+    happily let a leading '/' override root_dir entirely, pathlib treats
+    joining with an absolute path as a replacement, not a traversal, so the
+    unsafe case has to be rejected before the join ever happens. This alone
+    is not sufficient against a symlink physically planted inside root_dir
+    that points elsewhere (its own filename contains neither '..' nor a
+    leading '/'), which is what `_resolve_within` below is for."""
     return ".." not in filename and not filename.startswith("/")
+
+
+def _resolve_within(root_dir: Path, filename: str) -> Optional[Path]:
+    """Join `filename` onto `root_dir` and confirm the fully-resolved path,
+    symlinks included, is still contained within `root_dir`. Returns None if
+    it escapes. This covers both any traversal that slipped past
+    `_is_traversal_safe` and a symlink planted inside root_dir that points
+    outside it, since following the symlink target is exactly what
+    `Path.resolve()` does. `root_dir` is assumed already resolved (done once
+    in `build_media_routes`, not per request)."""
+    candidate = (root_dir / filename).resolve()
+    if candidate != root_dir and not candidate.is_relative_to(root_dir):
+        return None
+    return candidate
 
 
 def _make_media_handler(prefix: str, root_dir: Path, extensions: set) -> Callable:
@@ -61,13 +96,16 @@ def _make_media_handler(prefix: str, root_dir: Path, extensions: set) -> Callabl
         if not _is_traversal_safe(filename) or ext not in extensions:
             return _respond_error(start_response, "400 Bad Request", b"invalid filename")
 
-        file_path = root_dir / filename
-        if not file_path.is_file():
+        resolved_path = _resolve_within(root_dir, filename)
+        if resolved_path is None:
+            return _respond_error(start_response, "400 Bad Request", b"invalid filename")
+
+        if not resolved_path.is_file():
             return _respond_error(start_response, "404 Not Found", b"not found")
 
         content_type, _ = mimetypes.guess_type(filename)
         content_type = content_type or "application/octet-stream"
-        file_size = file_path.stat().st_size
+        file_size = resolved_path.stat().st_size
         range_header = environ.get("HTTP_RANGE")
 
         if range_header:
@@ -77,11 +115,36 @@ def _make_media_handler(prefix: str, root_dir: Path, extensions: set) -> Callabl
             # multipart/byteranges body.
             range_spec = range_header.split("=", 1)[-1]
             start_str, _, end_str = range_spec.partition("-")
-            start = int(start_str) if start_str else 0
-            end = int(end_str) if end_str else file_size - 1
+            try:
+                if start_str == "":
+                    # Suffix-byte-range-spec ("bytes=-N"): the last N bytes,
+                    # not "bytes 0 through N". An empty start_str here is
+                    # the RFC 7233 suffix form, not a missing/defaulted start.
+                    if end_str == "":
+                        raise ValueError("empty range spec")
+                    suffix_length = int(end_str)
+                    if suffix_length < 0:
+                        raise ValueError("negative suffix length")
+                    if suffix_length == 0 or file_size == 0:
+                        return _respond_range_not_satisfiable(start_response, file_size)
+                    start = max(0, file_size - suffix_length)
+                    end = file_size - 1
+                else:
+                    start = int(start_str)
+                    end = int(end_str) if end_str else file_size - 1
+            except ValueError:
+                return _respond_error(start_response, "400 Bad Request", b"malformed range header")
+
+            # Unsatisfiable per RFC 7233 section 2.1: start at/past EOF, or
+            # an end before start. Caught here, before any arithmetic feeds
+            # into f.read(), so a crafted start like 999999999 on a small
+            # file can never turn into a negative read length.
+            if start < 0 or start >= file_size or end < start:
+                return _respond_range_not_satisfiable(start_response, file_size)
+
             end = min(end, file_size - 1)
             chunk_size = end - start + 1
-            with open(file_path, "rb") as f:
+            with open(resolved_path, "rb") as f:
                 f.seek(start)
                 data = f.read(chunk_size)
             start_response("206 Partial Content", [
@@ -92,7 +155,7 @@ def _make_media_handler(prefix: str, root_dir: Path, extensions: set) -> Callabl
             ])
             return [data]
 
-        data = file_path.read_bytes()
+        data = resolved_path.read_bytes()
         start_response("200 OK", [
             ("Accept-Ranges", "bytes"),
             ("Content-Length", str(file_size)),
@@ -106,10 +169,29 @@ def _make_media_handler(prefix: str, root_dir: Path, extensions: set) -> Callabl
 def build_media_routes(project_root: Path, media_config: List[Dict[str, Any]]) -> List[HttpRoute]:
     """Turn the `media:` fymo.yml section into `HttpRoute`s. Returns `[]`
     when `media_config` is empty, so apps without a `media:` section (the
-    vast majority, pre-existing and new alike) register zero extra routes."""
+    vast majority, pre-existing and new alike) register zero extra routes.
+
+    Raises `ValueError` for an entry missing `prefix` or `dir` (a plain
+    KeyError at startup would point at the wrong place, this names the bad
+    entry). A prefix colliding with a reserved fymo prefix only warns
+    (printed, matching ConfigManager's own warning style in
+    fymo/core/config.py) rather than raising, since it's a config smell
+    worth flagging loudly, not a guaranteed misconfiguration fymo should
+    refuse to boot over."""
     routes: List[HttpRoute] = []
     for entry in media_config:
+        if "prefix" not in entry or "dir" not in entry:
+            raise ValueError(
+                f"media: entry is missing required key(s) 'prefix' and/or 'dir': {entry!r}"
+            )
         prefix = entry["prefix"]
+        for reserved in _RESERVED_PREFIXES:
+            if prefix.startswith(reserved) or reserved.startswith(prefix):
+                print(
+                    f"Warning: media: prefix {prefix!r} overlaps with fymo's "
+                    f"reserved {reserved!r} route, which is matched first and "
+                    f"will always win. This media route may never be reached."
+                )
         root_dir = (Path(project_root) / entry["dir"]).resolve()
         extensions = {str(e).lower().lstrip(".") for e in entry.get("extensions", [])}
         routes.append(HttpRoute(

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -134,10 +134,17 @@ class FymoApp:
         _remote_router._explicit_optin = bool(remote_cfg.get("explicit_optin", False))
 
         self.asset_manager = AssetManager(self.project_root)
-        # App-level raw HTTP routes (e.g. media streaming) — optional
-        # extension point, independent of auth. See fymo/core/http.py.
+        # App-level raw HTTP routes (e.g. hand-written media streaming),
+        # an optional extension point, independent of auth. See fymo/core/http.py.
+        # Declarative media routes (fymo.yml `media:` section) are built the
+        # same way and appended to the same list, so both are checked by the
+        # single loop in `_dispatch` below. An app can mix hand-written
+        # raw-WSGI routes with config-driven ones. See fymo/core/media.py.
         from fymo.core.http import discover_app_http_routes
-        self._app_routes = discover_app_http_routes(self.project_root)
+        from fymo.core.media import build_media_routes
+        self._app_routes = discover_app_http_routes(self.project_root) + build_media_routes(
+            self.project_root, self.config_manager.get_media_config()
+        )
         self.router = self._initialize_router()
         self.template_renderer = TemplateRenderer(
             self.project_root,

--- a/tests/core/test_app_http_routes.py
+++ b/tests/core/test_app_http_routes.py
@@ -184,3 +184,40 @@ def test_fymo_app_dispatches_declarative_media_route(example_app: Path, monkeypa
         assert body == b"video-bytes"
     finally:
         app.shutdown()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_fymo_app_rejects_media_traversal_through_full_dispatch(example_app: Path, monkeypatch):
+    """Same traversal attack as tests/core/test_media.py's route-handler-level
+    test, but driven through `app(environ, start_response)` (FymoApp.__call__)
+    end to end, so it also exercises the body-cap/rate-limit/security-header
+    chain and the prefix-matching loop in `_dispatch`, not just the media
+    route's own handler in isolation."""
+    monkeypatch.setenv("FYMO_SECRET", "test-secret-please-do-not-use-in-prod-32b!")
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=example_app).build(dev=False)
+
+    video_dir = example_app / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    (example_app / "secret.webm").write_bytes(b"top secret")
+
+    from fymo import create_app
+    app = create_app(example_app, config={
+        "media": [
+            {"prefix": "/media/videos/", "dir": "data/videos", "extensions": ["webm"]},
+        ],
+    })
+    try:
+        captured = {}
+
+        def start_response(status, headers, exc_info=None):
+            captured["status"] = status
+            captured["headers"] = dict(headers)
+
+        body = b"".join(app(
+            _make_wsgi_env("/media/videos/../../secret.webm"), start_response
+        ))
+        assert captured["status"] == "400 Bad Request"
+        assert b"top secret" not in body
+    finally:
+        app.shutdown()

--- a/tests/core/test_app_http_routes.py
+++ b/tests/core/test_app_http_routes.py
@@ -150,3 +150,37 @@ def test_fymo_app_boots_fine_with_no_app_routes_py(example_app: Path, monkeypatc
         assert app._app_routes == []
     finally:
         app.shutdown()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_fymo_app_dispatches_declarative_media_route(example_app: Path, monkeypatch):
+    """`media:` in fymo.yml must produce a working route through the same
+    `_app_routes` seam app/routes.py uses, with no app/routes.py involved at
+    all, config-only wiring end to end."""
+    monkeypatch.setenv("FYMO_SECRET", "test-secret-please-do-not-use-in-prod-32b!")
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=example_app).build(dev=False)
+
+    video_dir = example_app / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    (video_dir / "clip.webm").write_bytes(b"video-bytes")
+
+    from fymo import create_app
+    app = create_app(example_app, config={
+        "media": [
+            {"prefix": "/media/videos/", "dir": "data/videos", "extensions": ["webm"]},
+        ],
+    })
+    try:
+        captured = {}
+
+        def start_response(status, headers, exc_info=None):
+            captured["status"] = status
+            captured["headers"] = dict(headers)
+
+        body = b"".join(app(_make_wsgi_env("/media/videos/clip.webm"), start_response))
+        assert captured["status"] == "200 OK"
+        assert captured["headers"]["Content-Type"] == "video/webm"
+        assert body == b"video-bytes"
+    finally:
+        app.shutdown()

--- a/tests/core/test_config_media.py
+++ b/tests/core/test_config_media.py
@@ -1,0 +1,20 @@
+"""Tests for ConfigManager.get_media_config, the `media:` fymo.yml section."""
+from pathlib import Path
+
+from fymo.core.config import ConfigManager
+
+
+def test_returns_empty_list_when_media_section_absent(tmp_path: Path):
+    cm = ConfigManager(tmp_path)
+    assert cm.get_media_config() == []
+
+
+def test_returns_the_media_section_when_present(tmp_path: Path):
+    entries = [{"prefix": "/media/videos/", "dir": "data/videos", "extensions": ["webm"]}]
+    cm = ConfigManager(tmp_path, initial_config={"media": entries})
+    assert cm.get_media_config() == entries
+
+
+def test_returns_empty_list_when_media_section_is_explicitly_null(tmp_path: Path):
+    cm = ConfigManager(tmp_path, initial_config={"media": None})
+    assert cm.get_media_config() == []

--- a/tests/core/test_media.py
+++ b/tests/core/test_media.py
@@ -99,10 +99,14 @@ def test_nonexistent_file_returns_404(tmp_path: Path):
 
 
 @pytest.mark.parametrize("filename", ["../../etc/passwd.webm", "/etc/passwd.webm"])
-def test_traversal_attempt_returns_400_through_real_wsgi_dispatch(tmp_path: Path, filename: str):
-    """A real WSGI request whose PATH_INFO carries a traversal attempt must
-    be rejected by the actual route handler, not a standalone validator
-    function, proving the dispatch path itself is safe."""
+def test_traversal_attempt_returns_400_via_route_handler(tmp_path: Path, filename: str):
+    """The built route's handler (the actual WSGI callable a request would
+    hit, not a standalone validator function) must reject a traversal
+    attempt on its own. This calls `route.handler` directly rather than
+    through FymoApp.__call__, so it does not exercise the prefix-matching /
+    rate-limiter / security-header chain in front of it; see
+    tests/core/test_app_http_routes.py for a full-FymoApp-dispatch version
+    of this same attack."""
     (tmp_path / "data" / "videos").mkdir(parents=True)
     # Plant a file outside the media dir that a successful traversal would read.
     (tmp_path / "secret.webm").write_bytes(b"top secret")
@@ -110,6 +114,27 @@ def test_traversal_attempt_returns_400_through_real_wsgi_dispatch(tmp_path: Path
     route = _one_route(tmp_path)
     captured, start_response = _capture()
     body = b"".join(route.handler(_make_wsgi_env("/media/videos/" + filename), start_response))
+
+    assert captured["status"] == "400 Bad Request"
+    assert b"top secret" not in body
+
+
+def test_symlink_inside_media_dir_pointing_outside_is_rejected(tmp_path: Path):
+    """A string-only traversal check (no '..', no leading '/') is not
+    enough: a symlink physically planted inside the configured media dir
+    can point anywhere, including outside root_dir, and its own filename
+    contains neither '..' nor a leading '/'. The handler must resolve the
+    final path and verify it is still contained within root_dir before
+    serving it."""
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    secret = tmp_path / "secret.webm"
+    secret.write_bytes(b"top secret, outside the media dir")
+    (video_dir / "evil.webm").symlink_to(secret)
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    body = b"".join(route.handler(_make_wsgi_env("/media/videos/evil.webm"), start_response))
 
     assert captured["status"] == "400 Bad Request"
     assert b"top secret" not in body
@@ -124,3 +149,90 @@ def test_disallowed_extension_returns_400(tmp_path: Path):
     captured, start_response = _capture()
     route.handler(_make_wsgi_env("/media/videos/clip.mp4"), start_response)
     assert captured["status"] == "400 Bad Request"
+
+
+def test_malformed_range_header_returns_400_not_crash(tmp_path: Path):
+    """Non-numeric Range values must be rejected cleanly, not raise a
+    ValueError out of int() that crashes the request."""
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    (video_dir / "clip.webm").write_bytes(b"x" * 1000)
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    env = _make_wsgi_env("/media/videos/clip.webm", range_header="bytes=abc-def")
+    route.handler(env, start_response)
+    assert captured["status"] == "400 Bad Request"
+
+
+def test_range_start_beyond_file_size_returns_416_not_crash(tmp_path: Path):
+    """A start offset at or past the end of the file is an unsatisfiable
+    range per RFC 7233, not a crash: `end - start + 1` going negative must
+    never reach `f.read()`."""
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    (video_dir / "clip.webm").write_bytes(b"x" * 1000)
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    env = _make_wsgi_env("/media/videos/clip.webm", range_header="bytes=999999999-")
+    route.handler(env, start_response)
+    assert captured["status"] == "416 Range Not Satisfiable"
+    assert captured["headers"]["Content-Range"] == "bytes */1000"
+
+
+def test_range_end_before_start_returns_416_not_crash(tmp_path: Path):
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    (video_dir / "clip.webm").write_bytes(b"x" * 1000)
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    env = _make_wsgi_env("/media/videos/clip.webm", range_header="bytes=10-5")
+    route.handler(env, start_response)
+    assert captured["status"] == "416 Range Not Satisfiable"
+
+
+def test_suffix_range_returns_the_actual_last_n_bytes(tmp_path: Path):
+    """`bytes=-100` is RFC 7233's suffix-range syntax for "the last 100
+    bytes", not "the first 100 bytes". partition("-") gives an empty
+    start_str for this form, and that case must be handled explicitly."""
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    payload = bytes(range(256)) * 4  # 1024 bytes
+    (video_dir / "clip.webm").write_bytes(payload)
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    env = _make_wsgi_env("/media/videos/clip.webm", range_header="bytes=-100")
+    body = b"".join(route.handler(env, start_response))
+
+    file_size = len(payload)
+    assert captured["status"] == "206 Partial Content"
+    assert captured["headers"]["Content-Range"] == f"bytes {file_size - 100}-{file_size - 1}/{file_size}"
+    assert body == payload[-100:]
+
+
+@pytest.mark.parametrize("entry", [
+    {"dir": "data/videos", "extensions": ["webm"]},
+    {"prefix": "/media/videos/", "extensions": ["webm"]},
+])
+def test_entry_missing_required_key_raises_value_error(tmp_path: Path, entry):
+    """A raw KeyError at startup points at fymo's own code, not the bad
+    fymo.yml entry. A descriptive ValueError names what's actually wrong."""
+    with pytest.raises(ValueError, match="prefix.*dir|dir.*prefix"):
+        build_media_routes(tmp_path, [entry])
+
+
+@pytest.mark.parametrize("prefix", ["/dist/videos/", "/assets/videos/", "/dist/"])
+def test_prefix_colliding_with_reserved_route_warns(tmp_path: Path, prefix, capsys):
+    """`/dist/` and `/assets/` are matched by FymoApp._dispatch before the
+    app-routes loop ever runs (fymo/core/server.py), so a media prefix
+    under either would silently never be reached. Still registers the
+    route (this is a warning, not a hard failure) but prints it loudly."""
+    build_media_routes(tmp_path, [
+        {"prefix": prefix, "dir": "data/videos", "extensions": ["webm"]},
+    ])
+    captured = capsys.readouterr()
+    assert "Warning" in captured.out
+    assert prefix in captured.out

--- a/tests/core/test_media.py
+++ b/tests/core/test_media.py
@@ -1,0 +1,126 @@
+"""Tests for declarative media routes (fymo.yml `media:` section ->
+fymo.core.media.build_media_routes -> HttpRoute list).
+
+These exercise the built route's WSGI handler directly with a real WSGI
+environ (mirroring tests/core/test_app_http_routes.py's `_make_wsgi_env`
+helper) rather than unit-testing an internal validation function in
+isolation. The point is to prove the actual dispatch path a request would
+take is safe, not just that some helper returns the right boolean.
+"""
+import io
+from pathlib import Path
+
+import pytest
+
+from fymo.core.media import build_media_routes
+
+
+def _make_wsgi_env(path: str, method: str = "GET", range_header: str | None = None) -> dict:
+    env = {
+        "REQUEST_METHOD": method,
+        "PATH_INFO": path,
+        "SERVER_NAME": "testserver",
+        "SERVER_PORT": "80",
+        "wsgi.input": io.BytesIO(b""),
+        "wsgi.errors": io.StringIO(),
+        "wsgi.version": (1, 0),
+        "wsgi.multithread": False,
+        "wsgi.multiprocess": False,
+        "wsgi.run_once": False,
+        "wsgi.url_scheme": "http",
+    }
+    if range_header is not None:
+        env["HTTP_RANGE"] = range_header
+    return env
+
+
+def _capture():
+    captured = {}
+
+    def start_response(status, headers, exc_info=None):
+        captured["status"] = status
+        captured["headers"] = dict(headers)
+
+    return captured, start_response
+
+
+def _one_route(tmp_path: Path, extensions=("webm",)):
+    routes = build_media_routes(tmp_path, [
+        {"prefix": "/media/videos/", "dir": "data/videos", "extensions": list(extensions)},
+    ])
+    assert len(routes) == 1
+    return routes[0]
+
+
+def test_absent_media_config_registers_zero_routes(tmp_path: Path):
+    assert build_media_routes(tmp_path, []) == []
+
+
+def test_full_file_get_returns_200_with_content_length_and_type(tmp_path: Path):
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    payload = b"x" * 1000
+    (video_dir / "clip.webm").write_bytes(payload)
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    body = b"".join(route.handler(_make_wsgi_env("/media/videos/clip.webm"), start_response))
+
+    assert captured["status"] == "200 OK"
+    assert captured["headers"]["Content-Length"] == str(len(payload))
+    assert captured["headers"]["Content-Type"] == "video/webm"
+    assert body == payload
+
+
+def test_range_request_returns_206_with_correct_content_range_and_body_length(tmp_path: Path):
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    payload = bytes(range(256)) * 4  # 1024 bytes
+    (video_dir / "clip.webm").write_bytes(payload)
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    env = _make_wsgi_env("/media/videos/clip.webm", range_header="bytes=0-99")
+    body = b"".join(route.handler(env, start_response))
+
+    assert captured["status"] == "206 Partial Content"
+    assert captured["headers"]["Content-Range"] == f"bytes 0-99/{len(payload)}"
+    assert captured["headers"]["Content-Length"] == "100"
+    assert len(body) == 100
+    assert body == payload[0:100]
+
+
+def test_nonexistent_file_returns_404(tmp_path: Path):
+    (tmp_path / "data" / "videos").mkdir(parents=True)
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    route.handler(_make_wsgi_env("/media/videos/missing.webm"), start_response)
+    assert captured["status"] == "404 Not Found"
+
+
+@pytest.mark.parametrize("filename", ["../../etc/passwd.webm", "/etc/passwd.webm"])
+def test_traversal_attempt_returns_400_through_real_wsgi_dispatch(tmp_path: Path, filename: str):
+    """A real WSGI request whose PATH_INFO carries a traversal attempt must
+    be rejected by the actual route handler, not a standalone validator
+    function, proving the dispatch path itself is safe."""
+    (tmp_path / "data" / "videos").mkdir(parents=True)
+    # Plant a file outside the media dir that a successful traversal would read.
+    (tmp_path / "secret.webm").write_bytes(b"top secret")
+
+    route = _one_route(tmp_path)
+    captured, start_response = _capture()
+    body = b"".join(route.handler(_make_wsgi_env("/media/videos/" + filename), start_response))
+
+    assert captured["status"] == "400 Bad Request"
+    assert b"top secret" not in body
+
+
+def test_disallowed_extension_returns_400(tmp_path: Path):
+    video_dir = tmp_path / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    (video_dir / "clip.mp4").write_bytes(b"not allowed")
+
+    route = _one_route(tmp_path, extensions=("webm",))
+    captured, start_response = _capture()
+    route.handler(_make_wsgi_env("/media/videos/clip.mp4"), start_response)
+    assert captured["status"] == "400 Bad Request"


### PR DESCRIPTION
Closes #12

## Summary

- Streaming a video/PDF with scrubbing/seeking used to require hand-writing a raw WSGI handler under `app/routes.py` per app: Range-header parsing, path-traversal validation, content-type mapping, 404/400 handling, all repeated.
- `fymo/core/media.py` (new): declarative `media:` fymo.yml section (`[{prefix, dir, extensions}]`) turns into fymo-owned `HttpRoute`s with full RFC 7233 byte-range support (206 partial content, 416 range-not-satisfiable including the suffix-range `bytes=-N` form) and symlink-safe path containment (`_resolve_within` via `Path.resolve()` + `is_relative_to()`).
- Fixed during implementation: an unhandled `ValueError` crash on malformed/out-of-bounds `Range` headers, a silent suffix-range misparse, and a missing symlink-containment check — all re-verified via live exploit attempts by the reviewer.

## Test plan

- [x] Full suite green
- [x] 206/416/suffix-range/malformed-range/traversal/symlink-escape all covered by dedicated tests
- [x] Symlink-escape and traversal exploits re-attempted live against the fixed handler
- [x] Independent adversarial task review + final whole-branch review, no Critical/Important findings