### PR TITLE
ClerkProvider: derive issuer/jwks_url from env, implement is_configured()

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -205,9 +205,13 @@ force a custom Python class just to read `os.environ`:
 ```yaml
 auth:
   providers:
-    - class: fymo.auth.providers.clerk.ClerkProvider
-      issuer: ${CLERK_ISSUER}
-      jwks_url: ${CLERK_JWKS_URL:-https://example.clerk.accounts.dev/.well-known/jwks.json}
+    - type: oidc
+      id: auth0
+      authorize_endpoint: ${AUTH0_AUTHORIZE_ENDPOINT}
+      token_endpoint: ${AUTH0_TOKEN_ENDPOINT}
+      userinfo_endpoint: ${AUTH0_USERINFO_ENDPOINT}
+      client_id_env: AUTH0_CLIENT_ID
+      client_secret_env: AUTH0_CLIENT_SECRET
 ```
 
 - `${VAR}` resolves to the environment variable's value. If it's unset,
@@ -240,7 +244,7 @@ half-broken provider:
 ```yaml
 auth:
   providers:
-    - class: app.lib.clerk_env.ClerkFromEnv
+    - type: clerk
       required: auto
 ```
 
@@ -254,6 +258,14 @@ Any value other than the literal string `"auto"` for `required` (a typo
 like `Auto`, or anything else) raises a `ProviderConfigError` naming the
 bad value, rather than being silently ignored or crashing the provider's
 constructor with an unrelated `TypeError`.
+
+`ClerkProvider` implements this fully out of the box: `is_configured()`
+checks for `CLERK_ISSUER`, falling back to decoding the Frontend API domain
+out of `PUBLIC_CLERK_PUBLISHABLE_KEY` (Clerk's own `pk_test_`/`pk_live_` key
+shape), and `from_config()` derives `jwks_url` as
+`{issuer}/.well-known/jwks.json` when it isn't given explicitly. Neither
+env var needs a custom wrapper class or an explicit `issuer:`/`jwks_url:`
+in `fymo.yml` -- the config block above is the entire setup.
 
 `is_configured()` defaults to `True` on `BaseProvider`, so every existing
 provider is unaffected: only an entry that both sets `required: auto` and

--- a/fymo/auth/providers/clerk.py
+++ b/fymo/auth/providers/clerk.py
@@ -11,6 +11,8 @@ present, and tests inject a fake. Core stays dependency-free.
 """
 from __future__ import annotations
 
+import base64
+import os
 from typing import Callable, Optional
 
 from fymo.auth.context import get_user_store
@@ -20,6 +22,38 @@ from fymo.auth.store import User
 
 # verify(token) -> claims dict, or None if the token is invalid/expired.
 Verifier = Callable[[str], Optional[dict]]
+
+_ISSUER_ENV = "CLERK_ISSUER"
+_PUBLISHABLE_KEY_ENV = "PUBLIC_CLERK_PUBLISHABLE_KEY"
+
+
+def _issuer_from_publishable_key(key: str) -> Optional[str]:
+    """Clerk publishable keys (`pk_test_<b64>` / `pk_live_<b64>`) base64-encode
+    the Frontend API domain, terminated with a literal `$` -- Clerk's own
+    documented key shape, e.g. `pk_test_Y2xlcmsuZXhhbXBsZS5jb20k` decodes to
+    `clerk.example.com$`. Returns None on any key that doesn't match, rather
+    than raising, so callers (is_configured included) can treat it as "not
+    configured" instead of crashing on a typo'd key."""
+    parts = key.split("_", 2)
+    if len(parts) != 3 or parts[0] != "pk":
+        return None
+    encoded = parts[2]
+    padded = encoded + "=" * (-len(encoded) % 4)
+    try:
+        domain = base64.b64decode(padded).decode("ascii").rstrip("$")
+    except Exception:
+        return None
+    return f"https://{domain}" if domain else None
+
+
+def _issuer_from_env() -> Optional[str]:
+    """CLERK_ISSUER wins when set; otherwise derive it from the publishable
+    key, which every Clerk app already has lying around in its frontend env."""
+    issuer = os.environ.get(_ISSUER_ENV)
+    if issuer:
+        return issuer
+    key = os.environ.get(_PUBLISHABLE_KEY_ENV)
+    return _issuer_from_publishable_key(key) if key else None
 
 
 class ClerkProvider(BaseProvider):
@@ -42,12 +76,29 @@ class ClerkProvider(BaseProvider):
 
     @classmethod
     def from_config(cls, opts: dict) -> "ClerkProvider":
+        issuer = opts.get("issuer") or _issuer_from_env()
+        if not issuer:
+            raise RuntimeError(
+                f"ClerkProvider has no issuer: set {_ISSUER_ENV}, or "
+                f"{_PUBLISHABLE_KEY_ENV} (Clerk's pk_test_/pk_live_ key) so it "
+                "can be derived, or pass issuer= explicitly in fymo.yml"
+            )
         return cls(
-            issuer=opts["issuer"],
-            jwks_url=opts["jwks_url"],
+            issuer=issuer,
+            jwks_url=opts.get("jwks_url") or f"{issuer}/.well-known/jwks.json",
             audience=opts.get("audience"),
             cookie_name=opts.get("cookie_name", "__session"),
         )
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        """Only consulted when a fymo.yml entry opts in with `required: auto`
+        (see BaseProvider); reasons purely from the environment since the
+        registry calls this with no opts, so an explicit literal `issuer:` in
+        yml without either env var set won't count as configured here -- that
+        app doesn't need `required: auto` anyway, it already knows it's
+        configured."""
+        return _issuer_from_env() is not None
 
     def _token(self, event: dict) -> Optional[str]:
         cookie = event.get("cookies", {}).get(self.cookie_name)

--- a/journal/journal_013.md
+++ b/journal/journal_013.md
@@ -1,0 +1,117 @@
+# Journal Entry 013: The Provider That Made Every App Reinvent Itself
+
+**Date**: July 15, 2026
+**Focus**: ClerkProvider derives its own config instead of making every app write a wrapper for it
+**Status**: Shipped
+
+## What a Real App Was Doing
+
+I went looking at a live app built on fymo and found a file called
+`app/lib/clerk_env.py`, about seventy lines, whose entire job was: read
+`CLERK_ISSUER` or decode it out of `PUBLIC_CLERK_PUBLISHABLE_KEY`, build a
+JWKS URL from it, and only construct the real `ClerkProvider` if any of that
+actually resolved to something. None of that is specific to that app. It's
+just what Clerk is. Every single app that wires up Clerk on fymo would need
+to write the same seventy lines, because `ClerkProvider.from_config` took
+`issuer` and `jwks_url` as flat required keys with no derivation, and never
+overrode `is_configured()` even though the framework already has a
+mechanism built for exactly this — `required: auto`, which skips a provider
+entirely if it isn't configured instead of crashing or half-registering it.
+The mechanism existed. Clerk just never plugged into it.
+
+## What Clerk Actually Publishes
+
+The publishable key Clerk hands out (`pk_test_...` / `pk_live_...`) isn't
+an opaque token — the part after the prefix is base64 for the Frontend API
+domain with a trailing `$`. Decode `pk_test_Y2xlcmsuZXhhbXBsZS5jb20k` and
+you get `clerk.example.com$`. Every Clerk app already has this key sitting
+in its frontend env for the client widget, so there's no reason the backend
+should need a second, separately-configured issuer URL when it can just
+read the same key and derive one. That's the whole crux of the fix: the
+issuer resolves from `CLERK_ISSUER` if it's set, and falls back to decoding
+the publishable key if it's not, and the JWKS URL derives from whichever
+issuer it lands on (`{issuer}/.well-known/jwks.json`, Clerk's own
+convention) unless something explicit overrides it.
+
+## The Design Calls the Issue Left Open
+
+A couple of things weren't fully pinned down and I had to just decide:
+
+- **What counts as "configured."** `is_configured()` is called by the
+  registry with no arguments — it can't see whatever's actually written in
+  `fymo.yml`, only the environment. So it can only ever answer "does the
+  environment have enough to build this," not "does this specific config
+  entry have enough." An app that hardcodes a literal `issuer:` in its yml
+  without setting either env var, and also opts into `required: auto`, will
+  see Clerk silently skipped even though `from_config` would have worked
+  fine with the literal value. I decided that's fine, because an app in
+  that position doesn't need `required: auto` in the first place — it
+  already knows Clerk is configured, that's why it hardcoded the value.
+  `required: auto` exists for the "maybe configured, maybe not, depends on
+  environment" case, and that's exactly what env-only `is_configured()`
+  answers correctly.
+
+- **What happens when nothing resolves.** Previously this was a bare
+  `KeyError: 'issuer'` if you forgot the config and weren't using
+  `required: auto`. I made it a real error message naming both env vars,
+  since a stack trace pointing at a dict lookup inside the framework isn't
+  something an app author should have to decode.
+
+- **Malformed keys degrade instead of crashing.** A key with the wrong
+  prefix, bad padding, or garbage where the domain should be just resolves
+  to "not configured" rather than raising out of `is_configured()`. Getting
+  that classification wrong (treating a bad key as valid) would be worse
+  than getting it right slowly, so the decode function fails closed.
+
+## Doing It the Way the Repo Already Does It
+
+Wrote the failing tests first — explicit issuer without env, `CLERK_ISSUER`
+alone, publishable-key derivation alone, one env winning over the other,
+explicit values winning over both, the missing-everything error, and
+`is_configured()` in each of those states, plus the full path through
+`build_providers()` with `required: auto`. Watched all of them fail for the
+right reason: the derivation tests died on the same `KeyError` the app's
+wrapper existed to work around, and the `is_configured()` tests failed
+because `BaseProvider`'s default just always says yes. Then wrote the
+actual derivation and the override, and watched the same tests turn green
+without touching anything else about the provider — the constructor still
+takes plain `issuer=`/`jwks_url=` kwargs exactly like before, so nothing
+that constructs `ClerkProvider` directly noticed a thing.
+
+Full suite stayed green throughout, and I ran the zero-config path for
+real — set only the publishable key in the environment, called
+`build_providers` with `{type: clerk, required: auto}`, and confirmed it
+produced a working provider with the right derived issuer and JWKS URL,
+then cleared the environment and confirmed the same config just quietly
+produced nothing instead of an error. That's the actual behavior an app
+depending on this would see, not just an assertion on a return value.
+
+Independent review came back clean — traced the base64 edge cases (wrong
+prefix, bad padding, non-ascii, empty domain after stripping the
+terminator) and didn't find a gap, confirmed the explicit-wins-over-env
+precedence matches how the existing OAuth and OIDC providers already do
+config resolution, and confirmed nothing in the diff broke backward
+compatibility for apps already passing explicit values. It did point out
+two thin spots in the test matrix — explicit issuer against a conflicting
+env var, and a key with the right shape but a body that just isn't valid
+base64 — so I added both before calling it finished.
+
+## What This Actually Changes
+
+`fymo.yml` goes from a custom wrapper class plus explicit issuer and JWKS
+URL, down to:
+
+```yaml
+auth:
+  providers:
+    - type: clerk
+      required: auto
+```
+
+Dormant until Clerk env vars show up, active the moment they do, no app
+code standing between "I have a Clerk account" and "this works." The
+seventy-line file that started this doesn't need to exist anywhere anymore.
+
+---
+
+*End of Journal Entry 013*

--- a/tests/auth/test_clerk_config.py
+++ b/tests/auth/test_clerk_config.py
@@ -1,0 +1,118 @@
+"""ClerkProvider zero-config: derive issuer/jwks_url from env, implement
+is_configured() so `required: auto` actually works for Clerk (issue #28)."""
+import base64
+
+import pytest
+
+from fymo.auth.providers.clerk import ClerkProvider
+from fymo.auth.providers.registry import build_providers
+
+# pk_test_<base64("clerk.example.com$")>
+PUBLISHABLE_KEY = "pk_test_" + base64.b64encode(b"clerk.example.com$").decode()
+
+
+def test_from_config_uses_explicit_issuer_and_jwks_url(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.delenv("PUBLIC_CLERK_PUBLISHABLE_KEY", raising=False)
+    prov = ClerkProvider.from_config({
+        "issuer": "https://x.clerk.accounts.dev",
+        "jwks_url": "https://x.example/jwks",
+    })
+    assert prov.issuer == "https://x.clerk.accounts.dev"
+    assert prov.jwks_url == "https://x.example/jwks"
+
+
+def test_from_config_derives_jwks_url_from_explicit_issuer(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.delenv("PUBLIC_CLERK_PUBLISHABLE_KEY", raising=False)
+    prov = ClerkProvider.from_config({"issuer": "https://x.clerk.accounts.dev"})
+    assert prov.jwks_url == "https://x.clerk.accounts.dev/.well-known/jwks.json"
+
+
+def test_from_config_reads_issuer_from_clerk_issuer_env(monkeypatch):
+    monkeypatch.setenv("CLERK_ISSUER", "https://env.clerk.accounts.dev")
+    monkeypatch.delenv("PUBLIC_CLERK_PUBLISHABLE_KEY", raising=False)
+    prov = ClerkProvider.from_config({})
+    assert prov.issuer == "https://env.clerk.accounts.dev"
+    assert prov.jwks_url == "https://env.clerk.accounts.dev/.well-known/jwks.json"
+
+
+def test_from_config_derives_issuer_from_publishable_key_env(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.setenv("PUBLIC_CLERK_PUBLISHABLE_KEY", PUBLISHABLE_KEY)
+    prov = ClerkProvider.from_config({})
+    assert prov.issuer == "https://clerk.example.com"
+    assert prov.jwks_url == "https://clerk.example.com/.well-known/jwks.json"
+
+
+def test_from_config_clerk_issuer_env_wins_over_publishable_key(monkeypatch):
+    monkeypatch.setenv("CLERK_ISSUER", "https://explicit.clerk.accounts.dev")
+    monkeypatch.setenv("PUBLIC_CLERK_PUBLISHABLE_KEY", PUBLISHABLE_KEY)
+    prov = ClerkProvider.from_config({})
+    assert prov.issuer == "https://explicit.clerk.accounts.dev"
+
+
+def test_from_config_explicit_opt_wins_over_conflicting_env(monkeypatch):
+    monkeypatch.setenv("CLERK_ISSUER", "https://env.clerk.accounts.dev")
+    monkeypatch.setenv("PUBLIC_CLERK_PUBLISHABLE_KEY", PUBLISHABLE_KEY)
+    prov = ClerkProvider.from_config({"issuer": "https://yml.clerk.accounts.dev"})
+    assert prov.issuer == "https://yml.clerk.accounts.dev"
+
+
+def test_from_config_explicit_jwks_url_wins_over_derived(monkeypatch):
+    monkeypatch.setenv("CLERK_ISSUER", "https://env.clerk.accounts.dev")
+    prov = ClerkProvider.from_config({"jwks_url": "https://custom/jwks.json"})
+    assert prov.jwks_url == "https://custom/jwks.json"
+
+
+def test_from_config_raises_clear_error_when_nothing_configured(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.delenv("PUBLIC_CLERK_PUBLISHABLE_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="CLERK_ISSUER"):
+        ClerkProvider.from_config({})
+
+
+def test_is_configured_false_with_no_env(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.delenv("PUBLIC_CLERK_PUBLISHABLE_KEY", raising=False)
+    assert ClerkProvider.is_configured() is False
+
+
+def test_is_configured_true_with_clerk_issuer_env(monkeypatch):
+    monkeypatch.setenv("CLERK_ISSUER", "https://env.clerk.accounts.dev")
+    assert ClerkProvider.is_configured() is True
+
+
+def test_is_configured_true_with_publishable_key_env(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.setenv("PUBLIC_CLERK_PUBLISHABLE_KEY", PUBLISHABLE_KEY)
+    assert ClerkProvider.is_configured() is True
+
+
+def test_is_configured_false_for_malformed_publishable_key(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.setenv("PUBLIC_CLERK_PUBLISHABLE_KEY", "not-a-real-key")
+    assert ClerkProvider.is_configured() is False
+
+
+def test_is_configured_false_for_pk_prefixed_key_with_undecodable_body(monkeypatch):
+    """Right shape (pk_test_<...>) but the body isn't valid base64 at all,
+    as opposed to the wrong-shape case above (no pk_<env>_ prefix)."""
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.setenv("PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_test_!!!not-base64!!!")
+    assert ClerkProvider.is_configured() is False
+
+
+def test_required_auto_skips_clerk_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.delenv("PUBLIC_CLERK_PUBLISHABLE_KEY", raising=False)
+    providers = build_providers([{"type": "clerk", "required": "auto"}])
+    assert providers == []
+
+
+def test_required_auto_includes_clerk_when_configured_via_publishable_key(monkeypatch):
+    monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    monkeypatch.setenv("PUBLIC_CLERK_PUBLISHABLE_KEY", PUBLISHABLE_KEY)
+    providers = build_providers([{"type": "clerk", "required": "auto"}])
+    assert len(providers) == 1
+    assert providers[0].issuer == "https://clerk.example.com"


### PR DESCRIPTION
## Summary

Closes #28. `ClerkProvider.from_config` required `issuer` and `jwks_url` as flat, hard-coded keys with no defaults, and never overrode `is_configured()`, so `required: auto` (the mechanism built for conditional provider construction) never worked for Clerk. A real app on fymo had ended up hand-writing a ~70 line wrapper class just to read Clerk's env vars, derive the JWKS URL, and degrade gracefully when Clerk wasn't configured. None of that is app-specific, it's generic Clerk knowledge.

- `issuer` now resolves from `CLERK_ISSUER`, falling back to decoding it out of `PUBLIC_CLERK_PUBLISHABLE_KEY` (Clerk's own `pk_test_`/`pk_live_` key shape: base64 Frontend API domain terminated with `$`)
- `jwks_url` derives as `{issuer}/.well-known/jwks.json` when not given explicitly
- `is_configured()` reflects the same two env vars, so `required: auto` actually gates construction for Clerk
- a missing issuer now raises a clear error naming both env vars instead of a raw `KeyError`
- `ClerkProvider.__init__` is unchanged (still takes explicit `issuer=`/`jwks_url=`), so direct construction and existing tests are unaffected; all the derivation lives in `from_config`, same split as `OAuthProvider`/`OIDCProvider`

Design calls the issue left open, documented in the commit: `is_configured()` is a classmethod called with no config access, so it can only reason from the environment, not from literal yml values. An app that hardcodes an explicit `issuer:` without setting either env var, while also opting into `required: auto`, will see the provider skipped. That's an acceptable edge case since such an app already knows it's configured and doesn't need `required: auto` in the first place.

Result: `fymo.yml` goes from a custom wrapper class plus explicit issuer/JWKS config down to:

```yaml
auth:
  providers:
    - type: clerk
      required: auto
```

## Test plan

- [x] New tests in `tests/auth/test_clerk_config.py` written first (TDD), watched fail against the old code for the right reason (`KeyError: 'issuer'`, wrong `is_configured()` default)
- [x] Covers: explicit issuer/jwks_url, `CLERK_ISSUER` alone, publishable-key derivation alone, env precedence both ways, explicit opts winning over conflicting env, missing-everything error, malformed publishable key (wrong shape and right-shape-bad-body), `is_configured()` in each state, full `build_providers()` wiring with `required: auto`
- [x] Full suite green: 684 passed, 106 skipped
- [x] Ran the zero-config path end to end (not just unit tests): built a provider from only `PUBLIC_CLERK_PUBLISHABLE_KEY` in the environment via `build_providers([{"type": "clerk", "required": "auto"}])`, confirmed the derived issuer/jwks_url, then cleared the env and confirmed it degrades to an empty provider list with no error
- [x] `docs/deployment.md` updated to drop the now-unnecessary wrapper-class example