### PR TITLE
Load .env into os.environ, dev-only, before fymo.yml is parsed

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -230,6 +230,31 @@ auth:
   validated (an unset required var there still raises), since the
   substitution pass has no notion of YAML comments.
 
+### `.env` for local development
+
+In dev mode (`dev=True` / `FYMO_DEV=1`), Fymo loads a `.env` file from the
+project root into the process environment before `fymo.yml` is parsed, so
+`${VAR}` placeholders and any code reading `os.environ` can see it:
+
+```
+CLERK_ISSUER=https://example.clerk.accounts.dev
+DATABASE_URL=postgres://localhost/myapp_dev
+```
+
+- One `KEY=value` per line. Blank lines and lines starting with `#` are
+  ignored. A value may be wrapped in matching single or double quotes,
+  which are stripped.
+- A real environment variable already set (exported in the shell, set by
+  the process manager, etc.) always wins — `.env` never overwrites it. Use
+  this to override a single value for a one-off run without editing the
+  file.
+- **Never read in production.** `.env` is only loaded when `dev=True`; a
+  production process (`dev=False`, the default when `FYMO_DEV` is unset)
+  never touches it, even if a `.env` file exists on disk (e.g. committed by
+  accident).
+- Add `.env` to `.gitignore` in your project — Fymo doesn't do this for
+  you, since project scaffolding and `.gitignore` are separate concerns.
+
 ### Conditional auth providers: `required: auto`
 
 A provider entry can carry `required: auto` to make its inclusion depend

--- a/fymo/cli/commands/jobs_worker.py
+++ b/fymo/cli/commands/jobs_worker.py
@@ -24,16 +24,24 @@ def run_jobs_worker(project_root: Optional[Path] = None) -> None:
     `procrastinate` with no `DATABASE_URL`).
     """
     project_root = Path(project_root) if project_root else Path.cwd()
+
+    # Resolved before ConfigManager so both this dev-only .env load and
+    # ConfigManager's ${VAR} interpolation of fymo.yml see the same env,
+    # matching FymoApp.__init__'s ordering (fymo/core/server.py).
+    from fymo.core.config import env_truthy, load_dotenv
+    dev = env_truthy("FYMO_DEV")
+    if dev:
+        load_dotenv(project_root)
+
     config_manager = ConfigManager(project_root)
 
     # The worker is its own OS process — FymoApp's logging configuration
     # happened in the web process, not here. Same config source, same
     # dev-detection (FYMO_DEV), so both processes log to the same place in
     # the same format.
-    from fymo.core.config import env_truthy
     from fymo.core.logging import configure as _configure_logging
     _configure_logging(
-        dev=env_truthy("FYMO_DEV"),
+        dev=dev,
         config=config_manager.get_logging_config(),
         project_root=project_root,
     )

--- a/fymo/core/config.py
+++ b/fymo/core/config.py
@@ -16,6 +16,38 @@ def env_truthy(name: str) -> bool:
     return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
 
 
+def load_dotenv(project_root: Path) -> None:
+    """Load KEY=value pairs from a .env file at the project root into
+    os.environ, without overwriting a variable that's already set there.
+
+    Callers gate this on dev mode and call it before constructing a
+    ConfigManager, so ${VAR} interpolation in fymo.yml can see .env values
+    alongside real env vars, while a real env var set outside .env always
+    wins (so a one-off override doesn't require editing the file) and
+    production never reads .env at all, even if one exists on disk.
+
+    Hand-rolled rather than a python-dotenv dependency: the subset of the
+    format actually needed (KEY=value, # comments, blank lines, optional
+    matching quotes) is small and stable, matching the lazy-optional-dep
+    philosophy already used for pyjwt in auth/providers/clerk.py rather
+    than adding a hard dependency for a few lines of parsing.
+    """
+    dotenv_path = project_root / ".env"
+    if not dotenv_path.is_file():
+        return
+    for raw_line in dotenv_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
 # ${VAR} (required) or ${VAR:-default} (falls back when unset). Resolved on
 # the raw YAML text before yaml.safe_load parses it: the simplest correct
 # approach, and it applies uniformly to the whole file (any section, any

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Dict, Any, Optional
 
-from fymo.core.config import ConfigManager
+from fymo.core.config import ConfigManager, load_dotenv
 from fymo.core.assets import AssetManager
 from fymo.core.template_renderer import TemplateRenderer
 from fymo.core.router import Router
@@ -85,6 +85,13 @@ class FymoApp:
         """
         self.project_root = Path(project_root) if project_root else Path.cwd()
         self.dev = dev if dev is not None else _env_truthy("FYMO_DEV")
+
+        # Local dev often needs values (API keys, DATABASE_URL, ...) that
+        # shouldn't be exported in every shell. Load them from .env before
+        # anything reads os.environ, so both this constructor and
+        # ConfigManager's ${VAR} interpolation of fymo.yml see them.
+        if self.dev:
+            load_dotenv(self.project_root)
 
         # Wire the dev flag into the remote router so its 500 path knows whether
         # to include traceback details.

--- a/journal/journal_013.md
+++ b/journal/journal_013.md
@@ -1,0 +1,112 @@
+# Journal Entry 013: The .env File That Never Existed
+
+**Date**: July 15, 2026
+**Focus**: Loading a `.env` file into the process environment, dev-only, before `fymo.yml` gets parsed
+**Status**: Shipped
+
+## The Gap
+
+Went looking for something specific this time, not tripping over it by
+accident: does fymo load a `.env` file anywhere? It doesn't. `${VAR}`
+interpolation in `fymo.yml` reads straight from `os.environ`, which is
+correct in production, but means every local session starts with exporting
+half a dozen variables into the shell by hand before `fymo dev` resolves
+anything. Clone a project, open a new terminal, forget you did that
+yesterday, watch `fymo.yml` blow up with "references undefined environment
+variable." Not a bug exactly. Just friction nobody had gotten around to
+fixing.
+
+The open question was whether to hand-roll a parser or pull in
+`python-dotenv`. Checked what the codebase already does with optional
+dependencies before deciding: `pyjwt[crypto]` is used for Clerk token
+verification, and it's not even in `pyproject.toml` — it's a bare `import
+jwt` inside a `try/except ImportError` that only fires if you actually
+exercise Clerk auth. That's the house style: core stays dependency-free,
+anything not needed by every install is either declared optional or lazily
+imported with a clear failure message. `.env` parsing is fifteen lines of
+`KEY=value`, comments, and quote-stripping. Adding a dependency for that
+would have been the wrong kind of consistency — consistent with what other
+frameworks do, inconsistent with what this one already does.
+
+## Where It Actually Has to Go
+
+The interpolation itself lives in `config.py`, resolved on the raw YAML
+text before `yaml.safe_load` ever sees it. So the loader has to run before
+`ConfigManager` gets constructed, not before `fymo.yml` gets read — those
+aren't the same moment, and `ConfigManager.__init__` does both back to
+back. `FymoApp.__init__` resolves `self.dev` and then builds a
+`ConfigManager` thirty-some lines later in the same function. That gap is
+exactly where the load needs to sit: after `dev` is known, before config
+parsing starts.
+
+There's a second place `ConfigManager` gets built: `fymo jobs-worker`, its
+own OS process, separate from the web app entirely. And it had a real
+ordering problem already, unrelated to `.env` — it constructed
+`ConfigManager` first and only figured out `dev` nine lines later, purely
+for a logging call. Nobody had ever needed dev-mode to be known before
+config parsing there, so nobody noticed the ordering was backwards. Adding
+`.env` support meant fixing that ordering too, otherwise the worker would
+be the one place `.env` quietly didn't work, which is precisely the kind
+of inconsistency the original bug report was about in the first place.
+
+One thing I deliberately didn't try to fix: `FYMO_DEV` itself only ever
+comes from a real environment variable, read before `.env` loads. You
+can't put `FYMO_DEV=1` in `.env` and have it flip a process into dev mode,
+because by the time anything would read `.env`, it's already decided
+whether it's allowed to. That's not an oversight, it's the only ordering
+that isn't circular — checking `.env` to decide whether to read `.env`
+doesn't have a sane answer. Wrote it down as a known limitation instead of
+quietly working around it with something clever, because the clever
+version would have been a chicken-and-egg bug wearing a feature costume.
+
+## What Constructing a FymoApp in a Test Actually Costs
+
+Wanted a test proving that a value loaded from `.env` really does flow
+through to `${VAR}` interpolation in `fymo.yml`, not just that `os.environ`
+gets populated. Building a real `FymoApp` for that turned out to need more
+than a `.env` file and a `fymo.yml` — the constructor unconditionally wants
+`dist/sidecar.mjs` to exist and raises a clean `RuntimeError` if it
+doesn't, no dev-mode bypass. `test_logging.py` had already solved this by
+hand-rolling the smallest possible sidecar stub, just enough of the
+length-prefixed JSON protocol to answer a startup ping. Reused the same
+stub rather than inventing a second way to fake the same thing. For the
+two tests that only needed to check whether `os.environ` got touched, I
+skipped the stub entirely and let the `RuntimeError` happen — `.env` loads
+early enough in `__init__` that the assertion still holds true by the time
+construction fails later for an unrelated reason.
+
+## The Test That Would Have Passed Either Way
+
+Got this one wrong on the first pass and a review caught it before it
+shipped. The `jobs-worker` test asserted that a `.env` value ended up in
+`os.environ` after calling `run_jobs_worker` — true, but it would have
+been just as true if `.env` loaded *after* `ConfigManager` instead of
+before. The assertion didn't actually depend on the ordering it was named
+after. Fixed it by making `fymo.yml` require the `.env`-provided variable
+through `${VAR}` interpolation: if the ordering were ever wrong, config
+parsing would raise `ConfigurationError` instead of the worker's normal
+`SystemExit(1)`, and the test would fail on the wrong exception type.
+Didn't just trust that reasoning — reverted the ordering fix by hand for a
+minute, watched the test fail with exactly the `ConfigurationError` it was
+supposed to catch, then put the fix back. A test that can't fail isn't
+testing anything, it's just decoration that happens to be green.
+
+## What's Still Manual
+
+Fymo doesn't add `.env` to a new project's `.gitignore` for you. Scaffolding
+and the loader are separate concerns, and `fymo new`'s gitignore template
+not knowing about `.env` yet is a small, honest gap rather than something
+this change should have quietly absorbed. Worth a follow-up, not worth
+blocking on.
+
+Also ran into issue #26 while tracing where `dev` gets decided: `fymo dev`
+doesn't actually pass `dev=True` today, it falls through to whatever
+`FYMO_DEV` happens to be in the shell. That's a real, separate problem —
+once it's fixed, `.env` loading here will just start working for `fymo dev`
+without either issue having to know about the other, since both key off
+the same `self.dev`. Left it alone. Not every gap you notice while working
+is a gap you should be the one to close today.
+
+---
+
+*End of Journal Entry 013*

--- a/tests/cli/test_jobs_worker.py
+++ b/tests/cli/test_jobs_worker.py
@@ -1,5 +1,6 @@
 """Tests for the `fymo jobs-worker` CLI command."""
 import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -74,3 +75,30 @@ def test_jobs_worker_configures_logging_from_yml(tmp_path, monkeypatch):
         run_jobs_worker(tmp_path)
     assert fymo_logging._installed_handler is not None
     assert isinstance(fymo_logging._installed_handler, logging.FileHandler)
+
+
+def test_jobs_worker_loads_dotenv_before_config_manager_when_dev(tmp_path, monkeypatch):
+    """.env must be loaded (dev-only) before ConfigManager parses fymo.yml,
+    same ordering as FymoApp.__init__, so ${VAR} interpolation and any
+    os.environ read by provider setup both see .env values."""
+    monkeypatch.delenv("FYMO_TEST_WORKER_DOTENV", raising=False)
+    monkeypatch.setenv("FYMO_DEV", "1")
+    (tmp_path / ".env").write_text("FYMO_TEST_WORKER_DOTENV=loaded\n")
+
+    # Default threaded provider exits with SystemExit(1) quickly and
+    # predictably, same mechanism the other tests in this file rely on.
+    with pytest.raises(SystemExit):
+        run_jobs_worker(tmp_path)
+
+    assert os.environ["FYMO_TEST_WORKER_DOTENV"] == "loaded"
+
+
+def test_jobs_worker_ignores_dotenv_when_not_dev(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_WORKER_DOTENV_PROD", raising=False)
+    monkeypatch.delenv("FYMO_DEV", raising=False)
+    (tmp_path / ".env").write_text("FYMO_TEST_WORKER_DOTENV_PROD=should-not-load\n")
+
+    with pytest.raises(SystemExit):
+        run_jobs_worker(tmp_path)
+
+    assert "FYMO_TEST_WORKER_DOTENV_PROD" not in os.environ

--- a/tests/cli/test_jobs_worker.py
+++ b/tests/cli/test_jobs_worker.py
@@ -79,14 +79,20 @@ def test_jobs_worker_configures_logging_from_yml(tmp_path, monkeypatch):
 
 def test_jobs_worker_loads_dotenv_before_config_manager_when_dev(tmp_path, monkeypatch):
     """.env must be loaded (dev-only) before ConfigManager parses fymo.yml,
-    same ordering as FymoApp.__init__, so ${VAR} interpolation and any
-    os.environ read by provider setup both see .env values."""
+    same ordering as FymoApp.__init__. Proven by making fymo.yml's `name`
+    require a var only .env provides: if load_dotenv ran after ConfigManager
+    (or not at all), ${FYMO_TEST_WORKER_DOTENV} would be unresolved and
+    ConfigManager would raise ConfigurationError instead of the expected
+    SystemExit(1) from the (successfully parsed) default threaded provider,
+    so pytest.raises(SystemExit) below would fail if the ordering broke."""
     monkeypatch.delenv("FYMO_TEST_WORKER_DOTENV", raising=False)
     monkeypatch.setenv("FYMO_DEV", "1")
     (tmp_path / ".env").write_text("FYMO_TEST_WORKER_DOTENV=loaded\n")
+    (tmp_path / "fymo.yml").write_text("name: ${FYMO_TEST_WORKER_DOTENV}\n")
 
-    # Default threaded provider exits with SystemExit(1) quickly and
-    # predictably, same mechanism the other tests in this file rely on.
+    # Default threaded provider (no `jobs:` section) exits with SystemExit(1)
+    # quickly and predictably, same mechanism the other tests in this file
+    # rely on, but only once fymo.yml parses at all.
     with pytest.raises(SystemExit):
         run_jobs_worker(tmp_path)
 

--- a/tests/core/test_dotenv_loading.py
+++ b/tests/core/test_dotenv_loading.py
@@ -1,0 +1,59 @@
+"""Tests for load_dotenv: parses .env into os.environ, dev-gated at the
+call sites (FymoApp.__init__, run_jobs_worker), real env vars always win.
+"""
+import os
+from pathlib import Path
+
+from fymo.core.config import load_dotenv
+
+
+def _write_dotenv(tmp_path: Path, text: str) -> None:
+    (tmp_path / ".env").write_text(text)
+
+
+def test_loads_simple_key_value_pairs(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_DOTENV_A", raising=False)
+    _write_dotenv(tmp_path, "FYMO_TEST_DOTENV_A=hello\n")
+    load_dotenv(tmp_path)
+    assert os.environ["FYMO_TEST_DOTENV_A"] == "hello"
+
+
+def test_real_env_var_always_wins_over_dotenv(tmp_path, monkeypatch):
+    monkeypatch.setenv("FYMO_TEST_DOTENV_B", "from-shell")
+    _write_dotenv(tmp_path, "FYMO_TEST_DOTENV_B=from-dotenv\n")
+    load_dotenv(tmp_path)
+    assert os.environ["FYMO_TEST_DOTENV_B"] == "from-shell"
+
+
+def test_skips_blank_lines_and_comments(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_DOTENV_C", raising=False)
+    _write_dotenv(tmp_path, "\n# a comment\n\nFYMO_TEST_DOTENV_C=value\n# trailing comment\n")
+    load_dotenv(tmp_path)
+    assert os.environ["FYMO_TEST_DOTENV_C"] == "value"
+
+
+def test_strips_matching_surrounding_quotes(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_DOTENV_D", raising=False)
+    monkeypatch.delenv("FYMO_TEST_DOTENV_E", raising=False)
+    _write_dotenv(tmp_path, 'FYMO_TEST_DOTENV_D="double quoted"\nFYMO_TEST_DOTENV_E=\'single quoted\'\n')
+    load_dotenv(tmp_path)
+    assert os.environ["FYMO_TEST_DOTENV_D"] == "double quoted"
+    assert os.environ["FYMO_TEST_DOTENV_E"] == "single quoted"
+
+
+def test_ignores_lines_without_equals_sign(tmp_path, monkeypatch):
+    _write_dotenv(tmp_path, "not a valid line\nFYMO_TEST_DOTENV_F=value\n")
+    load_dotenv(tmp_path)
+    assert os.environ["FYMO_TEST_DOTENV_F"] == "value"
+
+
+def test_missing_dotenv_file_is_a_silent_noop(tmp_path):
+    # tmp_path has no .env at all; must not raise.
+    load_dotenv(tmp_path)
+
+
+def test_strips_whitespace_around_key_and_value(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_DOTENV_G", raising=False)
+    _write_dotenv(tmp_path, "  FYMO_TEST_DOTENV_G   =   spaced value  \n")
+    load_dotenv(tmp_path)
+    assert os.environ["FYMO_TEST_DOTENV_G"] == "spaced value"

--- a/tests/core/test_dotenv_loading.py
+++ b/tests/core/test_dotenv_loading.py
@@ -57,3 +57,74 @@ def test_strips_whitespace_around_key_and_value(tmp_path, monkeypatch):
     _write_dotenv(tmp_path, "  FYMO_TEST_DOTENV_G   =   spaced value  \n")
     load_dotenv(tmp_path)
     assert os.environ["FYMO_TEST_DOTENV_G"] == "spaced value"
+
+
+import pytest
+
+from fymo.core.server import FymoApp
+
+
+def _write_fake_sidecar(tmp_path: Path) -> None:
+    """FymoApp always requires dist/sidecar.mjs (no dev-mode bypass). Same
+    minimal length-prefixed-JSON-IPC stub as test_logging.py, only needed by
+    the one test below that must get past full construction to inspect
+    config_manager; the others assert on os.environ before that point and
+    don't need a working sidecar."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "sidecar.mjs").write_text(
+        "let buf = Buffer.alloc(0);\n"
+        "process.stdin.on('data', (chunk) => {\n"
+        "  buf = Buffer.concat([buf, chunk]);\n"
+        "  while (buf.length >= 4) {\n"
+        "    const len = buf.readUInt32BE(0);\n"
+        "    if (buf.length < 4 + len) break;\n"
+        "    const msg = JSON.parse(buf.slice(4, 4 + len).toString('utf8'));\n"
+        "    buf = buf.slice(4 + len);\n"
+        "    const replyBody = Buffer.from(JSON.stringify({ ok: true, id: msg.id }), 'utf8');\n"
+        "    const header = Buffer.alloc(4);\n"
+        "    header.writeUInt32BE(replyBody.length, 0);\n"
+        "    process.stdout.write(Buffer.concat([header, replyBody]));\n"
+        "  }\n"
+        "});\n"
+    )
+
+
+def test_fymo_app_loads_dotenv_in_dev_mode(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_DOTENV_APP", raising=False)
+    monkeypatch.setenv("FYMO_SECRET", "x" * 32)
+    _write_dotenv(tmp_path, "FYMO_TEST_DOTENV_APP=loaded\n")
+    # No dist/ here, so construction fails past the point load_dotenv runs;
+    # os.environ is already updated by then, which is all this test checks.
+    with pytest.raises(RuntimeError, match="dist/ not found"):
+        FymoApp(project_root=tmp_path, dev=True)
+    assert os.environ["FYMO_TEST_DOTENV_APP"] == "loaded"
+
+
+def test_fymo_app_ignores_dotenv_in_prod_mode(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_DOTENV_PROD", raising=False)
+    monkeypatch.setenv("FYMO_SECRET", "x" * 32)
+    _write_dotenv(tmp_path, "FYMO_TEST_DOTENV_PROD=should-not-load\n")
+    with pytest.raises(RuntimeError, match="dist/ not found"):
+        FymoApp(project_root=tmp_path, dev=False)
+    assert "FYMO_TEST_DOTENV_PROD" not in os.environ
+
+
+def test_fymo_app_dotenv_can_be_read_by_fymo_yml_interpolation(tmp_path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_DOTENV_YML", raising=False)
+    monkeypatch.setenv("FYMO_SECRET", "x" * 32)
+    _write_dotenv(tmp_path, "FYMO_TEST_DOTENV_YML=from-dotenv\n")
+    # Explicit (empty) routes section: without it the router falls back to
+    # treating the whole fymo.yml as its routes mapping and chokes on
+    # top-level scalar keys like `name`. Unrelated to .env; just the
+    # minimal scaffolding FymoApp/Router need to construct at all.
+    (tmp_path / "fymo.yml").write_text(
+        "name: ${FYMO_TEST_DOTENV_YML}\nroutes: {}\n"
+    )
+    _write_fake_sidecar(tmp_path)
+    app = FymoApp(project_root=tmp_path, dev=True)
+    try:
+        assert app.config_manager.get_app_name() == "from-dotenv"
+    finally:
+        if app.sidecar:
+            app.sidecar.stop()


### PR DESCRIPTION
Closes #27

## Summary

- Nothing in fymo loaded a `.env` file: `${VAR}` interpolation in `fymo.yml` only ever read real `os.environ`, so local dev required manually exporting every var into the shell before `fymo dev`/`fymo jobs-worker` would resolve anything.
- `fymo/core/config.py`: new `load_dotenv(project_root)`. Hand-rolled parser (`KEY=value`, `#` comments, blank lines, matched-quote stripping) rather than a `python-dotenv` dependency, matching the codebase's existing lazy-optional-dep convention (`pyjwt[crypto]` in `auth/providers/clerk.py` is undeclared and lazily imported; core stays dependency-free). A real env var already set is never overwritten.
- `fymo/core/server.py`: `FymoApp.__init__` calls `load_dotenv` right after `self.dev` resolves, before `ConfigManager` parses `fymo.yml`, and only when `dev` is true. Production never touches `.env`, even if one exists on disk.
- `fymo/cli/commands/jobs_worker.py`: this is a second, independent place that constructs a `ConfigManager` (its own OS process, separate from the web app) and it was determining `dev` *after* building config, purely for a logging call — an ordering issue unrelated to `.env` but the same shape of bug. Reordered to resolve `dev` first, load `.env`, then construct config, matching `FymoApp.__init__`.
- `docs/deployment.md`: new `.env` section documenting the format and precedence rules.
- Known, intentional limitation: `FYMO_DEV` itself is always read from a real env var, before `.env` loads, in both call sites — `.env` cannot be used to flip a process into dev mode. Checking `.env` to decide whether to read `.env` has no sane answer, so this isn't something to special-case.

## Test plan

- [x] Full suite: 681 passed, 106 skipped, 0 failed
- [x] Parser: simple pairs, real-env-always-wins, comments/blank lines, matched-quote stripping, malformed lines ignored, missing file no-op, whitespace stripping
- [x] `FymoApp`: loads `.env` in dev, ignores it in prod, and a value loaded from `.env` actually resolves a `${VAR}` in `fymo.yml` through `ConfigManager` (not just checked in `os.environ`)
- [x] `run_jobs_worker`: same three behaviors, dev-mode test proven via required `${VAR}` interpolation rather than only checking `os.environ` (a first draft of this test would have passed even with the ordering reverted — caught by independent review, verified the fix by reverting the ordering by hand and watching the test fail on `ConfigurationError` before restoring it)