### PR TITLE
Fix type coercion for ${VAR}-interpolated bool config values

### DIFF
--- a/fymo/build/hygiene.py
+++ b/fymo/build/hygiene.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 from typing import List
 
+from fymo.core.config import parse_bool
+
 _FRONTEND_ONLY_DIRS = ("templates", "components")
 
 
@@ -122,9 +124,9 @@ def check_remote_exposure_hygiene(project_root: Path, remote_config: "dict | Non
     this can never drift from what the manifest/router actually expose.
     """
     remote_config = remote_config or {}
-    if remote_config.get("explicit_optin", False):
+    if parse_bool(remote_config.get("explicit_optin", False), field="remote.explicit_optin"):
         return []
-    if remote_config.get("allow_implicit", False):
+    if parse_bool(remote_config.get("allow_implicit", False), field="remote.allow_implicit"):
         return []
 
     remote_dir = project_root / "app" / "remote"

--- a/fymo/core/config.py
+++ b/fymo/core/config.py
@@ -16,6 +16,32 @@ def env_truthy(name: str) -> bool:
     return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
 
 
+def parse_bool(value: Any, *, field: str) -> bool:
+    """Strictly coerce a fymo.yml config value to bool.
+
+    A value that flowed through ${VAR} interpolation is always a plain YAML
+    string (see _yaml_quote below), so a bare bool(value) downstream would
+    truthy-coerce any non-empty string -- including the string "false" --
+    to True. A real bool passes through unchanged (a literal true/false
+    YAML scalar untouched by interpolation, or a Python default like
+    `not dev`). A string is accepted only as "true"/"false", case- and
+    whitespace-insensitive. Anything else raises ConfigurationError naming
+    `field` and the value, instead of silently guessing -- deliberately
+    narrower than env_truthy above, which is fine defaulting an optional
+    dev flag to False on an unrecognized token but wrong here, where a
+    typo (e.g. "enabeld") should raise, not silently resolve to False.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+    raise ConfigurationError(f"{field} must be true or false, got {value!r}")
+
+
 # ${VAR} (required) or ${VAR:-default} (falls back when unset). Resolved on
 # the raw YAML text before yaml.safe_load parses it: the simplest correct
 # approach, and it applies uniformly to the whole file (any section, any

--- a/fymo/core/config.py
+++ b/fymo/core/config.py
@@ -21,12 +21,12 @@ def parse_bool(value: Any, *, field: str) -> bool:
 
     A value that flowed through ${VAR} interpolation is always a plain YAML
     string (see _yaml_quote below), so a bare bool(value) downstream would
-    truthy-coerce any non-empty string -- including the string "false" --
+    truthy-coerce any non-empty string, including the string "false",
     to True. A real bool passes through unchanged (a literal true/false
     YAML scalar untouched by interpolation, or a Python default like
     `not dev`). A string is accepted only as "true"/"false", case- and
     whitespace-insensitive. Anything else raises ConfigurationError naming
-    `field` and the value, instead of silently guessing -- deliberately
+    `field` and the value, instead of silently guessing. Deliberately
     narrower than env_truthy above, which is fine defaulting an optional
     dev flag to False on an unrecognized token but wrong here, where a
     typo (e.g. "enabeld") should raise, not silently resolve to False.

--- a/fymo/core/middleware.py
+++ b/fymo/core/middleware.py
@@ -42,6 +42,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
+from fymo.core.config import parse_bool
+
 
 # ---------------- Rate limiter ----------------
 
@@ -389,16 +391,16 @@ class MiddlewareSettings:
             # exhaust during ordinary local testing. Still fully overridable
             # either direction via an explicit `rate_limit.enabled` in
             # fymo.yml, in prod or in dev.
-            enabled=bool(rl.get("enabled", not dev)),
+            enabled=parse_bool(rl.get("enabled", not dev), field="limits.rate_limit.enabled"),
             default_rpm=int(rl.get("requests_per_minute", 60)),
             path_rules=path_rules,
-            trust_proxy=bool(rl.get("trust_proxy", False)),
+            trust_proxy=parse_bool(rl.get("trust_proxy", False), field="limits.rate_limit.trust_proxy"),
         )
 
         max_body_bytes = int((limits or {}).get("max_body_bytes", DEFAULT_MAX_BODY_BYTES))
 
         sec = (security or {}).get("headers", {}) or {}
-        security_enabled = bool(sec.get("enabled", True))
+        security_enabled = parse_bool(sec.get("enabled", True), field="security.headers.enabled")
         extra: List[Tuple[str, str]] = []
         for entry in sec.get("extra", []) or []:
             if isinstance(entry, (list, tuple)) and len(entry) == 2:

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Dict, Any, Optional
 
-from fymo.core.config import ConfigManager
+from fymo.core.config import ConfigManager, parse_bool
 from fymo.core.assets import AssetManager
 from fymo.core.template_renderer import TemplateRenderer
 from fymo.core.router import Router
@@ -136,7 +136,9 @@ class FymoApp:
         # (fymo/build/pipeline.py) — otherwise a function could be listed in
         # the client manifest but 404 at dispatch, or vice versa.
         remote_cfg = self.config_manager.get_remote_config()
-        _remote_router._explicit_optin = bool(remote_cfg.get("explicit_optin", False))
+        _remote_router._explicit_optin = parse_bool(
+            remote_cfg.get("explicit_optin", False), field="remote.explicit_optin"
+        )
 
         self.asset_manager = AssetManager(self.project_root)
         # App-level raw HTTP routes (e.g. hand-written media streaming),

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -205,7 +205,7 @@ class FymoApp:
         # appear in the manifest like any other remote function.
         self.auth_enabled = False
         auth_cfg = self.config_manager.get_auth_config()
-        if auth_cfg.get("enabled"):
+        if parse_bool(auth_cfg.get("enabled", False), field="auth.enabled"):
             self._init_auth(auth_cfg)
         # Mirror onto the renderer (constructed above, before auth_enabled was
         # known) so SSR only opens a request scope for apps that use auth --

--- a/fymo/remote/discovery.py
+++ b/fymo/remote/discovery.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from fymo.core.config import parse_bool
+
 
 def file_hash(path: Path) -> str:
     """Return a 12-char lowercase hex SHA-256 prefix of the file's contents."""
@@ -79,7 +81,7 @@ def discover_remote_modules(
     always ship regardless of the flag.
     """
     out: dict[str, dict[str, RemoteFunction]] = {}
-    explicit_optin = bool((remote_config or {}).get("explicit_optin", False))
+    explicit_optin = parse_bool((remote_config or {}).get("explicit_optin", False), field="remote.explicit_optin")
 
     remote_dir = project_root / "app" / "remote"
     if remote_dir.is_dir():

--- a/fymo/remote/discovery.py
+++ b/fymo/remote/discovery.py
@@ -102,7 +102,7 @@ def discover_remote_modules(
                 explicit_optin=explicit_optin,
             )
 
-    if auth_config and auth_config.get("enabled"):
+    if auth_config and parse_bool(auth_config.get("enabled", False), field="auth.enabled"):
         from fymo.auth.providers.registry import build_providers, system_remote_modules
         providers = build_providers(auth_config.get("providers"))
         for module_name, fns in system_remote_modules(providers).items():

--- a/journal/journal_013.md
+++ b/journal/journal_013.md
@@ -1,0 +1,125 @@
+# Journal Entry 013: The String That Was Always False
+
+**Date**: July 15, 2026
+**Focus**: A typing gap in fymo.yml's ${VAR} interpolation, and three quiet copies of the same bool bug it was hiding
+**Status**: Shipped
+
+## The Report
+
+Someone filed it as a small one: `port: ${PORT}` in fymo.yml doesn't
+become the int 8000, it becomes the string "8000". True, but not the
+interesting part. The interesting part was buried in the second sentence:
+"anywhere the config consumer expects a real number or bool, this'll
+break or silently misbehave depending what's downstream." I went looking
+for where that actually bites, and int() turned out fine everywhere, it
+fails loudly on garbage the same as it always has. bool() was the real
+problem, and it doesn't fail loudly. It doesn't fail at all.
+
+## Why This One Hides
+
+`bool("false")` is `True`. Every Python developer has tripped on this at
+least once and then forgotten about it, because it rarely shows up in
+code you'd actually write, nobody does `bool(some_string)` on purpose
+expecting string parsing. But that's exactly the shape rate_limit.enabled,
+trust_proxy, and security.headers.enabled were in: a dict lookup wrapped
+in bool(), written back when the only values that ever reached it were
+real YAML booleans or Python literal defaults. The interpolation feature
+landed later, in a completely different part of the file, and nothing
+connected the two. `rate_limit.enabled: ${RATE_LIMIT_ENABLED}` with
+`RATE_LIMIT_ENABLED=false` in the environment silently turns rate limiting
+*on* when someone asked for it off. No error, no warning, just the
+opposite of the config.
+
+I found the same shape twice more in the middleware settings: security.headers.enabled and trust_proxy. Three call sites in one file, one bug, written by three different moments of "this is obviously a bool, just cast it."
+
+## What I Didn't Do
+
+The obvious escape hatch is a type hint in the placeholder syntax, something
+like `${PORT:int}`. I thought about it for a while and put it down. The
+whole reason interpolated values are always quoted strings is a real
+security fix from a few months back, an env value with a newline and a
+fake YAML key in it used to be able to restructure the config file. Adding
+a second splice path for "trusted" types means maintaining two code paths
+through the exact code that fix closed off, for the benefit of skipping an
+explicit cast at a handful of call sites. Not worth it. The framework
+already has a working pattern for this: fymo/core/logging.py resolves its
+config with explicit string parsing and a fixed vocabulary, fails loud on
+anything it doesn't recognize. I wrote a `parse_bool` that does the same
+thing, real bool passes through, "true"/"false" strings parse, anything
+else raises naming the field.
+
+I also went looking for whether the same thing was true on the int side,
+since the bug report's own example was a port number, not a bool. It
+wasn't. Every int(...) cast on a config value in this codebase already
+fails loudly on a non-numeric string, which is the correct behavior, not
+a bug to fix. And the specific example in the report, port: ${PORT}, isn't
+actually reachable today: fymo.yml scaffolds a server: block in every new
+project, but nothing in ConfigManager has ever read it. I looked hard at
+whether to wire that up as part of this fix and decided against it, twice,
+for two different reasons. First, nobody asked for it, the bug report was
+about typing, not about making dead config live. Second, I checked open
+PRs before touching fymo/cli/main.py and found one already in flight
+rewriting the exact same serve/dev flag handling I would have touched.
+Two people editing the same option definitions with no coordination is
+how you get a conflict nobody wanted, over a feature nobody requested.
+Left it alone.
+
+## Where The Bug Actually Lived
+
+remote.explicit_optin looked like a one-line fix in server.py, the same
+shape as the middleware bugs. It wasn't. Before touching it I went
+looking for whether the fix belonged somewhere else entirely, since I
+knew there was unmerged work nearby touching this exact flag. There
+wasn't, not yet: the file that work was going to introduce doesn't exist
+on main. It's real code, reviewed and sitting ready in an open PR, but
+until that PR merges the config value still flows through the same old
+path it always has. Fixing the file that doesn't exist yet would have
+meant fabricating someone else's deliverable and guaranteeing a collision
+the moment their PR landed. Fixing the path that's actually live today was
+the only fix that was actually a fix.
+
+Then, checking the actual call sites instead of trusting my first grep,
+the bug turned out to be in three places, not one. server.py casts it
+with a bare bool(...). Two files over, the exact same flag gets read a
+second time to decide what goes in the built client manifest, also with a
+bare bool(...), independently, never sharing the cast with server.py's
+copy. And the build-time hygiene check that's supposed to catch unmarked
+functions reads the same flag a third time, plus a sibling flag,
+allow_implicit, with no cast at all, just a raw truthy check. Three
+readers of the same config key, three separate places for an interpolated
+"false" to quietly become "on." Fixing one and leaving the other two would
+have meant the manifest, the router, and the build check could each
+disagree about whether opt-in was active, which is its own bug independent
+of the string-coercion one, so all three got the same fix in the same
+pass instead of three separate ones later.
+
+## The One The Review Caught, Not Me
+
+I called it done after that and asked for a final pass over the whole
+branch before merging. It came back with a verdict of ready to merge, and
+one more thing I'd missed: auth.enabled has the exact same shape, read the
+same bare-truthy way in two places, server.py and the same discovery file
+as the opt-in flag. Higher stakes than any of the others, too, it gates
+whether the whole auth subsystem turns on at all. Nobody had caught it,
+not the original bug report, not my own research, not the first pass
+through server.py where I was staring directly at the sibling code fifty
+lines away.
+
+I'd already cut this branch back once for reaching past what was asked.
+Tempting to just fix it and move on since it was small and I was already
+in the file, but that's exactly the reasoning that got the scope too wide
+the first time, so I didn't. Reported it, named the two lines, said what
+it does, and waited. Got a yes. Then it was the same fix as every other
+one in this branch, same helper, same shape, done in the time it takes to
+write two tests.
+
+## The Count
+
+Zero failed, all previously-green tests still green, plus twenty-two new
+ones that exist specifically because they failed first, against the
+string "false" and a handful of deliberately garbage values, for the
+reason the fix was supposed to close.
+
+---
+
+*End of Journal Entry 013*

--- a/tests/build/test_remote_exposure_hygiene.py
+++ b/tests/build/test_remote_exposure_hygiene.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from fymo.core.exceptions import ConfigurationError
 from fymo.build.hygiene import check_remote_exposure_hygiene, format_remote_exposure_error
 
 
@@ -174,3 +175,43 @@ def test_format_remote_exposure_error_names_the_functions():
     assert "insert_version" in msg
     assert "app/remote/versions.py" in msg
     assert "allow_implicit" in msg
+
+
+def test_explicit_optin_string_false_from_interpolation_does_not_skip_the_check(tmp_path: Path):
+    """Regression for issue #30: a bare truthy check on an interpolated
+    remote.explicit_optin: ${VAR} would treat the resolved string "false"
+    as on and silently skip this check, the opposite of what was asked."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {"explicit_optin": "false"})
+    finally:
+        sys.path.remove(str(project))
+
+    assert len(violations) == 1
+    assert "insert_version" in violations[0]
+
+
+def test_allow_implicit_string_false_from_interpolation_does_not_skip_the_check(tmp_path: Path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/versions.py": MARKED_AND_UNMARKED,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        violations = check_remote_exposure_hygiene(project, {"allow_implicit": "false"})
+    finally:
+        sys.path.remove(str(project))
+
+    assert len(violations) == 1
+    assert "insert_version" in violations[0]
+
+
+def test_raises_configuration_error_on_garbage_explicit_optin(tmp_path: Path):
+    with pytest.raises(ConfigurationError, match="remote.explicit_optin"):
+        check_remote_exposure_hygiene(tmp_path, {"explicit_optin": "enabeld"})

--- a/tests/core/test_config_typed_values.py
+++ b/tests/core/test_config_typed_values.py
@@ -1,7 +1,7 @@
 """Tests for typed values flowing through fymo.yml.
 
 ${VAR} interpolation always produces a plain YAML string (see
-fymo.core.config._yaml_quote -- a deliberate anti-injection fix, not a
+fymo.core.config._yaml_quote, a deliberate anti-injection fix, not a
 typing decision), so a consumer that needs a real int/bool must cast
 explicitly instead of trusting the YAML type. See issue #30.
 """

--- a/tests/core/test_config_typed_values.py
+++ b/tests/core/test_config_typed_values.py
@@ -90,3 +90,48 @@ def test_fymo_app_explicit_optin_string_false_from_interpolation_resolves_false(
     with pytest.raises(RuntimeError, match="dist/ not found"):
         FymoApp(tmp_path, dev=True)
     assert remote_router._explicit_optin is False
+
+
+# ---------------- server.py auth.enabled wiring ----------------
+
+
+def test_fymo_app_auth_enabled_string_false_from_interpolation_stays_off(
+    tmp_path: Path, monkeypatch,
+):
+    """Regression for issue #30: auth.enabled: ${VAR} interpolating to the
+    string "false" must not run auth initialization. A bare truthy check
+    on auth_cfg.get("enabled") would treat any non-empty string as on.
+
+    _init_auth is monkeypatched to raise if called at all, since FymoApp's
+    __init__ raises on missing dist/ before returning, so there is no
+    instance left afterward to inspect a self.auth_enabled attribute on.
+    Whether _init_auth ran is the only observable signal here.
+    """
+    monkeypatch.setenv("FYMO_TEST_AUTH_ENABLED", "false")
+    _write_yml(
+        tmp_path,
+        "name: AuthTest\nroutes: {}\nauth:\n  enabled: ${FYMO_TEST_AUTH_ENABLED}\n",
+    )
+    from fymo.core.server import FymoApp
+
+    def _fail_if_called(self, auth_cfg):
+        raise AssertionError("auth should have stayed off")
+
+    monkeypatch.setattr(FymoApp, "_init_auth", _fail_if_called)
+
+    with pytest.raises(RuntimeError, match="dist/ not found"):
+        FymoApp(tmp_path, dev=True)
+
+
+def test_fymo_app_auth_enabled_raises_configuration_error_on_garbage(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setenv("FYMO_TEST_AUTH_ENABLED_GARBAGE", "enabeld")
+    _write_yml(
+        tmp_path,
+        "name: AuthTest\nroutes: {}\nauth:\n  enabled: ${FYMO_TEST_AUTH_ENABLED_GARBAGE}\n",
+    )
+    from fymo.core.server import FymoApp
+
+    with pytest.raises(ConfigurationError, match="auth.enabled"):
+        FymoApp(tmp_path, dev=True)

--- a/tests/core/test_config_typed_values.py
+++ b/tests/core/test_config_typed_values.py
@@ -58,3 +58,35 @@ def test_parse_bool_rejects_empty_string():
 def test_parse_bool_rejects_non_string_non_bool():
     with pytest.raises(ConfigurationError, match="rate_limit.enabled"):
         parse_bool(1, field="rate_limit.enabled")
+
+
+# ---------------- server.py explicit_optin wiring ----------------
+
+
+def test_fymo_app_explicit_optin_string_false_from_interpolation_resolves_false(
+    tmp_path: Path, monkeypatch,
+):
+    """Regression for issue #30: remote.explicit_optin: ${VAR} interpolates
+    to the plain string "false" (see fymo.core.config._yaml_quote); a bare
+    bool("false") would truthy-coerce this to True and silently enable the
+    dispatch gate the config asked to leave off.
+
+    FymoApp construction reaches _explicit_optin resolution well before it
+    needs dist/ (that check is the last thing __init__ does), so a bare
+    fymo.yml with an empty routes: section is enough to exercise this
+    without a real build. routes: {} avoids the router trying to treat the
+    whole fymo.yml as a routes mapping and choking on top-level scalar
+    keys, unrelated to this bug, just the minimal scaffolding FymoApp's
+    constructor needs to get as far as raising on the missing dist/.
+    """
+    monkeypatch.setenv("FYMO_TEST_EXPLICIT_OPTIN", "false")
+    _write_yml(
+        tmp_path,
+        "name: OptinTest\nroutes: {}\nremote:\n  explicit_optin: ${FYMO_TEST_EXPLICIT_OPTIN}\n",
+    )
+    from fymo.core.server import FymoApp
+    from fymo.remote import router as remote_router
+
+    with pytest.raises(RuntimeError, match="dist/ not found"):
+        FymoApp(tmp_path, dev=True)
+    assert remote_router._explicit_optin is False

--- a/tests/core/test_config_typed_values.py
+++ b/tests/core/test_config_typed_values.py
@@ -1,0 +1,60 @@
+"""Tests for typed values flowing through fymo.yml.
+
+${VAR} interpolation always produces a plain YAML string (see
+fymo.core.config._yaml_quote -- a deliberate anti-injection fix, not a
+typing decision), so a consumer that needs a real int/bool must cast
+explicitly instead of trusting the YAML type. See issue #30.
+"""
+from pathlib import Path
+
+import pytest
+
+from fymo.core.config import ConfigManager, parse_bool
+from fymo.core.exceptions import ConfigurationError
+
+
+def _write_yml(tmp_path: Path, text: str) -> None:
+    (tmp_path / "fymo.yml").write_text(text)
+
+
+# ---------------- parse_bool ----------------
+
+
+def test_parse_bool_passes_through_real_bool_true():
+    assert parse_bool(True, field="x") is True
+
+
+def test_parse_bool_passes_through_real_bool_false():
+    assert parse_bool(False, field="x") is False
+
+
+def test_parse_bool_accepts_true_string_case_and_whitespace_insensitive():
+    assert parse_bool("true", field="x") is True
+    assert parse_bool("TRUE", field="x") is True
+    assert parse_bool(" True ", field="x") is True
+
+
+def test_parse_bool_accepts_false_string_case_and_whitespace_insensitive():
+    assert parse_bool("false", field="x") is False
+    assert parse_bool("FALSE", field="x") is False
+    assert parse_bool(" False ", field="x") is False
+
+
+def test_parse_bool_rejects_yes_no():
+    with pytest.raises(ConfigurationError, match="rate_limit.enabled"):
+        parse_bool("yes", field="rate_limit.enabled")
+
+
+def test_parse_bool_rejects_numeric_strings():
+    with pytest.raises(ConfigurationError, match="rate_limit.enabled"):
+        parse_bool("1", field="rate_limit.enabled")
+
+
+def test_parse_bool_rejects_empty_string():
+    with pytest.raises(ConfigurationError, match="rate_limit.enabled"):
+        parse_bool("", field="rate_limit.enabled")
+
+
+def test_parse_bool_rejects_non_string_non_bool():
+    with pytest.raises(ConfigurationError, match="rate_limit.enabled"):
+        parse_bool(1, field="rate_limit.enabled")

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -372,7 +372,7 @@ def test_settings_skips_malformed_extra_headers():
 
 def test_rate_limit_enabled_string_false_from_interpolation_resolves_false():
     """fymo.yml values that flowed through ${VAR} interpolation are always
-    strings (see fymo.core.config._yaml_quote) -- a bare bool("false")
+    strings (see fymo.core.config._yaml_quote). A bare bool("false")
     would truthy-coerce this to True."""
     s = MiddlewareSettings.from_yaml(
         limits={"rate_limit": {"enabled": "false"}}, security={}, dev=False,

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -12,6 +12,7 @@ from fymo.core.middleware import (
     wrap_start_response,
     _TokenBucket,
 )
+from fymo.core.exceptions import ConfigurationError
 
 
 # ---------------- Token bucket ----------------
@@ -364,3 +365,37 @@ def test_settings_skips_malformed_extra_headers():
         security={"headers": {"extra": [["ok", "val"], "garbage", ["one-elem-only"]]}},
     )
     assert s.extra_security_headers == [("ok", "val")]
+
+
+# ---------------- Typed config values (issue #30) ----------------
+
+
+def test_rate_limit_enabled_string_false_from_interpolation_resolves_false():
+    """fymo.yml values that flowed through ${VAR} interpolation are always
+    strings (see fymo.core.config._yaml_quote) -- a bare bool("false")
+    would truthy-coerce this to True."""
+    s = MiddlewareSettings.from_yaml(
+        limits={"rate_limit": {"enabled": "false"}}, security={}, dev=False,
+    )
+    assert s.rate_limit_config.enabled is False
+
+
+def test_trust_proxy_string_false_from_interpolation_resolves_false():
+    s = MiddlewareSettings.from_yaml(
+        limits={"rate_limit": {"trust_proxy": "false"}}, security={},
+    )
+    assert s.rate_limit_config.trust_proxy is False
+
+
+def test_security_headers_enabled_string_false_from_interpolation_resolves_false():
+    s = MiddlewareSettings.from_yaml(
+        limits={}, security={"headers": {"enabled": "false"}},
+    )
+    assert s.security_headers_enabled is False
+
+
+def test_settings_raises_configuration_error_on_garbage_bool_string():
+    with pytest.raises(ConfigurationError, match="limits.rate_limit.enabled"):
+        MiddlewareSettings.from_yaml(
+            limits={"rate_limit": {"enabled": "enabeld"}}, security={},
+        )

--- a/tests/remote/test_discovery.py
+++ b/tests/remote/test_discovery.py
@@ -2,6 +2,7 @@
 import sys
 from pathlib import Path
 import pytest
+from fymo.core.exceptions import ConfigurationError
 from fymo.remote.discovery import discover_remote_modules, RemoteFunction
 
 
@@ -133,3 +134,18 @@ def test_module_hash_changes_with_source(tmp_path: Path):
         for name in list(sys.modules):
             if name.startswith("app."):
                 del sys.modules[name]
+
+
+def test_auth_enabled_string_false_from_interpolation_stays_off(tmp_path: Path):
+    """Regression for issue #30: auth.enabled: ${VAR} interpolates to the
+    plain string "false". A bare truthy check would treat that as on and
+    build auth provider remote modules nobody asked for. No app/remote/
+    directory needed here, an empty result proves the auth branch was
+    never entered (see test_returns_empty_when_no_remote_dir above for the
+    same no-directory baseline)."""
+    assert discover_remote_modules(tmp_path, auth_config={"enabled": "false"}) == {}
+
+
+def test_auth_enabled_raises_configuration_error_on_garbage(tmp_path: Path):
+    with pytest.raises(ConfigurationError, match="auth.enabled"):
+        discover_remote_modules(tmp_path, auth_config={"enabled": "enabeld"})

--- a/tests/remote/test_remote_optin.py
+++ b/tests/remote/test_remote_optin.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from fymo.core.exceptions import ConfigurationError
 from fymo.remote import devalue
 from fymo.remote.decorators import remote as remote_decorator
 from fymo.remote.discovery import discover_remote_modules, file_hash
@@ -91,6 +92,42 @@ def test_discovery_exposes_all_functions_when_optin_disabled_default(tmp_path):
 
     assert "marked" in result["posts"]
     assert "unmarked" in result["posts"]
+
+
+def test_discovery_string_false_from_interpolation_does_not_gate_like_true(tmp_path):
+    """Regression for issue #30: remote.explicit_optin: ${VAR} interpolates
+    to the plain string "false" (fymo.core.config._yaml_quote always
+    produces a string). A bare bool("false") would truthy-coerce this to
+    True and start gating on @remote markers nobody asked for."""
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": MODULE_SOURCE,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        result = discover_remote_modules(project, remote_config={"explicit_optin": "false"})
+    finally:
+        sys.path.remove(str(project))
+        _cleanup_app_modules()
+
+    assert "marked" in result["posts"]
+    assert "unmarked" in result["posts"]
+
+
+def test_discovery_raises_configuration_error_on_garbage_explicit_optin(tmp_path):
+    project = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/posts.py": MODULE_SOURCE,
+    })
+    sys.path.insert(0, str(project))
+    try:
+        with pytest.raises(ConfigurationError, match="remote.explicit_optin"):
+            discover_remote_modules(project, remote_config={"explicit_optin": "enabeld"})
+    finally:
+        sys.path.remove(str(project))
+        _cleanup_app_modules()
 
 
 # --- Router (dispatch time) --------------------------------------------------


### PR DESCRIPTION
## Summary

- `${VAR}` interpolation in `fymo.yml` always splices the resolved value back as a quoted YAML string (`_yaml_quote`, a deliberate anti-injection property, unchanged here). A bare `bool(...)` on an interpolated value truthy-coerces any non-empty string, including the string `"false"`, to `True`.
- Adds `parse_bool(value, *, field)` to `fymo/core/config.py`: a real bool passes through, `"true"`/`"false"` strings (case/whitespace-insensitive) parse, anything else raises `ConfigurationError` naming the field.
- Wires it into every live truthy-coercion site found: `middleware.py` (`rate_limit.enabled`, `trust_proxy`, `security.headers.enabled`), `server.py` + `discovery.py` + `hygiene.py` (`remote.explicit_optin`, `remote.allow_implicit`), and `server.py` + `discovery.py` (`auth.enabled`, the highest-stakes one, gates the whole auth subsystem).
- `int(...)` casts elsewhere were checked and are already safe (numeric strings cast fine, garbage fails loudly).
- Closes #30.

Scope note: an earlier draft of this branch also wired `fymo.yml`'s `server.host`/`server.port` into `fymo/cli/main.py` with CLI-flag precedence. Dropped entirely, not requested by the issue, and it collided with #37 which edits the same CLI commands concurrently.

## Test plan

- [x] `uv run pytest -q` — 787 passed, 10 skipped, 0 failed (baseline 765, 22 new regression tests, each written to fail against the pre-fix code first)
- [x] Every fixed site has a test proving the interpolated `"false"` string previously resolved wrong and now resolves correctly, plus a garbage-value test proving `ConfigurationError` is raised instead of silently guessing