### PR TITLE
Fail the build when @require_auth ships with zero active auth providers

### DIFF
--- a/fymo/auth/context.py
+++ b/fymo/auth/context.py
@@ -179,6 +179,13 @@ def require_auth(fn: F) -> F:
         if current_user() is None:
             raise AuthRequired()
         return fn(*args, **kwargs)
+    # Marker attribute, same pattern as fymo.remote.decorators.remote's
+    # __fymo_remote__. Lets build-time checks (see fymo.build.hygiene's
+    # check_auth_enforcement_hygiene) find every @require_auth site without
+    # re-deriving the answer from runtime behavior. functools.wraps already
+    # copied fn.__dict__ onto wrapper, so this must be set after that call
+    # to survive regardless of decorator stacking order with @remote.
+    wrapper.__fymo_require_auth__ = True
     return wrapper  # type: ignore[return-value]
 
 

--- a/fymo/build/hygiene.py
+++ b/fymo/build/hygiene.py
@@ -180,3 +180,95 @@ def format_remote_exposure_error(violations: List[str]) -> str:
         "underscore to keep it a private helper. To silence this check without fixing "
         "it (unsafe, temporary), set remote.allow_implicit: true in fymo.yml."
     )
+
+
+def check_auth_enforcement_hygiene(project_root: Path, auth_config: "dict | None") -> List[str]:
+    """Return one violation per app/remote/*.py function decorated with
+    @require_auth for which nobody could ever actually authenticate (issue
+    #29). require_auth itself fails closed correctly: no session means 401,
+    every time, regardless of why there's no session. The gap is upstream of
+    that. Nothing stops an app from shipping @require_auth while auth.enabled
+    is false, or while every configured provider has declined via
+    `required: auto` (its is_configured() classmethod returned False, see
+    fymo/auth/providers/base.py). Either way, the endpoint can never
+    authenticate anyone, and a real app was found papering over exactly
+    that: a hand-rolled wrapper that treated "auth isn't configured" as
+    "must be local dev" and quietly skipped the check instead.
+
+    Note this only catches providers that actually implement is_configured()
+    (custom providers are the common case today, see docs/deployment.md's
+    `required: auto` section). BaseProvider.is_configured() defaults to
+    True, and none of the built-in google/oidc/clerk providers override it
+    yet, so a built-in provider with a missing client-id/secret env var
+    still constructs (with blank credentials) and counts as active here,
+    even though it can't actually authenticate anyone at runtime. That gap
+    lives in the providers themselves, not this check.
+
+    Scans for the __fymo_require_auth__ marker fymo.auth.context.require_auth
+    stamps on its wrapper, the same way check_remote_exposure_hygiene scans
+    for __fymo_remote__. Returns [] immediately when nothing is marked, so
+    apps that don't use @require_auth pay no cost and see no noise regardless
+    of their auth config.
+    """
+    remote_dir = project_root / "app" / "remote"
+    if not remote_dir.is_dir():
+        return []
+
+    from fymo.remote.discovery import _ensure_parent_packages
+
+    guarded_sites: List[str] = []
+    project_root_str = str(project_root)
+    added = project_root_str not in sys.path
+    if added:
+        sys.path.insert(0, project_root_str)
+    try:
+        _ensure_parent_packages(project_root)
+        for py in sorted(remote_dir.glob("*.py")):
+            if py.name == "__init__.py" or py.stem.startswith("_"):
+                continue
+            module_name = py.stem
+            full = f"app.remote.{module_name}"
+            if full in sys.modules:
+                mod = importlib.reload(sys.modules[full])
+            else:
+                mod = importlib.import_module(full)
+            for name, obj in vars(mod).items():
+                if name.startswith("_"):
+                    continue
+                if getattr(obj, "__fymo_require_auth__", False):
+                    guarded_sites.append(f"{py.relative_to(project_root)}: {name}")
+    finally:
+        if added and project_root_str in sys.path:
+            sys.path.remove(project_root_str)
+
+    if not guarded_sites:
+        return []
+
+    auth_config = auth_config or {}
+    if not auth_config.get("enabled"):
+        return [f"{site} is decorated with @require_auth but auth.enabled is not true in fymo.yml"
+                for site in guarded_sites]
+
+    from fymo.auth.providers.registry import build_providers
+
+    providers = build_providers(auth_config.get("providers"))
+    if not providers:
+        return [
+            f"{site} is decorated with @require_auth but auth.providers resolves to "
+            "zero active providers (every entry with required: auto declined)"
+            for site in guarded_sites
+        ]
+
+    return []
+
+
+def format_auth_enforcement_error(violations: List[str]) -> str:
+    bullet_list = "\n".join(f"  - {v}" for v in violations)
+    return (
+        "@require_auth site(s) that nobody can ever authenticate against:\n" + bullet_list +
+        "\n\nWith auth off or zero active providers, these endpoints either stay "
+        "permanently unreachable or (more dangerously) invite app code to route "
+        "around @require_auth instead of fixing the underlying config. Enable "
+        "auth.enabled and configure at least one provider in fymo.yml, or remove "
+        "@require_auth from the function(s) above if the guard is no longer needed."
+    )

--- a/fymo/build/prepare.py
+++ b/fymo/build/prepare.py
@@ -24,10 +24,12 @@ from fymo.build.composition_generator import generate_ssr_tree
 from fymo.build.discovery import discover_routes, discover_all_layouts
 from fymo.build.entry_generator import write_client_entries
 from fymo.build.hygiene import (
+    check_auth_enforcement_hygiene,
     check_directory_hygiene,
     check_lib_directory_warnings,
     check_remote_exposure_hygiene,
     check_storage_required_for_media,
+    format_auth_enforcement_error,
     format_hygiene_error,
     format_remote_exposure_error,
 )
@@ -128,6 +130,20 @@ def prepare_build_config(project_root: Path, dist_dir: Path, cache_dir: Path, de
     if storage_violations:
         raise BuildError("\n".join(storage_violations))
 
+    # Same `auth:` section discover_remote_modules reads below, read once
+    # here too so both calls agree on it.
+    auth_config = read_yaml_section(project_root, "auth")
+
+    # Build-only, same as the "no routes" check further down (issue #29):
+    # @require_auth shipped with auth off or zero active providers means
+    # nobody can ever authenticate against that endpoint, but during `fymo
+    # dev` an app is routinely mid-setup (auth not wired up yet), so this
+    # only fails a real `fymo build`, not local dev.
+    if not dev:
+        auth_enforcement_violations = check_auth_enforcement_hygiene(project_root, auth_config)
+        if auth_enforcement_violations:
+            raise BuildError(format_auth_enforcement_error(auth_enforcement_violations))
+
     if shutil.which("node") is None:
         raise BuildError("node not found on PATH" if dev else "node executable not found on PATH")
 
@@ -166,7 +182,7 @@ def prepare_build_config(project_root: Path, dist_dir: Path, cache_dir: Path, de
         # normal manifest -- discovered from the providers, not hardcoded.
         remote_modules = discover_remote_modules(
             project_root,
-            auth_config=read_yaml_section(project_root, "auth"),
+            auth_config=auth_config,
             remote_config=remote_config,
         )
     except ValueError as e:

--- a/journal/journal_013.md
+++ b/journal/journal_013.md
@@ -1,0 +1,125 @@
+# Journal Entry 013: The Decorator That Was Telling the Truth
+
+**Date**: July 15, 2026
+**Focus**: Closing the gap between "require_auth works correctly" and "require_auth actually protects anything"
+**Status**: Shipped
+
+## A Bug Report About Code That Isn't Wrong
+
+This one started strange. The issue wasn't "require_auth is broken." It was
+the opposite: require_auth is correct. No session means 401, every time,
+no matter why there's no session. Someone had gone looking for a bug in it
+and hadn't found one, because there isn't one.
+
+What they'd found instead, on a real app, was a hand-rolled wrapper around
+require_auth. The app's own code, not fymo's. It checked whether the right
+env vars were present before deciding whether to enforce auth at all, and
+if they weren't, it fell through to a no-op. The intent was reasonable on
+its face: let local dev run without wiring up a real auth provider first.
+But the check it used to decide "is this local dev" was "are the env vars
+set", and a prod box that simply forgot to set one env var looks
+identical, from inside that check, to a laptop that never got them in the
+first place. Every mutation behind that wrapper went unauthenticated, and
+nothing anywhere said so.
+
+I can't fix code that lives in someone else's app. What I can do is make
+sure the framework itself would have caught the underlying condition that
+made the app-level shortcut tempting in the first place: shipping
+@require_auth with no way for anyone to actually get a session.
+
+## The Precedent Question
+
+The issue left a real decision open: should this be an opt-in check, the
+way #8's remote-exposure enforcement started, or on by default, the way
+#16's storage check is. I went back and reread both.
+
+#8 needed the gradual opt-in because implicit remote exposure was the
+existing, deliberate default — every app already relied on it, and turning
+it into a hard failure overnight would have broken working code doing
+exactly what it was supposed to do. #16 has no such excuse: media
+configured with no storage section has never been a valid app shape, so it
+just fails the build, no flag, no escape hatch.
+
+@require_auth with zero active providers is the second kind of problem,
+not the first. There's no app where that combination is intentional — it's
+either dead code that will 401 forever, or it's inviting exactly the kind
+of app-side workaround that filed this issue. So I built it unconditional,
+same as storage, and said so directly in the code rather than leaving the
+decision implicit. The one thing I did carry over from precedent was
+gating on `dev`: `fymo build` fails, `fymo dev` doesn't, matching the
+existing "zero routes" check, because an app mid-setup locally with auth
+not wired up yet is a completely normal state that shouldn't block
+iteration.
+
+## Making require_auth Say What It Is
+
+The check needed a reliable way to find every @require_auth site without
+re-deriving the answer by calling functions and checking status codes.
+fymo already had exactly this pattern for a different decorator — `@remote`
+stamps `__fymo_remote__ = True` on the function object it's given, and the
+build-time exposure check just looks for that attribute. I did the same
+thing to require_auth: its wrapper now carries `__fymo_require_auth__ =
+True`, set after `functools.wraps` runs so it survives regardless of
+whether `@remote` sits above or below it in the stack. Wrote the stacking-
+order tests before the implementation, watched them fail because the
+attribute didn't exist yet, then added the one line that made them pass.
+
+From there the check itself is a straight copy of the shape
+check_remote_exposure_hygiene already established: walk app/remote/*.py,
+import each module, look for the marker, and if anything's marked, decide
+whether auth.enabled is actually true and whether the configured providers
+resolve to anything. Zero providers or auth off, and the build fails
+naming the exact file and function.
+
+## Proving It For Real
+
+Unit tests passing wasn't enough for something framed as closing a
+security gap. I scaffolded a throwaway app off todo_app, gave it a
+`@require_auth` function with no auth config, and ran the actual `fymo
+build` binary against it. It failed with the message I'd written, pointing
+at the exact function. Added `auth: {enabled: true}` — nothing else, just
+that one line, letting the default password provider kick in — and ran it
+again. Clean build. That's the whole point of the check: the fix for the
+misconfiguration is one line in fymo.yml, and now the build tells you
+that instead of staying quiet.
+
+## What Review Caught
+
+I asked for an independent pass before calling this done, same as every
+issue before it, and it earned its keep. My check's own docstring claimed
+it would catch a provider "declining via required: auto (e.g. its env var
+was never set in prod)" — which is literally the scenario from the issue.
+But I'd only tested that against a custom provider class that overrides
+`is_configured()`. The reviewer went and checked the built-in providers —
+google, oidc, clerk — and none of them override it. `BaseProvider`
+defaults `is_configured()` to True, and the OAuth providers read their
+client id and secret via `os.environ.get(key, "")`, silently falling back
+to an empty string rather than declining. So a real app that reached for
+`type: google, required: auto` expecting exactly the protection this issue
+asked for would get a provider that "counts" as active while being
+completely unable to authenticate anyone.
+
+That's not a bug in what I shipped — required: auto already worked exactly
+as documented, and I didn't touch oauth.py or clerk.py. But my check's own
+comments were overselling what it actually covers, and that's a real
+problem in code whose whole job is to be trusted at face value. Fixed the
+wording to say precisely what's true today: it catches providers that
+implement is_configured(), which right now means custom provider
+subclasses, not the built-in OAuth ones. Giving the built-in providers a
+real is_configured() is worth doing, but it's a change to the provider
+layer, not to a build-time check, and bundling it in here would have meant
+shipping a bigger, less reviewable diff for a problem that deserves its
+own attention. Left a clear note about it instead of quietly letting the
+gap ride on optimistic docstring language.
+
+## The Count
+
+780 passing, 10 skipped, zero failed with node available for the example-app
+fixtures; the same suite clean at 681/109 without it. Six files touched,
+under 400 lines, and the real proof wasn't the test count — it was running
+the actual CLI against a broken app and watching it refuse to build, then
+watching one line of config fix it.
+
+---
+
+*End of Journal Entry 013*

--- a/tests/auth/test_context.py
+++ b/tests/auth/test_context.py
@@ -1,0 +1,50 @@
+"""Unit tests for fymo.auth.context's require_auth marker attribute.
+
+Issue #29's build-time check needs a way to tell whether a given app/remote
+function is guarded by @require_auth without re-deriving the answer from
+behavior (calling it and checking for a 401). The marker mirrors the
+__fymo_remote__ pattern fymo/remote/decorators.py already uses for @remote.
+"""
+from fymo.auth.context import require_auth
+from fymo.remote.decorators import remote
+
+
+def test_require_auth_stamps_marker_attribute():
+    @require_auth
+    def guarded() -> str:
+        return "ok"
+
+    assert getattr(guarded, "__fymo_require_auth__", False) is True
+
+
+def test_plain_function_has_no_marker():
+    def unguarded() -> str:
+        return "ok"
+
+    assert getattr(unguarded, "__fymo_require_auth__", False) is False
+
+
+def test_marker_survives_remote_decorator_applied_above_require_auth():
+    """@remote sits outside, @require_auth inside: remote() stamps and
+    returns the require_auth wrapper unchanged, so the marker must still
+    be there."""
+    @remote
+    @require_auth
+    def guarded() -> str:
+        return "ok"
+
+    assert getattr(guarded, "__fymo_require_auth__", False) is True
+    assert getattr(guarded, "__fymo_remote__", False) is True
+
+
+def test_marker_survives_remote_decorator_applied_below_require_auth():
+    """@require_auth sits outside, @remote inside: functools.wraps copies
+    the inner function's __dict__ (which already has __fymo_remote__ from
+    @remote) onto the wrapper, so both markers must survive here too."""
+    @require_auth
+    @remote
+    def guarded() -> str:
+        return "ok"
+
+    assert getattr(guarded, "__fymo_require_auth__", False) is True
+    assert getattr(guarded, "__fymo_remote__", False) is True

--- a/tests/build/test_auth_enforcement_hygiene.py
+++ b/tests/build/test_auth_enforcement_hygiene.py
@@ -1,0 +1,174 @@
+"""Build-time enforcement that @require_auth is actually enforceable (issue #29).
+
+require_auth itself fails closed correctly: no session means 401, always. The
+gap is upstream of that -- nothing stops an app from decorating a remote
+function with @require_auth while auth is disabled entirely, or while every
+configured provider has declined (required: auto with a missing env var). In
+either state nobody can ever authenticate, so the endpoint is either
+permanently dead or, in the real case that filed this issue, some app-level
+wrapper treats "auth isn't configured" as "must be local dev" and silently
+skips the check instead. check_auth_enforcement_hygiene closes the build-time
+half of that gap: any @require_auth site plus zero active providers fails the
+build, naming the site.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+from fymo.build.hygiene import check_auth_enforcement_hygiene, format_auth_enforcement_error
+
+
+def _scaffold(tmp_path: Path, files: dict[str, str]) -> Path:
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return tmp_path
+
+
+def _cleanup_app_modules() -> None:
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    _cleanup_app_modules()
+
+
+GUARDED_FN = (
+    "from fymo.auth import require_auth\n"
+    "@require_auth\n"
+    "def create_comment(body: str) -> str: return body\n"
+)
+
+UNGUARDED_FN = (
+    "def get_posts() -> list: return []\n"
+)
+
+
+def test_no_app_remote_dir_has_no_violations(tmp_path: Path):
+    assert check_auth_enforcement_hygiene(tmp_path, {}) == []
+
+
+def test_no_require_auth_usage_has_no_violations_regardless_of_auth_config(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": UNGUARDED_FN,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        assert check_auth_enforcement_hygiene(project, {}) == []
+        assert check_auth_enforcement_hygiene(project, {"enabled": False}) == []
+    finally:
+        sys.path.remove(str(project))
+
+
+def test_require_auth_with_auth_not_enabled_is_a_violation(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": GUARDED_FN,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_auth_enforcement_hygiene(project, {})
+    finally:
+        sys.path.remove(str(project))
+
+    assert len(violations) == 1
+    assert "app/remote/posts.py" in violations[0]
+    assert "create_comment" in violations[0]
+
+
+def test_require_auth_with_auth_enabled_and_zero_providers_is_a_violation(tmp_path: Path):
+    """required: auto on the only configured provider, declined because its
+    env var isn't set -- resolves to an empty provider list at build time,
+    the exact real-world shape from the issue."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": GUARDED_FN,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        auth_config = {
+            "enabled": True,
+            "providers": [{
+                "class": "tests.auth.test_providers.AlwaysUnconfiguredProvider",
+                "required": "auto",
+            }],
+        }
+        violations = check_auth_enforcement_hygiene(project, auth_config)
+    finally:
+        sys.path.remove(str(project))
+
+    assert len(violations) == 1
+    assert "create_comment" in violations[0]
+
+
+def test_require_auth_with_auth_enabled_and_a_real_provider_has_no_violations(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": GUARDED_FN,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_auth_enforcement_hygiene(project, {"enabled": True})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_require_auth_defaults_to_password_provider_when_providers_unset(tmp_path: Path):
+    """build_providers([]) defaults to [PasswordProvider()] -- auth.enabled
+    true with no providers: key at all must resolve the same way here."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": GUARDED_FN,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_auth_enforcement_hygiene(project, {"enabled": True, "providers": []})
+    finally:
+        sys.path.remove(str(project))
+
+    assert violations == []
+
+
+def test_multiple_guarded_functions_across_modules_all_reported(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": GUARDED_FN,
+        "app/remote/likes.py": (
+            "from fymo.auth import require_auth\n"
+            "@require_auth\n"
+            "def add_like(slug: str) -> str: return slug\n"
+        ),
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_auth_enforcement_hygiene(project, {})
+    finally:
+        sys.path.remove(str(project))
+
+    assert len(violations) == 2
+    joined = "\n".join(violations)
+    assert "create_comment" in joined
+    assert "add_like" in joined
+
+
+def test_format_auth_enforcement_error_names_the_sites():
+    msg = format_auth_enforcement_error([
+        "app/remote/posts.py: create_comment requires auth.enabled but auth is off"
+    ])
+    assert "create_comment" in msg
+    assert "app/remote/posts.py" in msg

--- a/tests/build/test_prepare.py
+++ b/tests/build/test_prepare.py
@@ -101,6 +101,55 @@ def test_read_yaml_section_returns_requested_key(tmp_path: Path):
     assert read_yaml_section(tmp_path, "missing") == {}
 
 
+_REQUIRE_AUTH_MODULE = (
+    "from fymo.auth import require_auth\n"
+    "from fymo.remote import remote\n"
+    "@remote\n"
+    "@require_auth\n"
+    "def create_comment(body: str) -> str: return body\n"
+)
+
+
+def test_require_auth_with_no_active_providers_raises_build_error(example_app: Path):
+    """Issue #29: @require_auth shipped with auth off entirely must fail
+    `fymo build`, naming the site, before node/esbuild runs. @remote here
+    keeps the function clear of the unrelated #8 exposure check, isolating
+    this test to the auth-enforcement failure."""
+    (example_app / "app" / "remote").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "remote" / "__init__.py").write_text("")
+    (example_app / "app" / "remote" / "comments.py").write_text(_REQUIRE_AUTH_MODULE)
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    with pytest.raises(BuildError, match="auth.enabled is not true"):
+        prepare_build_config(example_app, dist_dir, cache_dir, dev=False)
+
+
+def test_require_auth_with_no_active_providers_does_not_fail_dev(example_app: Path, monkeypatch):
+    """Same misconfiguration, but `fymo dev`: an app is routinely mid-setup
+    locally (auth not wired up yet), so this check is build-only, matching
+    the "no routes" check's existing dev-mode exemption."""
+    (example_app / "app" / "remote").mkdir(parents=True, exist_ok=True)
+    (example_app / "app" / "remote" / "__init__.py").write_text("")
+    (example_app / "app" / "remote" / "comments.py").write_text(_REQUIRE_AUTH_MODULE)
+    monkeypatch.setattr("fymo.build.prepare.shutil.which", lambda cmd: "/usr/bin/node")
+    dist_dir = example_app / "dist"
+    cache_dir = example_app / ".fymo" / "entries"
+    config = prepare_build_config(example_app, dist_dir, cache_dir, dev=True)
+    assert isinstance(config, BuildConfig)
+
+
+@pytest.mark.usefixtures("node_available")
+def test_blog_app_require_auth_with_password_provider_builds_clean(blog_app: Path):
+    """Regression check, not just a new-code assumption: blog_app already
+    has auth.enabled true, the default password provider, and a real
+    @require_auth site in app/remote/posts.py (create_comment). That's
+    exactly the shape check_auth_enforcement_hygiene must let through."""
+    dist_dir = blog_app / "dist"
+    cache_dir = blog_app / ".fymo" / "entries"
+    config = prepare_build_config(blog_app, dist_dir, cache_dir, dev=False)
+    assert isinstance(config, BuildConfig)
+
+
 def test_unmarked_remote_function_raises_build_error(example_app: Path):
     """Issue #8: with explicit_optin left at its default (false) and no
     allow_implicit escape hatch, an unmarked app/remote/*.py function must


### PR DESCRIPTION
## Summary

require_auth already fails closed correctly (no session means 401, always, regardless of why), but nothing stopped an app from shipping @require_auth on a remote function while auth.enabled is false or every configured provider has declined via required: auto. In that state nobody can ever authenticate against the endpoint. A real app was found papering over exactly that with a hand-rolled wrapper that treated "auth isn't configured" as "must be local dev" and silently skipped the check, which is how a prod deploy that simply forgot to set an env var ended up shipping unauthenticated mutations.

Closes #29. Related to #7, #8, #16.

- `fymo/auth/context.py`: `require_auth` now stamps `__fymo_require_auth__ = True` on its wrapper, mirroring the existing `__fymo_remote__` marker `@remote` uses.
- `fymo/build/hygiene.py`: new `check_auth_enforcement_hygiene`, same shape as the existing remote-exposure and storage hygiene checks. Scans app/remote/*.py for the marker and fails naming every site where auth is off or resolves to zero active providers.
- `fymo/build/prepare.py`: wired into `prepare_build_config`, gated on `not dev` (same precedent as the existing "zero routes" check), so `fymo dev` stays unaffected while an app is mid-setup.

**Design decision** (left open in the issue, made and documented here): no opt-in flag, on by default. Modeled on #16's storage check rather than #8's gradual remote-exposure opt-in, since unlike implicit remote exposure, there's no legitimate app shape where @require_auth with zero active providers is intentional.

**Review note**: an independent pass caught that the check's docstring/error message implied `required: auto` catches "missing env var in prod" generically. In fact `BaseProvider.is_configured()` defaults to True and none of the built-in google/oidc/clerk providers override it (pre-existing behavior, not touched by this PR), so that scenario is only actually caught for custom provider subclasses today. Docstring/comments were corrected to state precisely what's covered rather than oversell it.

## Test plan

- [x] New unit tests for the `__fymo_require_auth__` marker, including both `@remote`/`@require_auth` stacking orders
- [x] New unit tests for `check_auth_enforcement_hygiene` covering: no violation with no app/remote dir, auth off, zero active providers, a real active provider, default password provider, multiple sites across modules
- [x] New `prepare_build_config` integration tests: raises `BuildError` naming the site under `dev=False`, does not fail under `dev=True`, and the blog_app fixture (auth enabled, real @require_auth usage) still builds clean, a regression check
- [x] Full existing suite green (780 passed / 10 skipped with node available, 0 failed)
- [x] Real end-to-end check: ran the actual `fymo` CLI against a scaffolded app with `@require_auth` and no auth config, confirmed it fails the build naming the function, then confirmed it builds clean after adding `auth: {enabled: true}` to fymo.yml