### PR TITLE
Add a runtime accessor for the configured StorageProvider

### DIFF
--- a/fymo/cli/commands/jobs_worker.py
+++ b/fymo/cli/commands/jobs_worker.py
@@ -48,6 +48,16 @@ def run_jobs_worker(project_root: Optional[Path] = None) -> None:
     from fymo.broadcast import init_broadcasts
     init_broadcasts(project_root, config_manager.get_broadcasts_config().get("provider"))
 
+    # Same reasoning for storage (issue #31): a job that writes a file
+    # (e.g. a finished video recording) calls fymo.storage.get_storage_provider(),
+    # and this worker is a separate process from the one FymoApp initialized
+    # it in. Only wired up when storage: is actually configured, mirroring
+    # FymoApp's own no-default treatment, see fymo/storage/registry.py.
+    storage_config = config_manager.get_storage_config()
+    if storage_config is not None:
+        from fymo.storage import init_storage_provider
+        init_storage_provider(project_root, storage_config)
+
     Color.print_info(f"Starting job worker ({provider.id}) for {project_root}")
     try:
         provider.run_worker()

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -147,6 +147,20 @@ class FymoApp:
         # raw-WSGI routes with config-driven ones. See fymo/core/media.py.
         from fymo.core.http import discover_app_http_routes
         from fymo.core.media import build_media_routes
+
+        # Storage: built once, whenever storage: is configured, independent
+        # of whether media: is also configured. App code (a remote function,
+        # a job) reaches this same instance process-wide via
+        # fymo.storage.get_storage_provider() (issue #31); gating
+        # construction on media_config would leave that accessor unusable
+        # for an app that only writes files itself and never declares
+        # media: routes.
+        from fymo.storage import init_storage_provider
+        storage_config = self.config_manager.get_storage_config()
+        self.storage_provider = None
+        if storage_config is not None:
+            self.storage_provider = init_storage_provider(self.project_root, storage_config)
+
         media_config = self.config_manager.get_media_config()
         media_routes = []
         if media_config:
@@ -157,17 +171,15 @@ class FymoApp:
             # startup path shares. The message is phrased for a running app (fix
             # fymo.yml and restart) rather than build_storage_provider's own
             # build-context wording.
-            from fymo.storage.registry import StorageConfigError, build_storage_provider
-            storage_config = self.config_manager.get_storage_config()
-            if storage_config is None:
+            if self.storage_provider is None:
+                from fymo.storage.registry import StorageConfigError
                 raise StorageConfigError(
                     "media: is configured in fymo.yml but storage: is missing. "
                     "media: routes resolve files through the configured "
                     "StorageProvider and there is no default, add a storage: "
                     "section (e.g. `storage: {provider: local}`) to fymo.yml."
                 )
-            storage = build_storage_provider(storage_config, self.project_root)
-            media_routes = build_media_routes(self.project_root, media_config, storage)
+            media_routes = build_media_routes(self.project_root, media_config, self.storage_provider)
         self._app_routes = discover_app_http_routes(self.project_root) + media_routes
         self.router = self._initialize_router()
         self.template_renderer = TemplateRenderer(

--- a/fymo/storage/__init__.py
+++ b/fymo/storage/__init__.py
@@ -7,4 +7,108 @@ generated files) actually live.
 The fymo.yml `storage:` section selects a provider (built-in `local`, or a
 `class:` dotted path to a custom one). See `fymo.storage.base.StorageProvider`
 for the Protocol.
+
+App code (a remote function, a job) never calls `build_storage_provider`
+directly. It reaches the same provider `FymoApp` built at startup through
+the process-wide accessor below:
+
+    from fymo.storage import get_storage_provider
+
+    get_storage_provider().write("videos/clip.webm", data)
+
+`get_storage_provider()` mirrors `fymo.jobs.get_job_provider()` and
+`fymo.broadcast.get_broadcast_provider()`: a no-arg singleton, installed by
+`init_storage_provider(project_root, storage_config)` (called by `FymoApp`
+at startup, and by `fymo jobs-worker` for the separate worker process). One
+deliberate difference from those two: storage has no default provider (see
+`fymo.storage.registry`'s docstring), so `get_storage_provider()` raises
+instead of silently constructing a local-disk fallback when nothing has
+initialized it yet.
+
+`write(key, data)` takes a complete `bytes` payload, there is no streaming
+append. Something that produces bytes incrementally, like a Playwright
+recording running live, can't call it until the recording is finished. The
+pattern is: record to a scratch path on local disk (e.g. a temp file, or
+`app/data/tmp/`), then read the finished file and call `write()` once with
+the whole thing. That's also the pattern that keeps working once storage
+stops being local disk (#17, S3/R2 providers): those backends don't offer a
+"keep appending to this key" operation either, a live recording has to land
+somewhere writable before it becomes a single `write()` call.
 """
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+from fymo.storage.base import StorageProvider
+
+__all__ = [
+    "StorageProvider",
+    "set_storage_provider",
+    "get_storage_provider",
+    "init_storage_provider",
+    "reset_storage_provider",
+]
+
+# --- process-wide provider singleton -------------------------------------
+#
+# Mirrors fymo.jobs' and fymo.broadcast's provider singletons: FymoApp calls
+# init_storage_provider() at startup (whenever storage: is configured, not
+# only when media: is also configured, see fymo/core/server.py), and
+# fymo jobs-worker does the same for its own separate process. App code then
+# calls get_storage_provider() from anywhere without wiring anything itself.
+
+_provider: Optional[Any] = None
+_lock = threading.Lock()
+
+
+def set_storage_provider(provider: Any) -> None:
+    """Replace the process-wide StorageProvider singleton."""
+    global _provider
+    with _lock:
+        _provider = provider
+
+
+def get_storage_provider() -> Any:
+    """Return the process-wide StorageProvider.
+
+    Unlike `get_job_provider()`/`get_broadcast_provider()`, there is no
+    default to fall back to, storage has none on purpose (see
+    `fymo.storage.registry`'s docstring). Raises `RuntimeError` if
+    `init_storage_provider()` hasn't run in this process yet.
+    """
+    with _lock:
+        if _provider is None:
+            raise RuntimeError(
+                "storage is not initialized — FymoApp calls init_storage_provider() "
+                "at startup when storage: is configured in fymo.yml; a separate "
+                "process (e.g. a job worker) must call "
+                "fymo.storage.init_storage_provider(project_root, storage_config) itself"
+            )
+        return _provider
+
+
+def init_storage_provider(project_root: Path, storage_config: Any) -> Any:
+    """Build the configured StorageProvider, install it as the process-wide
+    singleton, and return it. Raises `StorageConfigError` (see
+    `fymo.storage.registry`) if `storage_config` is falsy, there is no
+    default provider.
+
+    Called once by FymoApp at startup (mirrors `fymo.jobs.init_job_provider`
+    and `fymo.broadcast.init_broadcasts`), and by `fymo jobs-worker` for its
+    own separate process.
+    """
+    from fymo.storage.registry import build_storage_provider
+
+    provider = build_storage_provider(storage_config, project_root)
+    set_storage_provider(provider)
+    return provider
+
+
+def reset_storage_provider() -> None:
+    """Test-only: clear the shared StorageProvider so each test gets
+    isolation. Not meant to be called from application code."""
+    global _provider
+    with _lock:
+        _provider = None

--- a/journal/journal_013.md
+++ b/journal/journal_013.md
@@ -1,0 +1,128 @@
+# Journal Entry 013: The Provider Nobody Could Reach
+
+**Date**: July 15, 2026
+**Focus**: A runtime accessor for the configured StorageProvider
+**Status**: Shipped
+
+## The Complaint
+
+A video-recording job needed to know where to write its finished file. Not
+a hypothetical, a real one: something driving a headless browser, recording
+a session, and needing to land the result wherever `storage:` in fymo.yml
+says it should live. It reached for the obvious thing first, and the
+obvious thing turned out not to exist.
+
+`StorageProvider` gets built exactly once in this codebase, inside
+`FymoApp.__init__`, and only when `media:` is configured. There was no
+accessor for anything else. So the job did what jobs do when the framework
+doesn't give them a door: it found a window. It imported
+`fymo.build.prepare.read_yaml_section`, a function whose own docstring says
+"used only to thread config into build-time discovery, not the runtime
+config loader" — and reimplemented the prefix-matching dir-resolution loop
+that `build_media_routes` already does internally, by hand, badly,
+duplicated.
+
+That's the whole bug report, really. Not a crash, not a wrong answer, just
+a job that had to go around the framework because the framework hadn't
+built the door yet.
+
+## What the Issue Actually Asked For
+
+The ticket sketched `get_storage_provider(project_root)`, off `fymo.storage`,
+"built the same way FymoApp builds its own internally." Reasonable enough
+sketch. But I'd just spent an entry pulling `fymo.jobs` and `fymo.broadcast`
+apart and found they'd already solved this exact problem, twice, the same
+way: a process-wide singleton, installed once by an `init_X(project_root,
+config)` call at startup, read anywhere after with a no-arg `get_X()`. `fymo
+jobs-worker` — a separate OS process from the web server — already calls
+both `init_job_provider()` and `init_broadcasts()` at its own startup for
+exactly this reason: it needs the same providers the web process has,
+without carrying a socket or a shared-memory segment between them.
+
+A `get_storage_provider(project_root)` that rebuilds from `fymo.yml` on
+every call would work today. It would also mean re-parsing YAML and
+reconstructing the provider on every single call site, which is fine for
+`LocalStorageProvider` and a real cost the moment #17 lands and a provider
+is holding an S3 client. And it would be the third storage-shaped thing in
+this codebase that doesn't match how the other two work. I went with the
+singleton instead — same shape as jobs and broadcasts, `set_/get_/init_/
+reset_storage_provider()` in `fymo/storage/__init__.py` — and wrote the
+deviation from the issue's own sketch down explicitly rather than quietly
+picking one, since it's the kind of call someone reading the PR later
+should be able to see was made on purpose.
+
+## The One Place It Can't Mirror the Pattern
+
+`get_job_provider()` and `get_broadcast_provider()` both fall back to a
+working default if nothing initialized them — an unconfigured
+`ThreadedJobProvider`, a default `PostgresBroadcastProvider`. That's the
+right call for those two. It is very much not the right call for storage.
+`build_storage_provider` has refused a default since the day it was
+written, on purpose: silently writing to local disk is the kind of thing
+that works fine on a laptop and quietly loses every uploaded file the
+moment the app runs behind a load balancer with more than one instance.
+Copying the "fall back to a default" half of the jobs/broadcasts pattern
+here would have undone that guarantee for the sake of API symmetry, which
+is a bad trade. `get_storage_provider()` raises a clear error instead,
+naming the fix, if nothing has called `init_storage_provider()` yet. Same
+shape as the other two singletons everywhere except the one line where
+being the same shape would have been a regression.
+
+## Decoupling Storage From Media
+
+The bigger structural change was inside `FymoApp.__init__` itself. Storage
+only ever got constructed inside the `if media_config:` branch, which made
+sense back when the only consumer of a `StorageProvider` was the media-route
+handler. It stopped making sense the moment a job wanted one too, since
+plenty of real apps will want write access to storage without wanting a
+single declarative `media:` route. So `FymoApp` now builds storage whenever
+`storage:` is configured, full stop, and hands that one instance to both
+`self.storage_provider` and to `build_media_routes` if `media:` also
+happens to be configured. Before this, a hypothetical app with both `media:`
+and `storage:` set would already build one provider for the media routes;
+after this, that's still exactly one provider, just reachable from
+everywhere instead of sealed inside the media-routes branch. Checked for
+that specifically — `get_storage_provider() is app.storage_provider` is one
+of the assertions — because the alternative bug (two providers, one for
+media routes and a second one built separately for the singleton) would
+have been invisible until someone hit a real backend where constructing a
+client twice actually costs something.
+
+`fymo jobs-worker` got the matching change: one more `init_storage_provider`
+call, sitting right next to the `init_broadcasts` call it already makes,
+gated the same way — only if `storage:` is actually configured, no default
+invented for the worker process either.
+
+## Writing Down a Pattern Before It's Needed
+
+The issue flagged something worth catching before #17 (S3/R2 providers)
+lands: `write(key, data)` takes a complete `bytes` payload. There's no
+append, no stream. A live Playwright recording can't call `write()` until
+it's finished, because there's nothing to write yet. The pattern is record
+to a scratch path on local disk, then read the whole thing back and call
+`write()` once — and that's not a workaround for local storage's
+limitations, it's the actual shape the API will keep once storage is S3 or
+R2 too, since neither of those offers "keep appending to this key" either.
+Put that directly in `fymo/storage/__init__.py`'s module docstring, next to
+`get_storage_provider` itself, on the theory that documentation nobody
+reads on the way to using the thing might as well not exist.
+
+## Proving It
+
+TDD start to finish — wrote the singleton tests first and watched them fail
+on a plain `ImportError` before `get_storage_provider` existed, then the
+`FymoApp` integration tests, which I stashed the server.py change to
+confirm actually failed for the reason I expected (an `AttributeError` on
+`app.storage_provider`, then a `RuntimeError` from the un-primed singleton)
+before unstashing it. Full suite: 776 passed, 10 skipped, all ten skips
+needing a real Postgres instance the test environment doesn't have, nothing
+to do with this change. And because a green test suite isn't the same as a
+working feature, I built a real todo-app fixture, called `create_app` with
+only a `storage:` section and no `media:` at all, and wrote a file through
+`get_storage_provider()` from outside `FymoApp` entirely — the exact shape
+of thing the original job would have wanted to do, minus the hand-rolled
+YAML parsing.
+
+---
+
+*End of Journal Entry 013*

--- a/tests/cli/test_jobs_worker.py
+++ b/tests/cli/test_jobs_worker.py
@@ -7,13 +7,16 @@ import pytest
 import fymo.core.logging as fymo_logging
 from fymo.cli.commands.jobs_worker import run_jobs_worker
 from fymo.jobs import reset_job_provider
+from fymo.storage import reset_storage_provider
 
 
 @pytest.fixture(autouse=True)
 def _reset():
     reset_job_provider()
+    reset_storage_provider()
     yield
     reset_job_provider()
+    reset_storage_provider()
 
 
 @pytest.fixture(autouse=True)
@@ -74,3 +77,32 @@ def test_jobs_worker_configures_logging_from_yml(tmp_path, monkeypatch):
         run_jobs_worker(tmp_path)
     assert fymo_logging._installed_handler is not None
     assert isinstance(fymo_logging._installed_handler, logging.FileHandler)
+
+
+def test_jobs_worker_initializes_storage_when_configured(tmp_path: Path):
+    """Issue #31: a job running in the worker process (a separate OS process
+    from the web process) needs fymo.storage.get_storage_provider() to work
+    too, the same way it already needs init_broadcasts() to make publish()
+    work here. The default threaded provider still exits with SystemExit(1)
+    (no separate worker loop), but storage must be wired up before that."""
+    (tmp_path / "fymo.yml").write_text("storage:\n  provider: local\n")
+
+    with pytest.raises(SystemExit):
+        run_jobs_worker(tmp_path)
+
+    from fymo.storage import get_storage_provider
+    from fymo.storage.providers.local import LocalStorageProvider
+
+    assert isinstance(get_storage_provider(), LocalStorageProvider)
+
+
+def test_jobs_worker_leaves_storage_uninitialized_when_not_configured(tmp_path: Path):
+    """No storage: section => no default provider (same guarantee as
+    FymoApp itself); get_storage_provider() must still raise."""
+    with pytest.raises(SystemExit):
+        run_jobs_worker(tmp_path)
+
+    from fymo.storage import get_storage_provider
+
+    with pytest.raises(RuntimeError, match="storage is not initialized"):
+        get_storage_provider()

--- a/tests/core/test_app_http_routes.py
+++ b/tests/core/test_app_http_routes.py
@@ -243,3 +243,80 @@ def test_fymo_app_raises_when_media_configured_without_storage(example_app: Path
                 {"prefix": "/media/videos/", "dir": "data/videos", "extensions": ["webm"]},
             ],
         })
+
+
+@pytest.mark.usefixtures("node_available")
+def test_fymo_app_registers_storage_provider_without_media_configured(example_app: Path, monkeypatch):
+    """Issue #31: app code (a job) needs the configured StorageProvider even
+    when the app never declares `media:` routes. storage: alone must be
+    enough to make fymo.storage.get_storage_provider() usable."""
+    monkeypatch.setenv("FYMO_SECRET", "test-secret-please-do-not-use-in-prod-32b!")
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=example_app).build(dev=False)
+
+    from fymo import create_app
+    from fymo.storage import get_storage_provider, reset_storage_provider
+    from fymo.storage.providers.local import LocalStorageProvider
+
+    reset_storage_provider()
+    app = create_app(example_app, config={"storage": {"provider": "local"}})
+    try:
+        assert isinstance(app.storage_provider, LocalStorageProvider)
+        assert get_storage_provider() is app.storage_provider
+    finally:
+        app.shutdown()
+        reset_storage_provider()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_fymo_app_media_routes_reuse_the_process_wide_storage_provider(example_app: Path, monkeypatch):
+    """The instance FymoApp hands to build_media_routes must be the exact
+    same object fymo.storage.get_storage_provider() returns elsewhere in the
+    process, not a second provider built separately, since a real provider
+    (an S3 client, once #17 lands) shouldn't be constructed twice per app."""
+    monkeypatch.setenv("FYMO_SECRET", "test-secret-please-do-not-use-in-prod-32b!")
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=example_app).build(dev=False)
+
+    video_dir = example_app / "data" / "videos"
+    video_dir.mkdir(parents=True)
+    (video_dir / "clip.webm").write_bytes(b"video-bytes")
+
+    from fymo import create_app
+    from fymo.storage import get_storage_provider, reset_storage_provider
+
+    reset_storage_provider()
+    app = create_app(example_app, config={
+        "media": [
+            {"prefix": "/media/videos/", "dir": "data/videos", "extensions": ["webm"]},
+        ],
+        "storage": {"provider": "local"},
+    })
+    try:
+        assert get_storage_provider() is app.storage_provider
+    finally:
+        app.shutdown()
+        reset_storage_provider()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_fymo_app_leaves_storage_uninitialized_when_not_configured(example_app: Path, monkeypatch):
+    """No storage: section at all (and no media: to require one) must not
+    silently register a default provider — get_storage_provider() should
+    still raise, matching build_storage_provider's no-default guarantee."""
+    monkeypatch.setenv("FYMO_SECRET", "test-secret-please-do-not-use-in-prod-32b!")
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=example_app).build(dev=False)
+
+    from fymo import create_app
+    from fymo.storage import get_storage_provider, reset_storage_provider
+
+    reset_storage_provider()
+    app = create_app(example_app)
+    try:
+        assert app.storage_provider is None
+        with pytest.raises(RuntimeError, match="storage is not initialized"):
+            get_storage_provider()
+    finally:
+        app.shutdown()
+        reset_storage_provider()

--- a/tests/storage/test_provider_singleton.py
+++ b/tests/storage/test_provider_singleton.py
@@ -1,0 +1,63 @@
+"""Tests for the process-wide StorageProvider singleton and its config-driven
+init helper (issue #31) — mirrors fymo.jobs's get_job_provider()/
+init_job_provider() tests (tests/jobs/test_provider_singleton.py), with the
+one deliberate difference: storage has no default provider, so
+get_storage_provider() raises instead of silently constructing one when
+nothing has called init_storage_provider() yet."""
+from pathlib import Path
+
+import pytest
+
+from fymo.storage import (
+    get_storage_provider,
+    init_storage_provider,
+    reset_storage_provider,
+    set_storage_provider,
+)
+from fymo.storage.providers.local import LocalStorageProvider
+from fymo.storage.registry import StorageConfigError
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_storage_provider()
+    yield
+    reset_storage_provider()
+
+
+def test_get_storage_provider_raises_before_init():
+    with pytest.raises(RuntimeError, match="storage is not initialized"):
+        get_storage_provider()
+
+
+def test_init_storage_provider_builds_and_registers_singleton(tmp_path: Path):
+    provider = init_storage_provider(tmp_path, {"provider": "local"})
+
+    assert isinstance(provider, LocalStorageProvider)
+    assert get_storage_provider() is provider
+
+
+def test_get_storage_provider_is_a_process_wide_singleton(tmp_path: Path):
+    init_storage_provider(tmp_path, {"provider": "local"})
+    assert get_storage_provider() is get_storage_provider()
+
+
+def test_set_storage_provider_overrides(tmp_path: Path):
+    init_storage_provider(tmp_path, {"provider": "local"})
+    custom = LocalStorageProvider(project_root=tmp_path, root="elsewhere")
+    set_storage_provider(custom)
+    assert get_storage_provider() is custom
+
+
+def test_init_storage_provider_with_no_config_raises_no_default(tmp_path: Path):
+    with pytest.raises(StorageConfigError, match="no default provider"):
+        init_storage_provider(tmp_path, None)
+    with pytest.raises(RuntimeError, match="storage is not initialized"):
+        get_storage_provider()
+
+
+def test_reset_storage_provider_clears_the_singleton(tmp_path: Path):
+    init_storage_provider(tmp_path, {"provider": "local"})
+    reset_storage_provider()
+    with pytest.raises(RuntimeError, match="storage is not initialized"):
+        get_storage_provider()


### PR DESCRIPTION
## Summary

- Closes #31. App code (a job, a remote function) had no supported way to reach the `StorageProvider` `FymoApp` builds internally, only the media-route handler could get to it, and only when `media:` was configured. A real video-recording job worked around this by importing `fymo.build.prepare.read_yaml_section` (explicitly build-time only per its own docstring) and reimplementing the dir-resolution logic by hand.
- Adds `get_storage_provider()` / `init_storage_provider()` / `set_storage_provider()` / `reset_storage_provider()` to `fymo/storage/__init__.py`, a process-wide singleton mirroring the existing `fymo.jobs`/`fymo.broadcast` provider pattern. This deviates from the issue's own `get_storage_provider(project_root)` sketch on purpose (documented in the commit and journal): a no-arg singleton avoids re-parsing `fymo.yml` and rebuilding the provider on every call, and matches the worker-process pattern `fymo jobs-worker` already uses for jobs/broadcasts.
- One deliberate difference from the jobs/broadcasts pattern: storage has no default provider (silently falling back to local disk is the footgun `build_storage_provider` already refuses to allow), so `get_storage_provider()` raises a clear error instead of a silent default when nothing has initialized it yet.
- `FymoApp.__init__` now builds storage whenever `storage:` is configured, not only when `media:` is also configured, and media routes reuse that one instance instead of a second provider being built separately.
- `fymo jobs-worker` gets the matching `init_storage_provider()` call it already makes for `init_broadcasts()`, so a job in the separate worker process can use `get_storage_provider()` too.
- Documents the "record to a scratch path, then `write()` the finished bytes" pattern (relevant to #17) directly in `fymo/storage`'s module docstring, since `write()` takes a complete payload and can't be streamed into.

## Test plan

- [x] TDD throughout: each new behavior watched failing for the right reason first (including stashing the `server.py` change to confirm the `FymoApp` integration tests failed correctly before reapplying it).
- [x] `uv run pytest -q` — full suite green, 776 passed, 10 skipped (all pre-existing Postgres-only tests unrelated to this change).
- [x] Real end-to-end check: built the `todo_app` example, constructed `FymoApp` with only `storage:` configured (no `media:`), and wrote/read a file through `get_storage_provider()` from outside `FymoApp` entirely, confirming the same instance FymoApp built is reachable process-wide.
- [x] Independent review pass against the diff (correctness, singleton locking consistency with `fymo.jobs`/`fymo.broadcast`, test coverage for all four `FymoApp` startup combinations, no stray double-construction of the provider) — no issues found.