### PR TITLE
Cache per-request reflection + fix stale app-module cache: 2.8x remote-fn throughput

### DIFF
--- a/fymo/remote/router.py
+++ b/fymo/remote/router.py
@@ -112,6 +112,29 @@ def set_system_modules(modules: "dict[str, dict[str, Callable]]") -> None:
     _system_modules = modules
 
 
+# (module_name, fn_name) -> (fn, signature, hints). inspect.signature and
+# typing.get_type_hints both do real reflection work (walking parameters,
+# resolving string/forward-ref annotations against the defining module's
+# globals) that produces the same result every time for a given function
+# object; it only needs to change when the function object itself does.
+# Keyed on identity rather than a version counter or explicit invalidation:
+# a reload that produces a new function object (e.g. importlib.reload, or a
+# fresh module import for the same module_name) naturally makes `cached_fn
+# is not fn` true, so the stale entry is replaced on the next lookup with no
+# extra bookkeeping.
+_sig_cache: "dict[tuple[str, str], tuple[Callable, inspect.Signature, dict]]" = {}
+
+
+def _sig_and_hints(cache_key: "tuple[str, str]", fn: Callable):
+    cached = _sig_cache.get(cache_key)
+    if cached is not None and cached[0] is fn:
+        return cached[1], cached[2]
+    sig = inspect.signature(fn)
+    hints = typing.get_type_hints(fn, include_extras=True)
+    _sig_cache[cache_key] = (fn, sig, hints)
+    return sig, hints
+
+
 def _resolve_fn_in_module(module_name: str, fn_name: str):
     if not fn_name.replace("_", "").isalnum() or fn_name.startswith("_"):
         return None, None, None
@@ -122,7 +145,8 @@ def _resolve_fn_in_module(module_name: str, fn_name: str):
         fn = _system_modules[module_name].get(fn_name)
         if fn is None:
             return None, None, None
-        return fn, inspect.signature(fn), typing.get_type_hints(fn, include_extras=True)
+        sig, hints = _sig_and_hints((module_name, fn_name), fn)
+        return fn, sig, hints
 
     if not module_name.replace("_", "").isalnum():
         return None, None, None
@@ -135,7 +159,8 @@ def _resolve_fn_in_module(module_name: str, fn_name: str):
     fn = getattr(mod, fn_name, None)
     if fn is None or not is_exposed_remote_fn(fn, full, _explicit_optin):
         return None, None, None
-    return fn, inspect.signature(fn), typing.get_type_hints(fn, include_extras=True)
+    sig, hints = _sig_and_hints((module_name, fn_name), fn)
+    return fn, sig, hints
 
 
 def handle_remote(environ: dict, start_response) -> Iterable[bytes]:

--- a/fymo/remote/router.py
+++ b/fymo/remote/router.py
@@ -3,6 +3,7 @@ import base64
 import importlib
 import inspect
 import json
+import os
 import sys
 import traceback
 import typing
@@ -83,10 +84,23 @@ def _origin_ok(environ: dict) -> bool:
 
 
 def _evict_stale_app_cache() -> None:
-    """Evict app.* packages from sys.modules if the app package root is no longer on sys.path.
+    """Evict app.* packages from sys.modules if the app package's project
+    root is no longer on sys.path.
 
     Handles test isolation and live-reload scenarios where the app package
-    directory changes between requests.
+    directory changes between requests (e.g. a test session that builds a
+    fresh "app" package under a new tmp_path for every test, or a dev
+    server whose project root moves).
+
+    The check compares sys.path against the PARENT of app.__path__ (the
+    project root that FymoApp.__init__ inserts into sys.path once, e.g.
+    "/proj"), not app.__path__ itself (the "app" subdirectory it points at,
+    e.g. "/proj/app"). sys.path holds project roots; it never holds the
+    "app" subdirectory directly. Comparing __path__ verbatim against
+    sys.path therefore never matched, so this used to evict and force a
+    full reimport of every app.* module on every single call, defeating
+    any caching keyed on the resulting function objects' identity even
+    though the project root never actually changed between requests.
     """
     app_mod = sys.modules.get("app")
     if app_mod is None:
@@ -94,7 +108,7 @@ def _evict_stale_app_cache() -> None:
     app_paths = list(getattr(app_mod, "__path__", []))
     if not app_paths:
         return
-    if not any(p in sys.path for p in app_paths):
+    if not any(os.path.dirname(p) in sys.path for p in app_paths):
         for name in list(sys.modules):
             if name == "app" or name.startswith("app."):
                 del sys.modules[name]

--- a/tests/remote/test_app_cache_eviction.py
+++ b/tests/remote/test_app_cache_eviction.py
@@ -1,0 +1,102 @@
+"""_evict_stale_app_cache: eviction must track the project ROOT, not fire
+unconditionally on every call.
+
+The bug: the eviction check compared app.__path__ (the "app" package's own
+directory, e.g. "/proj/app") against sys.path (which holds project roots,
+e.g. "/proj", never the "app" subdirectory itself). That comparison never
+matched, so app.* was evicted and fully reimported on every single remote
+dispatch, in both dev and prod, silently defeating anything keyed on the
+resulting function objects' identity (like the router's signature/hints
+cache) even when the project root never changed between requests.
+
+These tests pin down the fixed invariant from both directions:
+  1. within one continuously-running project root, no eviction fires
+     across repeated dispatches, so function identity (and therefore any
+     identity-keyed cache) stays stable.
+  2. across a genuine project-root change (e.g. one pytest session running
+     many tests, each building a fresh "app" package under its own
+     tmp_path, exactly as tests/conftest.py's blog_app fixture and
+     tests/remote/test_router.py's remote_project fixture do), eviction
+     still correctly fires and the newly active root's code is what gets
+     dispatched, not a stale cached function from the old root.
+"""
+import sys
+import pytest
+from fymo.remote import router as router_mod
+
+
+def _scaffold(root, hello_body: str):
+    (root / "app").mkdir()
+    (root / "app" / "__init__.py").write_text("")
+    (root / "app" / "remote").mkdir()
+    (root / "app" / "remote" / "__init__.py").write_text("")
+    (root / "app" / "remote" / "posts.py").write_text(hello_body)
+
+
+@pytest.fixture(autouse=True)
+def _clean_app_modules():
+    """Belt-and-suspenders: no test in this file should leak an "app" module
+    into any other test file, regardless of what sys.path manipulation it
+    does mid-test."""
+    yield
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
+
+
+def test_no_eviction_across_repeated_calls_within_one_stable_root(tmp_path):
+    """Simulates one continuously-running FymoApp: project_root is inserted
+    onto sys.path once (as FymoApp.__init__ does) and never touched again
+    between requests. Two dispatches for the same function must return the
+    exact same function object, proving no reimport (and thus no reflection
+    re-work) happened in between."""
+    _scaffold(tmp_path, "def hello(name: str) -> str: return f'hi {name}'\n")
+    root_str = str(tmp_path)
+    sys.path.insert(0, root_str)
+    try:
+        fn1, sig1, hints1 = router_mod._resolve_fn_in_module("posts", "hello")
+        fn2, sig2, hints2 = router_mod._resolve_fn_in_module("posts", "hello")
+        assert fn1 is not None
+        assert fn1 is fn2, (
+            "expected the same function object across two dispatches with an "
+            "unchanged project root; got a fresh reimport instead"
+        )
+    finally:
+        if root_str in sys.path:
+            sys.path.remove(root_str)
+
+
+def test_eviction_fires_when_project_root_changes(tmp_path_factory):
+    """Simulates a pytest session (or a dev-mode project-root switch) moving
+    from one "app" package to a different one under the same name, without
+    any manual sys.modules cleanup in between (that's exactly the job
+    _evict_stale_app_cache exists to do). The second dispatch must return
+    project B's function and behavior, not a stale cached function still
+    pointing at project A's file."""
+    root_a = tmp_path_factory.mktemp("proj_a")
+    root_b = tmp_path_factory.mktemp("proj_b")
+    _scaffold(root_a, "def hello() -> str: return 'from-a'\n")
+    _scaffold(root_b, "def hello() -> str: return 'from-b'\n")
+
+    root_a_str, root_b_str = str(root_a), str(root_b)
+    sys.path.insert(0, root_a_str)
+    try:
+        fn_a, _, _ = router_mod._resolve_fn_in_module("posts", "hello")
+        assert fn_a is not None
+        assert fn_a() == "from-a"
+    finally:
+        if root_a_str in sys.path:
+            sys.path.remove(root_a_str)
+
+    # Root A is gone from sys.path now; root B takes its place, same as a
+    # fresh FymoApp constructed against a different project. Nothing here
+    # manually clears sys.modules; that eviction must happen on its own.
+    sys.path.insert(0, root_b_str)
+    try:
+        fn_b, _, _ = router_mod._resolve_fn_in_module("posts", "hello")
+        assert fn_b is not None
+        assert fn_b is not fn_a, "stale function object from project A was reused for project B"
+        assert fn_b() == "from-b", "dispatch returned project A's stale behavior instead of project B's"
+    finally:
+        if root_b_str in sys.path:
+            sys.path.remove(root_b_str)

--- a/tests/remote/test_router_sig_cache.py
+++ b/tests/remote/test_router_sig_cache.py
@@ -1,0 +1,116 @@
+"""Signature/type-hint reflection caching in _resolve_fn_in_module.
+
+typing.get_type_hints() resolves annotations against module globals and
+builds a dict on every call; inspect.signature() walks parameters, both do
+real work that produces the same result every time for an unchanged
+function object. These tests pin down that the router memoizes that work
+per (module, fn_name) and correctly evicts the cache when the underlying
+function object changes (e.g. a provider re-registering a new version of a
+function under the same name, the system-module equivalent of a hot-reload).
+
+Exercised via the `_system_modules` allowlist path (the framework-shipped
+module route in _resolve_fn_in_module) rather than app/remote/*.py, because
+that path hands back the exact same function object across requests with no
+import machinery involved, an isolated, deterministic way to prove the
+memoization itself, independent of anything import-related.
+"""
+import io
+import base64
+import json
+import typing as typing_mod
+import pytest
+from fymo.remote.router import handle_remote
+from fymo.remote import router as router_mod
+from fymo.remote import devalue
+
+
+def _b64url(s: str) -> str:
+    return base64.urlsafe_b64encode(s.encode("utf-8")).rstrip(b"=").decode("ascii")
+
+
+def _make_environ(path: str, args: list, *, host: str = "x", origin: "str | None" = "http://x"):
+    body_obj = {"payload": _b64url(devalue.stringify(args))}
+    raw = json.dumps(body_obj).encode()
+    env = {
+        "REQUEST_METHOD": "POST",
+        "PATH_INFO": path,
+        "CONTENT_LENGTH": str(len(raw)),
+        "CONTENT_TYPE": "application/json",
+        "HTTP_COOKIE": "",
+        "HTTP_HOST": host,
+        "wsgi.url_scheme": "http",
+        "REMOTE_ADDR": "127.0.0.1",
+        "wsgi.input": io.BytesIO(raw),
+    }
+    if origin is not None:
+        env["HTTP_ORIGIN"] = origin
+    return env
+
+
+def _call(environ):
+    responses = []
+    def sr(status, headers): responses.append((status, headers))
+    body = b"".join(handle_remote(environ, sr))
+    return responses[0], json.loads(body)
+
+
+@pytest.fixture
+def system_module(monkeypatch):
+    """Registers a single system-module function ('sysmod.hello') and clears
+    the router's signature cache before and after so tests don't leak state
+    into each other through the shared module-level dict."""
+    def hello(name: str) -> str:
+        return f"hi {name}"
+
+    monkeypatch.setattr(router_mod, "_resolve_module_for_hash", lambda h: "sysmod" if h == "deadbeef0000" else None)
+    monkeypatch.setattr(router_mod, "_system_modules", {"sysmod": {"hello": hello}})
+    router_mod._sig_cache.clear()
+    yield "deadbeef0000", hello
+    router_mod._sig_cache.clear()
+
+
+def test_type_hints_resolved_once_across_repeated_calls(system_module, monkeypatch):
+    """Dispatching the same remote function twice must only reflect its type
+    hints once. The second call should hit the cache, not redo the work."""
+    hash_, hello = system_module
+
+    calls = []
+    real_get_type_hints = typing_mod.get_type_hints
+
+    def counting(fn, *a, **kw):
+        if fn is hello:
+            calls.append(fn)
+        return real_get_type_hints(fn, *a, **kw)
+
+    monkeypatch.setattr(typing_mod, "get_type_hints", counting)
+
+    _call(_make_environ(f"/_fymo/remote/{hash_}/hello", ["alice"]))
+    _call(_make_environ(f"/_fymo/remote/{hash_}/hello", ["bob"]))
+
+    assert len(calls) == 1, (
+        f"expected typing.get_type_hints to run once for 'hello' across two "
+        f"dispatches, it ran {len(calls)} times"
+    )
+
+
+def test_cache_invalidates_when_function_object_changes(system_module, monkeypatch):
+    """A different function landing under the same (module, fn_name) key
+    (e.g. a provider swapping in a new version) must be picked up, not
+    shadowed by the stale cached signature."""
+    hash_, hello = system_module
+
+    # Warm the cache with the original str-typed signature.
+    _call(_make_environ(f"/_fymo/remote/{hash_}/hello", ["alice"]))
+
+    def hello_v2(name: int) -> str:
+        return f"v2 {name}"
+
+    monkeypatch.setattr(router_mod, "_system_modules", {"sysmod": {"hello": hello_v2}})
+
+    (_, _), body = _call(_make_environ(f"/_fymo/remote/{hash_}/hello", ["alice"]))
+
+    # If the stale (str) signature were still cached, a str arg would validate
+    # fine against hello_v2 too. With correct identity-based invalidation,
+    # hello_v2's (int) signature rejects it.
+    assert body["type"] == "error"
+    assert body["status"] == 422


### PR DESCRIPTION
Closes #13

## Summary

Benchmark-driven fix (see linked benchmark in #13): remote-function (RPC) calls were ~35% slower than a bare JSON route doing identical work.

- `fymo/remote/router.py`'s `_resolve_fn_in_module` now caches `(fn, signature, hints)` via `_sig_cache`, keyed by `(module_name, fn_name)`, identity-invalidated so dev hot-reload still works correctly.
- The dominant fix wasn't the cache itself (~3% alone) — it was `_evict_stale_app_cache()`'s comparison, which was silently broken (`app.__path__ in sys.path`, essentially always false) and caused a near-full module reimport on almost every request. Fixed to compare `os.path.dirname(app_path) in sys.path`, matching what `FymoApp.__init__` actually inserts.
- The issue's own suggested fix (dev-mode gating) was rejected as unsafe — it would have broken `tests/remote/test_router.py`'s cross-test isolation — in favor of the proper root-cause fix above.

## Test plan

- [x] Full suite green, including 3x repeated + deliberately reordered/interleaved runs to hunt for the flakiness class this class of bug produces
- [x] 2.8x throughput improvement verified via the same `ab -n 2000 -c 50` benchmark methodology as the original report
- [x] Independent adversarial task review + final whole-branch review, no Critical/Important findings