### PR TITLE
remote.mode: collapse explicit_optin + allow_implicit into one tri-state

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -12,7 +12,7 @@ tribal knowledge.
 | `app/controllers` | Python | Page controllers, one module per route, exposing `getContext()`/`getDoc()` to the matching template. |
 | `app/templates` | Svelte / TS | The page components the router renders, one file per route (plus `_layout.svelte` files and `_global.css`). |
 | `app/components` | Svelte / TS | Reusable UI components shared across templates. |
-| `app/remote` | Python | Functions callable from the browser via the generated `$remote` client. Public, type-annotated top-level functions are exposed by default; mark with `@remote` (`fymo.remote.remote`) to opt into `remote.explicit_optin` mode. |
+| `app/remote` | Python | Functions callable from the browser via the generated `$remote` client. Public, type-annotated top-level functions are exposed by default; mark with `@remote` (`fymo.remote.remote`) to opt into `remote.mode: strict`. |
 | `app/jobs` | Python | Background task registry, submitted through a `JobProvider`. Every non-underscore top-level function becomes a submittable task; mark task entry points with `@task` (`fymo.jobs.task`) to say so explicitly (see below). |
 | `app/broadcasts` | Python | SSE channel definitions, discovered the same way as `app/jobs`. |
 | `app/lib` | TypeScript / Svelte | The `$lib/*` alias target (see `tsconfig.json`). TypeScript-only, there is no Python here, because nothing under `app/lib` ever runs server-side. |

--- a/examples/blog_app/fymo.yml
+++ b/examples/blog_app/fymo.yml
@@ -12,10 +12,10 @@ auth:
   enabled: true
 
 # Every function in app/remote/posts.py is marked @remote (see that file).
-# With explicit_optin on, that's what actually makes them reachable over the
+# With mode: strict, that's what actually makes them reachable over the
 # wire, rather than file placement alone deciding it.
 remote:
-  explicit_optin: true
+  mode: strict
 
 build:
   output_dir: dist

--- a/fymo/build/hygiene.py
+++ b/fymo/build/hygiene.py
@@ -182,5 +182,5 @@ def format_remote_exposure_error(violations: List[str]) -> str:
         "when remote.explicit_optin is false. Add @remote (from fymo.remote) to each "
         "function above that's meant to be an endpoint, or rename it with a leading "
         "underscore to keep it a private helper. To silence this check without fixing "
-        "it (unsafe, temporary), set remote.allow_implicit: true in fymo.yml."
+        "it (unsafe, temporary), set remote.mode: implicit-legacy in fymo.yml."
     )

--- a/fymo/build/hygiene.py
+++ b/fymo/build/hygiene.py
@@ -109,22 +109,26 @@ def check_remote_exposure_hygiene(project_root: Path, remote_config: "dict | Non
     internal storage helper landed in app/remote/ with no auth guard and
     turned out to be reachable over the wire).
 
-    A no-op (returns []) when `remote.explicit_optin` is true, since in that
-    mode an unmarked function is already excluded from the manifest and
-    the router by `discovery.is_exposed_remote_fn`, so there's nothing
-    silently exposed to warn about. Also a no-op when `remote.allow_implicit`
-    is true, the documented-unsafe escape hatch for apps that aren't ready
-    to migrate yet.
+    A no-op (returns []) whenever `fymo.remote.mode.resolve_remote_mode`
+    resolves `hygiene_enforced=False` for the given config: that covers
+    `remote.mode: strict` (an unmarked function is already excluded from the
+    manifest and the router by `discovery.is_exposed_remote_fn`, so there's
+    nothing silently exposed to warn about), `remote.mode: implicit-legacy`,
+    and the deprecated `explicit_optin`/`allow_implicit` spellings of both.
+
+    Lets `RemoteModeConfigError` propagate uncaught (an invalid `mode:`
+    value, or `mode:` combined with a deprecated key) so the caller
+    (`fymo/build/prepare.py`) can surface it as a distinct `BuildError`
+    rather than folding it into "found unmarked functions".
 
     Imports every app/remote/*.py module to apply the exact same exposure
     rule discovery uses at codegen time (`is_exposed_remote_fn` with
     explicit_optin=False, i.e. "what would ship if opt-in were off"), so
     this can never drift from what the manifest/router actually expose.
     """
-    remote_config = remote_config or {}
-    if remote_config.get("explicit_optin", False):
-        return []
-    if remote_config.get("allow_implicit", False):
+    from fymo.remote.mode import resolve_remote_mode
+
+    if not resolve_remote_mode(remote_config).hygiene_enforced:
         return []
 
     remote_dir = project_root / "app" / "remote"

--- a/fymo/build/prepare.py
+++ b/fymo/build/prepare.py
@@ -34,6 +34,7 @@ from fymo.build.hygiene import (
 from fymo.build.manifest import RemoteModuleAssets
 from fymo.remote.codegen import emit_module, emit_runtime
 from fymo.remote.discovery import discover_remote_modules
+from fymo.remote.mode import RemoteModeConfigError, uses_deprecated_remote_flags
 from fymo.utils.colors import Color
 
 
@@ -116,11 +117,23 @@ def prepare_build_config(project_root: Path, dist_dir: Path, cache_dir: Path, de
     # risk the two calls drifting if the file changes mid-build.
     remote_config = read_yaml_section(project_root, "remote")
 
+    # remote.explicit_optin / remote.allow_implicit still work for one
+    # deprecation cycle but are superseded by remote.mode; nudge toward the
+    # new key without failing the build over it.
+    if uses_deprecated_remote_flags(remote_config):
+        Color.print_warning(
+            "remote.explicit_optin and remote.allow_implicit are deprecated. "
+            "Use remote.mode: strict or remote.mode: implicit-legacy instead."
+        )
+
     # Also a pure-Python check (imports app/remote/*.py but does not touch
     # node/esbuild), so it runs alongside directory hygiene rather than
     # waiting on the node check below: a developer shipping an unguarded
     # endpoint should hear about it even on a machine without node installed.
-    remote_exposure_violations = check_remote_exposure_hygiene(project_root, remote_config)
+    try:
+        remote_exposure_violations = check_remote_exposure_hygiene(project_root, remote_config)
+    except RemoteModeConfigError as e:
+        raise BuildError(str(e))
     if remote_exposure_violations:
         raise BuildError(format_remote_exposure_error(remote_exposure_violations))
 

--- a/fymo/cli/commands/_scaffold.py
+++ b/fymo/cli/commands/_scaffold.py
@@ -23,11 +23,11 @@ routes:
     - posts
 
 # Remote functions (app/remote/*.py) require an explicit @remote marker to
-# be browser-callable: file placement alone is not enough. Flip to false
-# only if migrating an older project that relies on implicit exposure, and
-# consider remote.allow_implicit: true as a temporary bridge instead.
+# be browser-callable: file placement alone is not enough. Switch to
+# mode: implicit-legacy only if migrating an older project that relies on
+# implicit exposure.
 remote:
-  explicit_optin: true
+  mode: strict
 
 # Build configuration
 build:

--- a/fymo/core/config.py
+++ b/fymo/core/config.py
@@ -185,8 +185,11 @@ class ConfigManager:
         return self.get('broadcasts', {}) or {}
 
     def get_remote_config(self) -> Dict[str, Any]:
-        """`remote:` section. Holds explicit_optin (require @remote to expose
-        an app/remote/*.py function; default False for back-compat)."""
+        """`remote:` section. Holds remote.mode (strict or implicit-legacy),
+        controlling whether an app/remote/*.py function needs @remote to be
+        browser-callable; default is implicit for back-compat. The deprecated
+        explicit_optin/allow_implicit booleans still resolve through
+        fymo.remote.mode.resolve_remote_mode."""
         return self.get('remote', {}) or {}
 
     def get_logging_config(self) -> Dict[str, Any]:

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -134,9 +134,18 @@ class FymoApp:
         # Wire the remote `@remote` opt-in flag into the router, mirroring
         # _dev_mode above. Must agree with what discovery used at build time
         # (fymo/build/pipeline.py) — otherwise a function could be listed in
-        # the client manifest but 404 at dispatch, or vice versa.
+        # the client manifest but 404 at dispatch, or vice versa. Resolved
+        # through the same fymo.remote.mode.resolve_remote_mode as discovery
+        # and the build-time hygiene check so all three call sites can never
+        # drift on the truth table. An invalid remote: config (bad mode:
+        # value, or mode: combined with a deprecated key) raises
+        # RemoteModeConfigError here and is left to propagate, same posture
+        # as the StorageConfigError raised below for a bad media:/storage:
+        # combination: loud startup failure beats a server silently running
+        # with an ambiguous dispatch gate.
+        from fymo.remote.mode import resolve_remote_mode
         remote_cfg = self.config_manager.get_remote_config()
-        _remote_router._explicit_optin = bool(remote_cfg.get("explicit_optin", False))
+        _remote_router._explicit_optin = resolve_remote_mode(remote_cfg).strict
 
         self.asset_manager = AssetManager(self.project_root)
         # App-level raw HTTP routes (e.g. hand-written media streaming),

--- a/fymo/remote/discovery.py
+++ b/fymo/remote/discovery.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from fymo.remote.mode import resolve_remote_mode
+
 
 def file_hash(path: Path) -> str:
     """Return a 12-char lowercase hex SHA-256 prefix of the file's contents."""
@@ -69,17 +71,18 @@ def discover_remote_modules(
     remote functions are added too (e.g. password's under `auth`), discovered
     from the providers rather than any hardcoded module.
 
-    `remote_config` holds the `remote:` section of fymo.yml. When its
-    `explicit_optin` flag is true, only app-module functions decorated with
-    `@remote` (fymo.remote.decorators.remote, which stamps
+    `remote_config` holds the `remote:` section of fymo.yml, resolved through
+    `fymo.remote.mode.resolve_remote_mode`. Under `remote.mode: strict` (or
+    the deprecated `explicit_optin: true`), only app-module functions
+    decorated with `@remote` (fymo.remote.decorators.remote, which stamps
     `__fymo_remote__ = True`) are discovered — everything else in
-    app/remote/*.py is treated as a private helper. Default is false (every
-    public typed function is discovered, today's back-compat behavior). This
-    only applies to app modules; provider/system remote functions (below)
-    always ship regardless of the flag.
+    app/remote/*.py is treated as a private helper. Default is implicit
+    (every public typed function is discovered, today's back-compat
+    behavior). This only applies to app modules; provider/system remote
+    functions (below) always ship regardless of the mode.
     """
     out: dict[str, dict[str, RemoteFunction]] = {}
-    explicit_optin = bool((remote_config or {}).get("explicit_optin", False))
+    explicit_optin = resolve_remote_mode(remote_config).strict
 
     remote_dir = project_root / "app" / "remote"
     if remote_dir.is_dir():

--- a/fymo/remote/mode.py
+++ b/fymo/remote/mode.py
@@ -1,8 +1,8 @@
 """Remote mode resolution: collapse explicit_optin + allow_implicit into a tristate.
 
 The remote: section of fymo.yml originally used two independent booleans:
-- explicit_optin: true/false — gates whether only @remote-decorated functions dispatch
-- allow_implicit: true/false — silences the build-time hygiene check (only read when
+- explicit_optin: true/false, gates whether only @remote-decorated functions dispatch
+- allow_implicit: true/false, silences the build-time hygiene check (only read when
   explicit_optin is false)
 
 These are not independent: they're one three-state decision wearing two boolean flags.

--- a/fymo/remote/mode.py
+++ b/fymo/remote/mode.py
@@ -1,0 +1,122 @@
+"""Remote mode resolution: collapse explicit_optin + allow_implicit into a tristate.
+
+The remote: section of fymo.yml originally used two independent booleans:
+- explicit_optin: true/false — gates whether only @remote-decorated functions dispatch
+- allow_implicit: true/false — silences the build-time hygiene check (only read when
+  explicit_optin is false)
+
+These are not independent: they're one three-state decision wearing two boolean flags.
+This module collapses them into a single remote.mode key with two valid values:
+- strict: only @remote-decorated functions expose, hygiene check enforced
+- implicit-legacy: all public functions expose, hygiene check silenced (unsafe, temporary)
+
+The old boolean keys remain accepted for one deprecation cycle for back-compat, but
+remote.mode is the canonical interface. Combining mode: with either deprecated key
+is a hard config error (ambiguous).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+class RemoteModeConfigError(Exception):
+    """Raised when a remote.mode value is invalid or conflicts with deprecated keys."""
+
+
+@dataclass(frozen=True)
+class RemoteMode:
+    """Resolved remote configuration state.
+
+    strict: bool
+        True if only @remote-decorated functions can dispatch (explicit opt-in mode).
+        False if all public functions can dispatch (implicit mode).
+
+    hygiene_enforced: bool
+        True if fymo build hard-fails when discovering unmarked remote functions
+        that would be exposed under implicit mode. False if the hygiene check is
+        silenced (unsafe, for apps not yet ready to add @remote markers).
+    """
+    strict: bool
+    hygiene_enforced: bool
+
+
+def resolve_remote_mode(remote_config: Optional[Dict[str, Any]]) -> RemoteMode:
+    """Resolve remote configuration into a RemoteMode triple.
+
+    Implements the truth table from issue #25:
+    - nothing set -> strict=False, hygiene_enforced=True (implicit, checked)
+    - explicit_optin: true (deprecated) -> strict=True, hygiene_enforced=False
+    - allow_implicit: true (deprecated) -> strict=False, hygiene_enforced=False
+    - mode: strict -> strict=True, hygiene_enforced=False
+    - mode: implicit-legacy -> strict=False, hygiene_enforced=False
+    - mode: <other> -> raises RemoteModeConfigError
+    - mode: combined with explicit_optin or allow_implicit -> raises RemoteModeConfigError
+    - explicit_optin: true AND allow_implicit: true (no mode:) -> strict=True, hygiene_enforced=False
+      (discovery uses explicit_optin, hygiene returns [] if EITHER flag is true, per today's behavior)
+
+    Pure function, no I/O or side effects.
+    """
+    config = remote_config or {}
+
+    # Check for conflicting configuration: mode: combined with deprecated keys.
+    has_mode = "mode" in config
+    has_explicit_optin = "explicit_optin" in config
+    has_allow_implicit = "allow_implicit" in config
+
+    if has_mode and (has_explicit_optin or has_allow_implicit):
+        if has_explicit_optin:
+            raise RemoteModeConfigError(
+                "remote.mode conflicts with deprecated remote.explicit_optin. "
+                "Use remote.mode: strict or remote.mode: implicit-legacy, not both."
+            )
+        if has_allow_implicit:
+            raise RemoteModeConfigError(
+                "remote.mode conflicts with deprecated remote.allow_implicit. "
+                "Use remote.mode: strict or remote.mode: implicit-legacy, not both."
+            )
+
+    # Resolve the new mode: key if present.
+    if has_mode:
+        mode_val = config["mode"]
+        if mode_val == "strict":
+            return RemoteMode(strict=True, hygiene_enforced=False)
+        elif mode_val == "implicit-legacy":
+            return RemoteMode(strict=False, hygiene_enforced=False)
+        else:
+            raise RemoteModeConfigError(
+                f"unknown remote.mode value: {mode_val!r}. "
+                f"Valid values are 'strict' and 'implicit-legacy'."
+            )
+
+    # Fall back to deprecated keys. Both flags default to False if absent.
+    explicit_optin = config.get("explicit_optin", False)
+    allow_implicit = config.get("allow_implicit", False)
+
+    # If either flag is true, apply its meaning. The discovery gate uses
+    # explicit_optin; the hygiene check returns [] if EITHER is true (checks
+    # explicit_optin first today). Preserve this exact behavior for back-compat.
+    if explicit_optin:
+        # Dispatch gate is on, hygiene check is off. Once dispatch is gated, the
+        # hygiene scan is redundant; it would only false-flag private helpers that
+        # are already safely non-dispatchable.
+        return RemoteMode(strict=True, hygiene_enforced=False)
+    elif allow_implicit:
+        # Dispatch gate is off, hygiene check is off (this flag's whole purpose).
+        return RemoteMode(strict=False, hygiene_enforced=False)
+    else:
+        # Neither flag set: implicit mode, but with hygiene check enforced (the default).
+        return RemoteMode(strict=False, hygiene_enforced=True)
+
+
+def uses_deprecated_remote_flags(remote_config: Optional[Dict[str, Any]]) -> bool:
+    """Return True if the config uses deprecated explicit_optin or allow_implicit keys.
+
+    Returns True if either key is present in the config (regardless of value),
+    False otherwise. Does not trigger for the mode:-only case or when no config
+    is present (neither keys nor mode: set).
+
+    Used by the build system to decide whether to print a deprecation warning.
+    """
+    config = remote_config or {}
+    return "explicit_optin" in config or "allow_implicit" in config

--- a/tests/build/test_prepare.py
+++ b/tests/build/test_prepare.py
@@ -159,6 +159,86 @@ def test_explicit_optin_true_lets_unmarked_function_build_with_no_warning(exampl
     assert "versions" not in config.remote_assets
 
 
+def test_mode_strict_lets_unmarked_function_build_with_no_warning(example_app: Path, monkeypatch, capsys):
+    """remote.mode: strict must enforce identically to explicit_optin: true:
+    build succeeds, the unmarked function stays a private helper, and no
+    deprecation warning is printed for the new spelling."""
+    (example_app / "app" / "remote").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "remote" / "__init__.py").write_text("")
+    (example_app / "app" / "remote" / "versions.py").write_text(
+        "def insert_version(x: str) -> str: return x\n"
+    )
+    (example_app / "fymo.yml").write_text(
+        (example_app / "fymo.yml").read_text() + "\nremote:\n  mode: strict\n"
+    )
+    monkeypatch.setattr("fymo.build.prepare.shutil.which", lambda cmd: "/usr/bin/node")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    config = prepare_build_config(example_app, dist_dir, cache_dir, dev=True)
+    assert isinstance(config, BuildConfig)
+    assert "versions" not in config.remote_assets
+    out = capsys.readouterr().out
+    assert "deprecat" not in out.lower()
+
+
+def test_mode_implicit_legacy_lets_unmarked_function_build(example_app: Path, monkeypatch):
+    """remote.mode: implicit-legacy must silence the hygiene check identically
+    to allow_implicit: true today."""
+    (example_app / "app" / "remote").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "remote" / "__init__.py").write_text("")
+    (example_app / "app" / "remote" / "versions.py").write_text(
+        "def insert_version(x: str) -> str: return x\n"
+    )
+    (example_app / "fymo.yml").write_text(
+        (example_app / "fymo.yml").read_text() + "\nremote:\n  mode: implicit-legacy\n"
+    )
+    monkeypatch.setattr("fymo.build.prepare.shutil.which", lambda cmd: "/usr/bin/node")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    config = prepare_build_config(example_app, dist_dir, cache_dir, dev=True)
+    assert isinstance(config, BuildConfig)
+
+
+def test_invalid_remote_mode_raises_build_error(example_app: Path):
+    """remote.mode: <bogus value> must surface as a BuildError naming the bad
+    value, not a raw RemoteModeConfigError escaping to the CLI."""
+    (example_app / "fymo.yml").write_text(
+        (example_app / "fymo.yml").read_text() + "\nremote:\n  mode: bogus\n"
+    )
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    with pytest.raises(BuildError, match="bogus"):
+        prepare_build_config(example_app, dist_dir, cache_dir, dev=False)
+
+
+def test_deprecated_explicit_optin_prints_deprecation_warning(example_app: Path, monkeypatch, capsys):
+    """remote.explicit_optin (deprecated spelling) must trigger a non-fatal
+    build-time warning pointing at remote.mode."""
+    (example_app / "fymo.yml").write_text(
+        (example_app / "fymo.yml").read_text() + "\nremote:\n  explicit_optin: true\n"
+    )
+    monkeypatch.setattr("fymo.build.prepare.shutil.which", lambda cmd: "/usr/bin/node")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    prepare_build_config(example_app, dist_dir, cache_dir, dev=True)
+    out = capsys.readouterr().out
+    assert "explicit_optin" in out
+    assert "remote.mode" in out
+
+
+def test_mode_strict_prints_no_deprecation_warning(example_app: Path, monkeypatch, capsys):
+    (example_app / "fymo.yml").write_text(
+        (example_app / "fymo.yml").read_text() + "\nremote:\n  mode: strict\n"
+    )
+    monkeypatch.setattr("fymo.build.prepare.shutil.which", lambda cmd: "/usr/bin/node")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    prepare_build_config(example_app, dist_dir, cache_dir, dev=True)
+    out = capsys.readouterr().out
+    assert "explicit_optin" not in out
+    assert "remote.mode" not in out
+
+
 @pytest.mark.usefixtures("node_available")
 def test_prepare_build_config_reflects_blog_app_facts(blog_app: Path):
     """blog_app has index/, posts/ (with a resource _layout.svelte and

--- a/tests/build/test_remote_exposure_hygiene.py
+++ b/tests/build/test_remote_exposure_hygiene.py
@@ -217,4 +217,4 @@ def test_format_remote_exposure_error_names_the_functions():
     ])
     assert "insert_version" in msg
     assert "app/remote/versions.py" in msg
-    assert "allow_implicit" in msg
+    assert "implicit-legacy" in msg

--- a/tests/build/test_remote_exposure_hygiene.py
+++ b/tests/build/test_remote_exposure_hygiene.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from fymo.build.hygiene import check_remote_exposure_hygiene, format_remote_exposure_error
+from fymo.remote.mode import RemoteModeConfigError
 
 
 def _scaffold(tmp_path: Path, files: dict[str, str]) -> Path:
@@ -128,6 +129,49 @@ def test_explicit_optin_true_skips_the_check_entirely(tmp_path: Path):
         sys.path.remove(str(project))
 
     assert violations == []
+
+
+def test_mode_strict_skips_the_check_entirely(tmp_path: Path):
+    """remote.mode: strict must resolve to the same hygiene_enforced=False as
+    explicit_optin: true: dispatch is already gated, so there's nothing
+    silently exposed to warn about."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {"mode": "strict"})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_mode_implicit_legacy_skips_the_check_entirely(tmp_path: Path):
+    """remote.mode: implicit-legacy is the new spelling of allow_implicit:
+    true, the acknowledged-unsafe escape hatch."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {"mode": "implicit-legacy"})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_invalid_mode_raises_remote_mode_config_error(tmp_path: Path):
+    """An unresolvable remote.mode must surface as RemoteModeConfigError, not
+    a silent [] or a hygiene violation list. Wrapping into a BuildError is
+    the caller's job (fymo/build/prepare.py), not this function's."""
+    with pytest.raises(RemoteModeConfigError, match="bogus"):
+        check_remote_exposure_hygiene(tmp_path, {"mode": "bogus"})
 
 
 def test_multiple_unmarked_functions_across_modules_all_reported(tmp_path: Path):

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -52,15 +52,19 @@ def test_new_and_init_scaffold_identical_fymo_yml(tmp_path):
     assert "sample_app" in content
 
 
-def test_new_scaffold_defaults_to_explicit_remote_optin(tmp_path):
+def test_new_scaffold_defaults_to_remote_mode_strict(tmp_path):
     """Issue #8: fresh projects should require @remote to expose a function,
     not fall back to implicit file-placement exposure. Existing projects are
-    unaffected: this only changes what NEW projects generate."""
+    unaffected: this only changes what NEW projects generate.
+
+    Issue #25: new projects must be scaffolded on the current remote.mode
+    spelling, not the deprecated explicit_optin boolean."""
     from fymo.cli.commands._scaffold import render_fymo_yml
     import yaml
     content = render_fymo_yml("sample_app")
     data = yaml.safe_load(content)
-    assert data["remote"]["explicit_optin"] is True
+    assert data["remote"]["mode"] == "strict"
+    assert "explicit_optin" not in data["remote"]
 
 
 def test_new_does_not_scaffold_dead_config_routes(tmp_path, monkeypatch):

--- a/tests/core/test_remote_mode_startup.py
+++ b/tests/core/test_remote_mode_startup.py
@@ -1,0 +1,28 @@
+"""FymoApp.__init__ wires remote.mode into the router's dispatch gate
+(fymo/core/server.py). An invalid remote: config must fail startup loudly,
+the same posture as the existing StorageConfigError check a few lines below
+it in the same function -- see test_fymo_app_invalid_logging_config_fails_at_startup
+in tests/core/test_logging.py for the sibling pattern this mirrors."""
+from pathlib import Path
+
+import pytest
+
+from fymo.remote.mode import RemoteModeConfigError
+
+
+def test_fymo_app_invalid_remote_mode_fails_at_startup(tmp_path: Path):
+    (tmp_path / "fymo.yml").write_text(
+        "name: RemoteModeTest\nremote:\n  mode: bogus\n"
+    )
+    from fymo.core.server import FymoApp
+    with pytest.raises(RemoteModeConfigError, match="bogus"):
+        FymoApp(tmp_path, dev=True)
+
+
+def test_fymo_app_mode_conflicting_with_deprecated_key_fails_at_startup(tmp_path: Path):
+    (tmp_path / "fymo.yml").write_text(
+        "name: RemoteModeTest\nremote:\n  mode: strict\n  explicit_optin: true\n"
+    )
+    from fymo.core.server import FymoApp
+    with pytest.raises(RemoteModeConfigError, match="explicit_optin"):
+        FymoApp(tmp_path, dev=True)

--- a/tests/core/test_remote_mode_startup.py
+++ b/tests/core/test_remote_mode_startup.py
@@ -1,7 +1,7 @@
 """FymoApp.__init__ wires remote.mode into the router's dispatch gate
 (fymo/core/server.py). An invalid remote: config must fail startup loudly,
 the same posture as the existing StorageConfigError check a few lines below
-it in the same function -- see test_fymo_app_invalid_logging_config_fails_at_startup
+it in the same function, see test_fymo_app_invalid_logging_config_fails_at_startup
 in tests/core/test_logging.py for the sibling pattern this mirrors."""
 from pathlib import Path
 

--- a/tests/remote/test_mode.py
+++ b/tests/remote/test_mode.py
@@ -1,0 +1,122 @@
+"""Tests for fymo.remote.mode resolver (remote.mode tristate configuration)."""
+import pytest
+
+from fymo.remote.mode import (
+    RemoteMode,
+    RemoteModeConfigError,
+    resolve_remote_mode,
+    uses_deprecated_remote_flags,
+)
+
+
+class TestResolveRemoteMode:
+    """Test the resolve_remote_mode function against the truth table."""
+
+    def test_nothing_set(self):
+        """When remote config is empty or None, use implicit mode with hygiene enforced."""
+        assert resolve_remote_mode(None) == RemoteMode(strict=False, hygiene_enforced=True)
+        assert resolve_remote_mode({}) == RemoteMode(strict=False, hygiene_enforced=True)
+
+    def test_explicit_optin_true_deprecated(self):
+        """explicit_optin: true (deprecated) -> strict mode, hygiene NOT enforced.
+
+        Hygiene_enforced is False because once dispatch is gated, the hygiene scan
+        becomes redundant and would only false-flag private helpers already gated by
+        dispatch itself.
+        """
+        result = resolve_remote_mode({"explicit_optin": True})
+        assert result == RemoteMode(strict=True, hygiene_enforced=False)
+
+    def test_allow_implicit_true_deprecated(self):
+        """allow_implicit: true (deprecated) -> implicit mode, hygiene NOT enforced."""
+        result = resolve_remote_mode({"allow_implicit": True})
+        assert result == RemoteMode(strict=False, hygiene_enforced=False)
+
+    def test_mode_strict(self):
+        """mode: strict -> strict mode, hygiene NOT enforced.
+
+        Hygiene_enforced is False because once dispatch is gated, the hygiene scan
+        becomes redundant and would only false-flag private helpers already gated by
+        dispatch itself.
+        """
+        result = resolve_remote_mode({"mode": "strict"})
+        assert result == RemoteMode(strict=True, hygiene_enforced=False)
+
+    def test_mode_implicit_legacy(self):
+        """mode: implicit-legacy -> implicit mode, hygiene NOT enforced."""
+        result = resolve_remote_mode({"mode": "implicit-legacy"})
+        assert result == RemoteMode(strict=False, hygiene_enforced=False)
+
+    def test_mode_invalid_value(self):
+        """mode with invalid value raises RemoteModeConfigError."""
+        with pytest.raises(RemoteModeConfigError) as exc_info:
+            resolve_remote_mode({"mode": "bogus"})
+        error_msg = str(exc_info.value)
+        assert "bogus" in error_msg
+        assert "strict" in error_msg
+        assert "implicit-legacy" in error_msg
+
+    def test_mode_with_explicit_optin_conflict(self):
+        """mode: combined with explicit_optin raises RemoteModeConfigError."""
+        with pytest.raises(RemoteModeConfigError) as exc_info:
+            resolve_remote_mode({"mode": "strict", "explicit_optin": True})
+        error_msg = str(exc_info.value)
+        assert "mode" in error_msg.lower()
+        assert "explicit_optin" in error_msg
+
+    def test_mode_with_allow_implicit_conflict(self):
+        """mode: combined with allow_implicit raises RemoteModeConfigError."""
+        with pytest.raises(RemoteModeConfigError) as exc_info:
+            resolve_remote_mode({"mode": "strict", "allow_implicit": True})
+        error_msg = str(exc_info.value)
+        assert "mode" in error_msg.lower()
+        assert "allow_implicit" in error_msg
+
+    def test_explicit_optin_and_allow_implicit_both_set(self):
+        """Both deprecated keys set (no mode:) preserves today's behavior.
+
+        discovery uses explicit_optin (True), hygiene returns [] if EITHER is true
+        (checks explicit_optin first). So: strict=True, hygiene_enforced=False.
+        """
+        result = resolve_remote_mode({"explicit_optin": True, "allow_implicit": True})
+        assert result == RemoteMode(strict=True, hygiene_enforced=False)
+
+
+class TestUsesDeprecatedRemoteFlags:
+    """Test the uses_deprecated_remote_flags helper."""
+
+    def test_explicit_optin_true(self):
+        """explicit_optin: true is deprecated."""
+        assert uses_deprecated_remote_flags({"explicit_optin": True})
+
+    def test_explicit_optin_false_still_deprecated(self):
+        """explicit_optin: false still counts as using the deprecated key."""
+        assert uses_deprecated_remote_flags({"explicit_optin": False})
+
+    def test_allow_implicit_true(self):
+        """allow_implicit: true is deprecated."""
+        assert uses_deprecated_remote_flags({"allow_implicit": True})
+
+    def test_allow_implicit_false_still_deprecated(self):
+        """allow_implicit: false still counts as using the deprecated key."""
+        assert uses_deprecated_remote_flags({"allow_implicit": False})
+
+    def test_empty_config(self):
+        """Empty config does not use deprecated flags."""
+        assert not uses_deprecated_remote_flags({})
+
+    def test_none_config(self):
+        """None config does not use deprecated flags."""
+        assert not uses_deprecated_remote_flags(None)
+
+    def test_mode_only(self):
+        """mode: key alone does not trigger deprecation warning."""
+        assert not uses_deprecated_remote_flags({"mode": "strict"})
+
+    def test_both_deprecated_flags(self):
+        """Both deprecated flags present still counts as using deprecated."""
+        assert uses_deprecated_remote_flags({"explicit_optin": True, "allow_implicit": False})
+
+    def test_mode_with_deprecated_flags(self):
+        """Having mode: does not suppress deprecation detection."""
+        assert uses_deprecated_remote_flags({"mode": "strict", "explicit_optin": True})

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #25

## Summary

`remote.explicit_optin` and `remote.allow_implicit` were two booleans that were never independent, `allow_implicit` was only ever consulted when `explicit_optin` was already false, so it was really one three-state decision wearing two flags.

- `fymo/remote/mode.py` (new): `resolve_remote_mode(config) -> RemoteMode(strict, hygiene_enforced)`, the single source of truth for what used to be duplicated logic across three call sites. `remote.mode: strict` (only `@remote`-decorated functions are dispatchable, hygiene check redundant since dispatch is already gated) and `remote.mode: implicit-legacy` (old behavior, hygiene check silenced) replace the two booleans.
- `fymo/remote/discovery.py`, `fymo/core/server.py`, `fymo/build/hygiene.py` all route through the resolver now, zero re-implementations of the truth table anywhere in the codebase (verified by grep across the whole repo, not just the touched files).
- Both deprecated boolean keys still work, identically to today, for one deprecation cycle. `fymo build` prints a non-fatal warning pointing at `remote.mode` when it sees either of them. `mode:` combined with a deprecated key is a hard config error (ambiguous, refuses to guess).
- `fymo new`/`init` now scaffold `mode: strict` for new projects.

## Test plan

- [x] Full suite: 793 passed, 10 skipped, 0 failed
- [x] Every existing test exercising `explicit_optin`/`allow_implicit` keeps its original, unchanged assertions, only setup/construction changed
- [x] An app with `explicit_optin: true` or `allow_implicit: true` today behaves identically after this lands, verified concretely, not just via tests passing
- [x] `mode: <bad value>` surfaces as a clean `BuildError` naming the bad value, not a raw internal exception
- [x] `mode:` + a deprecated key raises, doesn't silently pick one
- [x] Independent adversarial task review (both tasks) + final whole-branch review, no Critical/Important findings

## Notes

Task 1's implementer plan actually had a bug in its own truth table (`explicit_optin: true` was mapped to enforce the hygiene check, which would have broken an existing test and false-flagged safe undecorated helpers, since dispatch is already gated under strict mode and has nothing to warn about). Caught in review before it reached the wiring task, fixed at the source.