### PR TITLE
Fix dev-flag handling across fymo dev, serve, and serve --prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ npm install
 ### Build and Serve
 
 ```bash
-fymo build      # produces dist/ with hashed JS/CSS bundles
-fymo serve      # production-style WSGI server
+fymo dev             # incremental rebuild + browser auto-reload (development)
 
-# or, for development:
-fymo dev        # incremental rebuild + browser auto-reload
+# or, for production:
+fymo build           # produces dist/ with hashed JS/CSS bundles
+fymo serve --prod    # gunicorn
 ```
 
 Visit `http://127.0.0.1:8000`.
@@ -98,9 +98,9 @@ def getContext():
 ## CLI Commands
 
 - `fymo new <project>` — Create a new project
-- `fymo build` — Build for production (produces `dist/`)
-- `fymo serve` — Serve a built project
 - `fymo dev` — Dev server with file watcher and live reload
+- `fymo serve` — Alias for `fymo dev`; `fymo serve --prod` serves a built project via gunicorn
+- `fymo build` — Build for production (produces `dist/`)
 - `fymo generate <type> <name>` — Generate components/controllers
 
 ## Configuration

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -352,7 +352,10 @@ job arguments.)
 fymo owns a single handler on Python's root logger, so your app's own
 `logging.getLogger(...)` output and library logs share the destination
 and format. Attach additional handlers in `server.py` if you need a
-second sink (e.g. Sentry).
+second sink (e.g. Sentry) — this only takes effect under `fymo serve
+--prod`, which imports `server.py`. `fymo dev` and bare `fymo serve`
+build the app directly and never import it, so module-level code in
+`server.py` doesn't run locally.
 
 File output is append-only with no built-in rotation — use logrotate or
 your container platform's log driver.

--- a/examples/blog_app/server.py
+++ b/examples/blog_app/server.py
@@ -6,7 +6,3 @@ from fymo import create_app
 PROJECT_ROOT = Path(__file__).resolve().parent
 
 app = create_app(PROJECT_ROOT)
-
-if __name__ == "__main__":
-    from fymo.cli.commands.serve import run_dev_server
-    run_dev_server(app)

--- a/examples/todo_app/README.md
+++ b/examples/todo_app/README.md
@@ -35,13 +35,8 @@ fymo build
 ### 3. Serve
 
 ```bash
-fymo serve     # production-like, port 8000
-```
-
-Or, for development with auto-rebuild and browser reload:
-
-```bash
-fymo dev
+fymo dev              # development, with auto-rebuild and browser reload
+fymo serve --prod     # production, via gunicorn
 ```
 
 Visit `http://127.0.0.1:8000` to see the app.

--- a/examples/todo_app/package.json
+++ b/examples/todo_app/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "A Fymo project",
   "scripts": {
-    "dev": "fymo serve",
+    "dev": "fymo dev",
     "build": "fymo build"
   },
   "dependencies": {

--- a/examples/todo_app/server.py
+++ b/examples/todo_app/server.py
@@ -9,8 +9,3 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 
 # Create the WSGI application
 app = create_app(PROJECT_ROOT)
-
-if __name__ == "__main__":
-    # Run development server
-    from fymo.cli.commands.serve import run_dev_server
-    run_dev_server(app)

--- a/fymo/cli/commands/dev.py
+++ b/fymo/cli/commands/dev.py
@@ -8,6 +8,14 @@ from fymo.build.dev_orchestrator import DevOrchestrator
 
 def run_dev(host: str = "127.0.0.1", port: int = 8000):
     project_root = Path.cwd()
+
+    # Set FYMO_DEV so anything downstream that reads it (subprocesses, the
+    # sidecar) sees dev mode too, and also pass dev=True explicitly below
+    # rather than relying on FymoApp's env-var fallback. Issue #26: this
+    # used to be silently skipped, so `fymo dev` without a separately
+    # exported FYMO_DEV=1 booted with production security defaults.
+    os.environ["FYMO_DEV"] = "1"
+
     Color.print_info("Starting dev server with watcher")
 
     orch = DevOrchestrator(project_root=project_root)
@@ -28,7 +36,7 @@ def run_dev(host: str = "127.0.0.1", port: int = 8000):
     os.environ["FYMO_NEW_PIPELINE"] = "1"
 
     from fymo import create_app
-    app = create_app(project_root)
+    app = create_app(project_root, dev=True)
     app.dev_orchestrator = orch
 
     # Respawn sidecar after every successful server-rebuild so Node's ESM

--- a/fymo/cli/commands/new.py
+++ b/fymo/cli/commands/new.py
@@ -54,7 +54,7 @@ def create_project(name: str, template: str = 'default'):
     print(f"  cd {name}")
     print(f"  pip install -r requirements.txt")
     print(f"  npm install")
-    print(f"  fymo serve")
+    print(f"  fymo dev")
 
 
 def create_project_files(project_path: Path, project_name: str):
@@ -77,7 +77,7 @@ gunicorn>=23.0.0
   "type": "module",
   "description": "A Fymo project",
   "scripts": {{
-    "dev": "fymo serve",
+    "dev": "fymo dev",
     "build": "fymo build"
   }},
   "dependencies": {{
@@ -148,7 +148,11 @@ npm-debug.log*
 """
     (project_path / '.gitignore').write_text(gitignore)
     
-    # server.py
+    # server.py — plain WSGI entrypoint, for gunicorn/uwsgi/`fymo serve
+    # --prod`. Local development runs through `fymo dev` (or its `fymo
+    # serve` alias) instead, which builds its own FymoApp with dev=True and
+    # a dev orchestrator; a `python server.py` entrypoint here would bypass
+    # that pipeline entirely, so it's deliberately not offered.
     server_py = """#!/usr/bin/env python3
 \"\"\"Entry point for Fymo application\"\"\"
 
@@ -160,11 +164,6 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 
 # Create the WSGI application
 app = create_app(PROJECT_ROOT)
-
-if __name__ == "__main__":
-    # Run development server
-    from fymo.cli.commands.serve import run_dev_server
-    run_dev_server(app)
 """
     (project_path / 'server.py').write_text(server_py)
     os.chmod(project_path / 'server.py', 0o755)
@@ -269,12 +268,7 @@ A Fymo project - Python SSR framework for Svelte 5
 
 Start the development server:
 ```bash
-fymo serve
-```
-
-Or:
-```bash
-python server.py
+fymo dev
 ```
 
 ## Build for Production

--- a/fymo/cli/commands/serve.py
+++ b/fymo/cli/commands/serve.py
@@ -2,14 +2,14 @@
 Development server command
 """
 
-import subprocess
+import os
 import sys
 from pathlib import Path
 from fymo.utils.colors import Color
 from fymo.server.gunicorn import run_prod
 
 
-def run_server(host: str = '127.0.0.1', port: int = 8000, reload: bool = True,
+def run_server(host: str = '127.0.0.1', port: int = 8000,
                prod: bool = False, workers: int = 4):
     """
     Run the server
@@ -17,42 +17,40 @@ def run_server(host: str = '127.0.0.1', port: int = 8000, reload: bool = True,
     Args:
         host: Host to bind to
         port: Port to bind to
-        reload: Enable auto-reload (dev mode only)
-        prod: Serve via gunicorn instead of the wsgiref dev server
+        prod: Serve via gunicorn instead of the dev pipeline
         workers: Number of gunicorn worker processes (prod mode only)
     """
-    Color.print_info(f"Starting Fymo {'production' if prod else 'development'} server at http://{host}:{port}")
+    # Bare `fymo serve` (no --prod) earns no separate identity from `fymo
+    # dev` -- issue #26: it used to boot the wsgiref server directly
+    # against server.py's module-level app object, with no watcher, no
+    # esbuild rebuild-on-save, no sidecar hot-reload, and whatever dev
+    # value happened to be inherited from the shell. It's now a straight
+    # alias for `fymo dev`.
+    if not prod:
+        from fymo.cli.commands.dev import run_dev
+        run_dev(host, port)
+        return
 
-    # Check if server.py exists
+    Color.print_info(f"Starting Fymo production server at http://{host}:{port}")
+
     server_file = Path.cwd() / 'server.py'
     if not server_file.exists():
         Color.print_error("server.py not found! Are you in a Fymo project directory?")
         return
 
-    # For development, use Python's built-in server to avoid STPyV8/gunicorn conflicts.
-    # For production, --prod boots gunicorn via fymo.server.gunicorn.run_prod.
-    if reload and not prod:
-        Color.print_warning("Note: Auto-reload is not available withe built-in server. Restart manually for changes.")
+    # Force dev off before server.py is even imported, so a stray FYMO_DEV=1
+    # left exported somewhere in the shell can't accidentally boot
+    # production in dev mode (verbose tracebacks, insecure cookies, no rate
+    # limiting). --prod must not trust whatever's inherited.
+    os.environ["FYMO_DEV"] = "0"
 
     try:
         # Import and run the app directly
         sys.path.insert(0, str(Path.cwd()))
         from server import app
 
-        if prod:
-            Color.print_success(f"Starting gunicorn with {workers} worker(s) at http://{host}:{port}")
-            run_prod(app, host, port, workers)
-            return
-
-        # Threaded dev server — concurrent requests, so one slow handler
-        # or open SSE subscription never freezes the whole process.
-        from fymo.server.dev import make_dev_server
-
-        Color.print_success(f"Server running at http://{host}:{port}")
-        Color.print_info("Press Ctrl+C to stop...")
-
-        with make_dev_server(host, port, app) as httpd:
-            httpd.serve_forever()
+        Color.print_success(f"Starting gunicorn with {workers} worker(s) at http://{host}:{port}")
+        run_prod(app, host, port, workers)
 
     except ImportError as e:
         Color.print_error(f"Failed to import server: {e}")
@@ -61,28 +59,3 @@ def run_server(host: str = '127.0.0.1', port: int = 8000, reload: bool = True,
         Color.print_info("\nShutting down server...")
     except Exception as e:
         Color.print_error(f"Failed to start server: {e}")
-
-
-def run_dev_server(app, host: str = '127.0.0.1', port: int = 8000):
-    """
-    Run development server directly with a WSGI app
-    
-    Args:
-        app: WSGI application
-        host: Host to bind to
-        port: Port to bind to
-    """
-    from fymo.server.dev import make_dev_server
-
-    Color.print_info(f"Starting development server at http://{host}:{port}")
-    Color.print_warning("This server is for development only. Use a production WSGI server for deployment.")
-
-    try:
-        with make_dev_server(host, port, app) as httpd:
-            Color.print_success(f"Server running at http://{host}:{port}")
-            print("Press Ctrl+C to stop...")
-            httpd.serve_forever()
-    except KeyboardInterrupt:
-        Color.print_info("\nShutting down server...")
-    except Exception as e:
-        Color.print_error(f"Server error: {e}")

--- a/fymo/cli/main.py
+++ b/fymo/cli/main.py
@@ -28,13 +28,12 @@ def new(name, template):
 @cli.command()
 @click.option('--host', '-h', default='127.0.0.1', help='Host to bind to')
 @click.option('--port', '-p', default=8000, type=int, help='Port to bind to')
-@click.option('--reload', '-r', is_flag=True, default=True, help='Enable auto-reload')
 @click.option('--prod', is_flag=True, default=False, help='Serve via gunicorn instead of the dev server')
 @click.option('--workers', '-w', default=4, type=int, help='Gunicorn worker processes (--prod only)')
-def serve(host, port, reload, prod, workers):
-    """Start the server (dev by default, or production via --prod)"""
+def serve(host, port, prod, workers):
+    """Alias for `fymo dev`, or production via --prod"""
     from fymo.cli.commands.serve import run_server
-    run_server(host, port, reload, prod=prod, workers=workers)
+    run_server(host, port, prod=prod, workers=workers)
 
 
 @cli.command()

--- a/journal/journal_013.md
+++ b/journal/journal_013.md
@@ -1,0 +1,35 @@
+# Journal Entry 013: Three Commands, One Working By Accident
+
+**Date**: July 15, 2026
+**Focus**: `fymo dev` never actually enabled dev mode; `fymo serve` was a worse `fymo dev` wearing a different name; `fymo serve --prod` trusted the shell more than it should have
+**Status**: Shipped
+
+## Tracing It End to End
+
+I went in expecting to fix one thing and found three commands tangled together, none of them behaving the way their name promised. I started by asking a simple question: if I run `fymo dev` in a fresh project, does the app actually end up in dev mode? I traced `run_dev()` all the way down and the answer was no. It called `create_app(project_root)` with no `dev` argument, which falls back to reading `FYMO_DEV` from the environment — and `run_dev()` never set that variable. So `fymo dev`, the command whose entire job is "run this in dev mode," silently produced a production-configured app unless you'd separately exported `FYMO_DEV=1` yourself. Error pages without tracebacks, secure-only cookies, full rate limiting, on the one command that exists specifically to turn all of that off.
+
+Then I looked at `fymo serve`. With `FYMO_DEV=1` exported by hand, it did resolve dev=True correctly, but it booted through a completely different path — importing the project's `server.py`, pulling out the already-constructed `app` object, and handing it straight to the plain wsgiref server. No watcher, no esbuild rebuild-on-save, no sidecar hot-reload. And it had a `--reload` flag that did nothing but print a warning telling you it did nothing. Without `FYMO_DEV` exported, plain `fymo serve` ran with full production security defaults on that same single-process server — not a real dev environment, and not something you'd actually want serving traffic either. Three ways to start a server, and depending which one you picked and what was in your shell, you got some inconsistent blend of dev ergonomics and production security that matched neither label.
+
+The last piece was worse in a quieter way: `fymo serve --prod` built its WSGI app the same way, by importing `server.py`, which meant its `dev` flag also came from whatever `FYMO_DEV` happened to be set to in the shell at that moment. A stray `export FYMO_DEV=1` left over from an earlier dev session, forgotten in a long-lived terminal, could silently boot a production deploy in dev mode. That's not a hypothetical — it's exactly the kind of thing that survives in a shell profile or a leftover `.env` someone sourced once and never unset.
+
+## The One Real Decision
+
+Fixing the first and third problems was direct: make `fymo dev` set `FYMO_DEV=1` and pass `dev=True` explicitly, first thing, instead of relying on an env var it never set. Make `--prod` force `FYMO_DEV=0` before it ever imports `server.py`, so nothing inherited from the shell can leak in.
+
+The open question was what to do with bare `fymo serve`. It didn't earn its own identity — depending on flags and env state it was either a broken dev server or an underpowered production one. I could kill it outright, or turn it into a straight alias for `fymo dev`. I went with alias. The reason wasn't sentiment about backward compatibility for its own sake — it's that `fymo new`'s own printed next-steps, the scaffolded `package.json`'s `dev` script, the README, and both example apps all told a new user to type `fymo serve` first. Deleting the command would have broken onboarding for anyone following docs written before this fix landed, for zero benefit — aliasing gets the exact same outcome (a broken command becomes a working one) without that cost. `fymo serve` with no `--prod` now does exactly what `fymo dev` does, byte for byte, because it just calls into it. `--prod` is still the one real production path. I updated the scaffolding and docs to point at `fymo dev` as the canonical name going forward, since the whole complaint here was commands not matching their names, but I didn't make the alias an error just to enforce that on people who type `serve` out of habit.
+
+One more small thing fell out of that decision: the generated `server.py` had an `if __name__ == "__main__":` block that called a `run_dev_server()` helper directly, completely bypassing the CLI and the dev pipeline — a fourth way to start a server, and the one most likely to confuse someone who ran `python server.py` expecting the watcher to be running. Since `fymo dev` and the `fymo serve` alias no longer import `server.py` at all, that block was dead weight pointing at the wrong thing. Dropped it. `server.py` is now what it always should have been: a plain WSGI entrypoint for gunicorn, uwsgi, or `fymo serve --prod`, nothing more.
+
+## Proving It, Not Just Testing It
+
+Unit tests with mocked collaborators are fine for pinning down the wiring, and I wrote those first — a failing assertion that `run_dev()` sets `FYMO_DEV` and passes `dev=True`, one that `--prod` forces the env var false even with a stray truthy value already set, one that bare `serve` actually delegates to `run_dev`. All of them failed against the old code for the reason I expected, then passed once I made the change.
+
+But mocks can lie to you about timing, and a review pass caught exactly that in my first version of the `--prod` test — it only checked the final state of the environment variable after `run_server()` returned, which would still pass even if the fix accidentally set the variable *after* importing `server.py` instead of before. I rewrote it to use a real `server.py` that calls `create_app()` the way an actual scaffolded project does, and assert on the constructed app's `.dev` attribute directly, so the test fails if the ordering is ever wrong again, not just if the end state happens to look right.
+
+For the real proof, I used something already built into the app: production refuses to boot without a signing secret, but dev mode will auto-generate one at `.fymo/secret.key` the first time it starts. That's a real, unmocked signal for exactly the bug I was fixing. I copied one of the example apps into a scratch directory with no `FYMO_SECRET` set and no existing secret file, ran the actual `fymo dev` command against it, and watched `.fymo/secret.key` get written and the server come up and answer a real HTTP request — proof dev mode was genuinely on, not just that a test double said so. Then I ran the mirror image: a fresh copy, `FYMO_DEV=1` exported in the shell exactly like someone would forget to unset, and `fymo serve --prod` against it. It refused to start, demanding `FYMO_SECRET`, exactly as production should when it hasn't been told otherwise — proof the stray env var couldn't leak through anymore. Same trick a third time confirmed bare `fymo serve` takes the dev path too. Three real server processes, not three mocked function calls.
+
+Full suite: 676 passing, 106 skipped, zero failed.
+
+---
+
+*End of Journal Entry 013*

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -1,0 +1,70 @@
+"""Tests for `fymo dev` explicitly enabling dev mode (issue #26).
+
+`run_dev()` used to build the app with `create_app(project_root)` and no
+`dev` kwarg, relying on the `FYMO_DEV` env var, which it never set itself.
+Running `fymo dev` without separately exporting `FYMO_DEV=1` silently left
+the app in production mode: no tracebacks on 500s, secure-only cookies,
+full rate limiting.
+"""
+import os
+
+import fymo.cli.commands.dev as dev_mod
+
+
+class _FakeOrchestrator:
+    def __init__(self, project_root):
+        self.project_root = project_root
+        self.listeners = []
+
+    def start(self):
+        manifest = self.project_root / "dist" / "manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text("{}")
+
+    def stop(self):
+        pass
+
+    def add_listener(self, fn):
+        self.listeners.append(fn)
+
+
+class _FakeServer:
+    def serve_forever(self):
+        raise KeyboardInterrupt
+
+
+class _FakeApp:
+    sidecar = None
+
+
+def test_run_dev_sets_fymo_dev_env_var(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("FYMO_DEV", raising=False)
+    monkeypatch.setattr(dev_mod, "DevOrchestrator", _FakeOrchestrator)
+    monkeypatch.setattr("fymo.create_app", lambda project_root, dev=None: _FakeApp())
+    monkeypatch.setattr("fymo.server.dev.make_dev_server", lambda host, port, app: _FakeServer())
+
+    dev_mod.run_dev(host="127.0.0.1", port=8000)
+
+    assert os.environ.get("FYMO_DEV") == "1"
+
+
+def test_run_dev_passes_dev_true_explicitly_to_create_app(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("FYMO_DEV", raising=False)
+    monkeypatch.setattr(dev_mod, "DevOrchestrator", _FakeOrchestrator)
+
+    calls = {}
+
+    def fake_create_app(project_root, dev=None):
+        calls["project_root"] = project_root
+        calls["dev"] = dev
+        return _FakeApp()
+
+    monkeypatch.setattr("fymo.create_app", fake_create_app)
+    monkeypatch.setattr("fymo.server.dev.make_dev_server", lambda host, port, app: _FakeServer())
+
+    dev_mod.run_dev(host="127.0.0.1", port=8000)
+
+    assert calls["dev"] is True
+    assert calls["project_root"] == tmp_path

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -8,7 +8,27 @@ full rate limiting.
 """
 import os
 
+import pytest
+
 import fymo.cli.commands.dev as dev_mod
+
+
+@pytest.fixture(autouse=True)
+def _restore_fymo_dev_env():
+    """run_dev() sets os.environ["FYMO_DEV"] directly (by design -- a real
+    `fymo dev` process wants that var visible to anything it spawns), not
+    through monkeypatch. monkeypatch.delenv on an already-absent key
+    registers no undo, so without this fixture that mutation survives past
+    the test and leaks FYMO_DEV=1 into every later test in the same pytest
+    process -- silently flipping unrelated dev=None call sites (rate
+    limiting, HSTS) into dev mode. Snapshot and restore regardless of what
+    the code under test does to the var."""
+    original = os.environ.get("FYMO_DEV")
+    yield
+    if original is None:
+        os.environ.pop("FYMO_DEV", None)
+    else:
+        os.environ["FYMO_DEV"] = original
 
 
 class _FakeOrchestrator:

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -73,3 +73,35 @@ def test_new_does_not_scaffold_dead_config_routes(tmp_path, monkeypatch):
     project = tmp_path / "deadfile_check"
     assert (project / "fymo.yml").is_file()
     assert not (project / "config" / "routes.py").exists()
+
+
+def test_new_scaffolds_server_py_as_plain_wsgi_entrypoint(tmp_path, monkeypatch):
+    """Issue #26: server.py's `if __name__ == "__main__":` block called
+    run_dev_server(app) directly, a path that never set dev=True or
+    FYMO_DEV and bypassed fymo dev's watcher/esbuild/sidecar pipeline
+    entirely. Generated server.py is now just the WSGI entrypoint, for
+    handing to gunicorn/uwsgi or `fymo serve --prod`; `fymo dev` (or its
+    `fymo serve` alias) is the one true way to run it locally."""
+    monkeypatch.chdir(tmp_path)
+    create_project("myapp")
+    content = (tmp_path / "myapp" / "server.py").read_text()
+    assert "create_app" in content
+    assert "__main__" not in content
+    assert "run_dev_server" not in content
+
+
+def test_new_prints_fymo_dev_as_next_step(tmp_path, monkeypatch, capsys):
+    """Next-steps output should point at the command that's actually named
+    for what it does, not the alias."""
+    monkeypatch.chdir(tmp_path)
+    create_project("myapp")
+    out = capsys.readouterr().out
+    assert "fymo dev" in out
+
+
+def test_new_scaffolds_package_json_dev_script_using_fymo_dev(tmp_path, monkeypatch):
+    import json
+    monkeypatch.chdir(tmp_path)
+    create_project("myapp")
+    package_json = json.loads((tmp_path / "myapp" / "package.json").read_text())
+    assert package_json["scripts"]["dev"] == "fymo dev"

--- a/tests/server/test_prod_serve.py
+++ b/tests/server/test_prod_serve.py
@@ -1,4 +1,6 @@
 """Tests for the production server mode (`fymo serve --prod`)."""
+import sys
+
 import fymo.cli.commands.serve as serve_mod
 
 
@@ -35,9 +37,83 @@ def test_run_server_prod_dispatches_to_run_prod(tmp_path, monkeypatch):
 
     monkeypatch.setattr(serve_mod, "run_prod", fake_run_prod)
 
-    serve_mod.run_server(host="127.0.0.1", port=8123, reload=False, prod=True, workers=5)
+    serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=5)
 
     assert calls["host"] == "127.0.0.1"
     assert calls["port"] == 8123
     assert calls["workers"] == 5
     assert callable(calls["wsgi_app"])
+
+
+class _FakeSidecar:
+    """Stand-in for fymo.core.sidecar.Sidecar so FymoApp construction
+    doesn't need to spawn a real Node process for this CLI-level test."""
+
+    def __init__(self, dist_dir, timeout=30.0):
+        self.dist_dir = dist_dir
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def ping(self):
+        return True
+
+
+def test_run_server_prod_forces_dev_false_despite_stray_env(tmp_path, monkeypatch):
+    """Issue #26: a stray FYMO_DEV=1 left exported in the shell must not be
+    able to boot production in dev mode. `--prod` forces dev off *before*
+    server.py is imported -- not just at some point before run_server
+    returns -- so server.py's own `create_app(PROJECT_ROOT)` call (which
+    reads FYMO_DEV the same way a real scaffolded server.py does) resolves
+    dev=False too, not just the env var's final state."""
+    project_dir = tmp_path / "myproj"
+    project_dir.mkdir()
+    (project_dir / "dist" / "sidecar.mjs").parent.mkdir(parents=True, exist_ok=True)
+    (project_dir / "dist" / "sidecar.mjs").write_text("// stub, never actually spawned in this test\n")
+    (project_dir / "server.py").write_text(
+        "from pathlib import Path\n"
+        "from fymo import create_app\n"
+        "PROJECT_ROOT = Path(__file__).resolve().parent\n"
+        "app = create_app(PROJECT_ROOT)\n"
+    )
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("FYMO_DEV", "1")
+    monkeypatch.delitem(sys.modules, "server", raising=False)
+    monkeypatch.setattr("fymo.core.sidecar.Sidecar", _FakeSidecar)
+
+    calls = {}
+    monkeypatch.setattr(
+        serve_mod, "run_prod",
+        lambda wsgi_app, host, port, workers: calls.__setitem__("wsgi_app", wsgi_app),
+    )
+
+    try:
+        serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=2)
+        assert calls["wsgi_app"].dev is False
+    finally:
+        sys.modules.pop("server", None)
+
+
+def test_run_server_without_prod_delegates_to_run_dev(tmp_path, monkeypatch):
+    """Issue #26: bare `fymo serve` (no --prod) is now a straight alias for
+    `fymo dev`. The old path imported server.py and booted the wsgiref
+    server directly against whatever dev value was already baked into the
+    app object, with no watcher, no esbuild rebuild-on-save, no sidecar
+    hot-reload -- effectively a worse `fymo dev`."""
+    monkeypatch.chdir(tmp_path)
+
+    import fymo.cli.commands.dev as dev_mod
+    calls = {}
+
+    def fake_run_dev(host, port):
+        calls["host"] = host
+        calls["port"] = port
+
+    monkeypatch.setattr(dev_mod, "run_dev", fake_run_dev)
+
+    serve_mod.run_server(host="0.0.0.0", port=9001, prod=False)
+
+    assert calls == {"host": "0.0.0.0", "port": 9001}


### PR DESCRIPTION
## Summary

Fixes #26. Traced fymo dev / fymo serve / fymo serve --prod end to end and found none of them behaved the way their name promised:

- `fymo dev` never set `FYMO_DEV` or passed `dev=True` to `create_app()`, so it silently ran with production security defaults (no tracebacks, secure-only cookies, full rate limiting) unless `FYMO_DEV=1` was separately exported.
- `fymo serve` (no `--prod`) booted an entirely different, watcher-less path (import `server.py`, hand its app object to a plain wsgiref server), with a `--reload` flag that did nothing but print a warning.
- `fymo serve --prod` inherited whatever `dev` value `server.py`'s `create_app()` resolved from the shell's `FYMO_DEV`, so a stray exported `FYMO_DEV=1` could silently boot production in dev mode.

Changes:

- `fymo dev` sets `FYMO_DEV=1` and passes `dev=True` explicitly, first thing.
- `fymo serve --prod` forces `FYMO_DEV=0` before importing `server.py`, so it can't inherit a stray dev flag from the shell.
- Bare `fymo serve` (no `--prod`) is now a straight alias for `fymo dev`, rather than a separate, half-broken path. The issue explicitly left "kill vs. alias" as an open call — went with alias because `fymo new`'s printed next-steps, the scaffolded `package.json`'s `dev` script, and the README all already send new users to `fymo serve`; killing it would break that onboarding path for no benefit over aliasing.
- Removed the `--reload` flag (documented no-op) along with the wsgiref-against-`server.py` code path it belonged to, and the now-dead `run_dev_server()` helper.
- Generated `server.py` (from `fymo new`, plus both example apps) no longer has an `if __name__ == "__main__"` block — it bypassed the dev pipeline entirely and never set `dev=True`. It's now a plain WSGI entrypoint for gunicorn/uwsgi/`fymo serve --prod`.
- Scaffolding text, example apps, README, and deployment docs updated to point at `fymo dev` as the canonical name.

## Test plan

- [x] TDD: each behavior change has a test that was confirmed failing against the old code first (`tests/cli/test_dev.py`, `tests/cli/test_new.py`, `tests/server/test_prod_serve.py`)
- [x] Full suite green: 676 passed, 106 skipped, 0 failed
- [x] Real end-to-end verification against a live copy of the todo_app example (not just mocked units):
  - `fymo dev` with no `FYMO_SECRET` set auto-generated `.fymo/secret.key` and served a real request — proves dev mode was genuinely on
  - `fymo serve --prod` with a stray `FYMO_DEV=1` exported correctly refused to boot, demanding `FYMO_SECRET` — proves the leak is closed
  - bare `fymo serve` took the same dev path as `fymo dev`
- [x] Independent review pass completed; findings addressed (removed dead code, strengthened a timing-sensitive test to assert on a real `create_app()`-constructed app's `.dev` attribute instead of just the env var's final state, added a deployment.md callout about `server.py` customizations only applying under `--prod`)