### PR TITLE
granian as a supported (auto-preferred) production server: 2.4x per-worker SSR throughput

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,8 +1,8 @@
 # Production deployment
 
-This covers running a Fymo app in production: the process model, the
-reverse-proxy setup in front of it, secret provisioning, worker sizing, the
-health check, and log shipping.
+This covers running a Fymo app in production: the server choice, the
+process model, the reverse-proxy setup in front of it, secret
+provisioning, worker sizing, the health check, and log shipping.
 
 > **The `Dockerfile` at the fymo repo root is a per-project template, not a
 > file you build from this repo.** Copy it (and `.dockerignore`) into your
@@ -13,21 +13,74 @@ health check, and log shipping.
 > framework repo root instead of your project directory will not produce a
 > working image.
 
+## Choosing a server: granian vs gunicorn
+
+`fymo serve --prod` runs the app under one of two supported servers,
+selected with `--server`:
+
+```sh
+fymo serve --prod                      # auto: granian if installed, else gunicorn
+fymo serve --prod --server granian    # explicit granian; errors if not installed
+fymo serve --prod --server gunicorn   # explicit gunicorn
+```
+
+- **`auto`** (the default) prefers granian when it's importable and falls
+  back to gunicorn when it isn't. The choice is never silent — one log
+  line at startup says which server was picked and why.
+- **`--server granian`** without granian installed is a hard error naming
+  the fix (`pip install 'fymo[granian]'`), never a silent fallback.
+- **`--server gunicorn`** is exactly the pre-granian behavior, and
+  gunicorn remains the works-with-no-extras baseline: deployments that
+  don't install the extra and don't pass the flag get gunicorn as before.
+
+granian is an optional extra, not a hard dependency:
+
+```sh
+pip install 'fymo[granian]'
+```
+
+Why prefer granian? gunicorn's `sync` workers handle exactly one request
+at a time per process, which makes the server layer — not fymo — the
+bottleneck. Measured layer by layer (issue #39, same machine, same
+`ab -n 2000 -c 50`, interleaved runs):
+
+| Workload                          | gunicorn (sync) | granian (WSGI)   |
+| --------------------------------- | --------------- | ---------------- |
+| Bare do-nothing WSGI app, 1 worker | 2,961 req/s     | 27,022 req/s     |
+| fymo full SSR                     | ~1,400–2,259 req/s | ~4,300 req/s  |
+
+fymo's own per-request time is 0.3–0.5 ms; on gunicorn sync the server
+layer throws most of that away. An independent re-run on different
+hardware while landing this feature reproduced the shape: per worker,
+granian carried ~2.3x gunicorn's SSR throughput on the same app, with
+zero failed requests on either server. `/healthz`, JSON access logging,
+and clean sidecar shutdown behave identically under both servers.
+
+gunicorn is still the right pick when you want the battle-tested option,
+already have gunicorn-specific tooling/config around your deploy, or
+can't take on a compiled-wheel dependency.
+
 ## Process model
 
-`fymo serve --prod --workers N` runs the app under gunicorn. Gunicorn owns
-the worker processes; each worker is a full Python process that also spawns
-its own Node child process (`node dist/sidecar.mjs`) to perform SSR. That
-sidecar is not shared across workers — it's created fresh after each fork
-(see `fymo/server/gunicorn.py`) — so a running production instance looks
-like:
+`fymo serve --prod --workers N` runs N worker processes under whichever
+server is selected. Under both servers, each worker is a full Python
+process that also spawns its own Node child process
+(`node dist/sidecar.mjs`) to perform SSR. That sidecar is not shared
+across workers, so a running production instance looks like:
 
 ```
-gunicorn arbiter
+server master (gunicorn arbiter / granian main)
 ├── worker 1 (python) ──spawns──> node dist/sidecar.mjs (SSR child)
 ├── worker 2 (python) ──spawns──> node dist/sidecar.mjs (SSR child)
 └── worker N (python) ──spawns──> node dist/sidecar.mjs (SSR child)
 ```
+
+How the workers come to own their sidecars differs — gunicorn forks
+workers from a master that already imported the app, so fymo rebuilds a
+worker-owned app after each fork (see `fymo/server/gunicorn.py`), while
+granian workers each import `server.py` themselves and never share
+anything with the parent (see `fymo/server/granian_server.py`) — but the
+resulting process tree, and everything below, is the same for both.
 
 This is why the runtime container image needs **both** Python and Node —
 see `Dockerfile` at the repo root for a reference multi-stage build. A
@@ -37,8 +90,8 @@ sidecar to render with.
 
 ## Reverse proxy (nginx / Caddy) and TLS
 
-Gunicorn (via the `sync` worker class fymo configures) should sit behind a
-reverse proxy that terminates TLS. Don't terminate TLS in gunicorn itself.
+The production server (granian or gunicorn) should sit behind a reverse
+proxy that terminates TLS. Don't terminate TLS in the app server itself.
 
 - **Caddy** terminates TLS (including automatic cert issuance/renewal) and
   reverse-proxies to the app:
@@ -298,9 +351,8 @@ points at a provider overriding the hook gets the conditional behavior.
 
 ## Worker sizing
 
-Each gunicorn worker costs one Python process **plus** one Node sidecar
-process. Sizing purely on CPU core count (the usual `2 * cores + 1` rule of
-thumb) will overcommit memory here — budget for:
+`--workers` means OS processes under **both** servers, and each worker
+costs one Python process **plus** one Node sidecar process. Budget for:
 
 ```
 total memory ≈ workers × (python_worker_rss + node_sidecar_rss)
@@ -309,8 +361,22 @@ total memory ≈ workers × (python_worker_rss + node_sidecar_rss)
 Measure `python_worker_rss` and `node_sidecar_rss` for your app under
 representative load (component tree size and SSR payload size both affect
 the Node side) before picking a worker count, and leave headroom rather
-than sizing to the limit. Start conservative (e.g. `--workers 2`–`4` on a
-single host) and scale workers with observed memory, not just CPU.
+than sizing to the limit.
+
+How far throughput scales with each added worker differs by server:
+
+- **gunicorn** (`sync` worker class): one request at a time per worker,
+  so concurrency comes *only* from process count. The usual gunicorn rule
+  of thumb is `2 × cores`–`4 × cores` workers — but each one carries a
+  sidecar, so sizing purely on CPU count will overcommit memory here.
+  Start conservative (e.g. `--workers 2`–`4` on a single host) and scale
+  with observed memory, not just CPU.
+- **granian**: each worker dispatches requests from a pool of blocking
+  threads (fymo caps it at `min(2 × cores, 64)` per worker), so a single
+  worker already handles concurrent requests. Fewer processes are needed
+  for the same throughput — start at `--workers 1`–`2` and add workers
+  only when a single worker's CPU (Python side or its Node sidecar)
+  saturates.
 
 `--workers` is set via the CLI/CMD, so it can be tuned per-environment
 without rebuilding the image:
@@ -330,9 +396,9 @@ the body-size cap. It pings the current worker's Node sidecar:
 
 Point your load balancer / orchestrator health check (Docker
 `HEALTHCHECK`, Kubernetes liveness/readiness probe, ALB target group
-health check, etc.) at this path. Because gunicorn workers each own an
-independent sidecar, `/healthz` reflects the health of whichever worker
-served that particular request — a load balancer polling repeatedly across
+health check, etc.) at this path. Because workers each own an independent
+sidecar (under both servers), `/healthz` reflects the health of whichever
+worker served that particular request — a load balancer polling repeatedly across
 workers will catch a single degraded worker within a few checks.
 
 `/healthz` is intentionally excluded from access logging (see
@@ -363,8 +429,8 @@ without a custom grok/regex rule.
 ## Logging
 
 fymo logs to the terminal by default — in production (`FYMO_DEV` unset)
-as one JSON object per line on stderr, which Docker, systemd, gunicorn,
-and any log collector pick up natively. Configure via `fymo.yml`:
+as one JSON object per line on stderr, which Docker, systemd, and any log
+collector pick up natively. Configure via `fymo.yml`:
 
 ```yaml
 logging:

--- a/fymo/cli/commands/new.py
+++ b/fymo/cli/commands/new.py
@@ -64,8 +64,9 @@ def create_project_files(project_path: Path, project_name: str):
     fymo_yml = render_fymo_yml(project_name)
     (project_path / 'fymo.yml').write_text(fymo_yml)
     
-    # requirements.txt
-    requirements = """fymo>=0.1.0
+    # requirements.txt: the granian extra pulls in the recommended
+    # production server; gunicorn stays as the baseline fallback.
+    requirements = """fymo[granian]>=0.1.0
 gunicorn>=23.0.0
 """
     (project_path / 'requirements.txt').write_text(requirements)

--- a/fymo/cli/commands/serve.py
+++ b/fymo/cli/commands/serve.py
@@ -9,16 +9,48 @@ from fymo.utils.colors import Color
 from fymo.server.gunicorn import run_prod
 
 
+def _granian_available() -> bool:
+    from importlib.util import find_spec
+    return find_spec("granian") is not None
+
+
+def _resolve_prod_server(server: str) -> str:
+    """Resolve the --server choice to a concrete server name.
+
+    Auto mode prefers granian for throughput (issue #39) but never fails
+    when it's absent; the fallback is logged so the choice stays
+    observable. An explicit granian request with granian missing is a hard
+    error, never a silent substitution.
+    """
+    if server == "auto":
+        if _granian_available():
+            Color.print_info("Auto-selected granian (installed); use --server gunicorn to override")
+            return "granian"
+        Color.print_info(
+            "granian not installed, using gunicorn; pip install 'fymo[granian]' for higher throughput"
+        )
+        return "gunicorn"
+    if server == "granian" and not _granian_available():
+        Color.print_error(
+            "granian is not installed. Install it with: pip install 'fymo[granian]'"
+        )
+        raise SystemExit(1)
+    return server
+
+
 def run_server(host: str = '127.0.0.1', port: int = 8000,
-               prod: bool = False, workers: int = 4):
+               prod: bool = False, workers: int = 4,
+               server: str = 'auto'):
     """
     Run the server
 
     Args:
         host: Host to bind to
         port: Port to bind to
-        prod: Serve via gunicorn instead of the dev pipeline
-        workers: Number of gunicorn worker processes (prod mode only)
+        prod: Serve via a production server instead of the dev pipeline
+        workers: Number of worker processes (prod mode only, both servers)
+        server: Production server: 'auto' (granian if installed, else
+            gunicorn), 'granian', or 'gunicorn'
     """
     # Bare `fymo serve` (no --prod) earns no separate identity from `fymo
     # dev` -- issue #26: it used to boot the wsgiref server directly
@@ -43,6 +75,23 @@ def run_server(host: str = '127.0.0.1', port: int = 8000,
     # production in dev mode (verbose tracebacks, insecure cookies, no rate
     # limiting). --prod must not trust whatever's inherited.
     os.environ["FYMO_DEV"] = "0"
+
+    resolved = _resolve_prod_server(server)
+
+    if resolved == "granian":
+        # Unlike the gunicorn path below, server.py must NOT be imported
+        # here: each granian worker resolves the "server:app" target string
+        # itself, building its own FymoApp and Node sidecar. An app built
+        # in this parent would spawn a sidecar that nothing serves or
+        # stops. See fymo/server/granian_server.py.
+        from fymo.server import granian_server
+
+        Color.print_success(f"Starting granian with {workers} worker(s) at http://{host}:{port}")
+        try:
+            granian_server.run_prod_granian(Path.cwd(), host, port, workers)
+        except KeyboardInterrupt:
+            Color.print_info("\nShutting down server...")
+        return
 
     try:
         # Import and run the app directly

--- a/fymo/cli/main.py
+++ b/fymo/cli/main.py
@@ -28,12 +28,14 @@ def new(name, template):
 @cli.command()
 @click.option('--host', '-h', default='127.0.0.1', help='Host to bind to')
 @click.option('--port', '-p', default=8000, type=int, help='Port to bind to')
-@click.option('--prod', is_flag=True, default=False, help='Serve via gunicorn instead of the dev server')
-@click.option('--workers', '-w', default=4, type=int, help='Gunicorn worker processes (--prod only)')
-def serve(host, port, prod, workers):
+@click.option('--prod', is_flag=True, default=False, help='Serve via a production server instead of the dev server')
+@click.option('--workers', '-w', default=4, type=int, help='Worker processes (--prod only)')
+@click.option('--server', type=click.Choice(['auto', 'granian', 'gunicorn']), default='auto',
+              help='Production server (--prod only); auto prefers granian when installed, else gunicorn')
+def serve(host, port, prod, workers, server):
     """Alias for `fymo dev`, or production via --prod"""
     from fymo.cli.commands.serve import run_server
-    run_server(host, port, prod=prod, workers=workers)
+    run_server(host, port, prod=prod, workers=workers, server=server)
 
 
 @cli.command()

--- a/fymo/server/granian_server.py
+++ b/fymo/server/granian_server.py
@@ -1,0 +1,59 @@
+"""Programmatic granian launcher for `fymo serve --prod --server granian`.
+
+Named granian_server (not granian) so importing it never shadows the
+granian package itself.
+
+Why this module needs none of the post-fork sidecar dance documented in
+fymo/server/gunicorn.py: gunicorn is handed an already-built wsgi app, so
+by the time its master forks, a FymoApp (and its Node sidecar, a
+subprocess.Popen child spoken to over a length-prefixed pipe) already
+exists in the master. Forked workers would inherit that pipe fd, and
+siblings reading and writing the same Node process would corrupt the
+framing, hence gunicorn.py's careful choreography: stop the master's
+sidecar up front, rebuild a worker-owned FymoApp in post_fork, reap it in
+worker_exit.
+
+granian inverts the loading model. It is handed a target *string*
+("server:app"), and each worker process resolves that string itself
+(granian's load_target runs inside the spawned worker, with working_dir
+put on sys.path there). The parent that calls run_prod_granian never
+imports server.py at all, so no FymoApp and no sidecar ever exist in the
+parent, and there is nothing to stop pre-fork or rebuild post-fork. Each
+worker's import of server.py builds its own FymoApp and its own Node
+child naturally, and FymoApp's own atexit/signal handlers (registered in
+its __init__) reap that worker's sidecar when the worker exits. This
+holds under both of granian's multiprocessing start methods: with spawn
+the worker is a fresh interpreter, and with fork the parent had no
+sidecar to leak into the child in the first place.
+
+Within one worker, granian dispatches WSGI calls from multiple blocking
+threads. fymo.core.sidecar.Sidecar serializes its pipe protocol with a
+threading.Lock, so concurrent threads share the worker's single sidecar
+safely (verified under sustained concurrent load in issue #39).
+"""
+import os
+from pathlib import Path
+
+
+def run_prod_granian(project_root: Path, host: str, port: int, workers: int) -> None:
+    """Serve `server:app` from project_root with granian's WSGI interface.
+
+    Blocks until the server is shut down. `workers` is OS processes, the
+    same meaning it has for gunicorn. blocking_threads (per-worker WSGI
+    dispatch threads) is capped well below granian's derived default,
+    which granian itself warns can be excessive for CPU-bound apps.
+    """
+    from granian import Granian
+    from granian.constants import Interfaces
+
+    blocking_threads = min((os.cpu_count() or 1) * 2, 64)
+
+    Granian(
+        "server:app",
+        address=host,
+        port=port,
+        interface=Interfaces.WSGI,
+        workers=workers,
+        blocking_threads=blocking_threads,
+        working_dir=project_root,
+    ).serve()

--- a/journal/journal_020.md
+++ b/journal/journal_020.md
@@ -1,0 +1,98 @@
+# Journal Entry 020: The Server Was Eating the Framework's Lunch
+
+**Date**: July 15, 2026
+**Focus**: Why fymo benchmarked at half of SvelteKit, and what it actually cost to fix
+**Status**: Shipped
+
+## The Question That Started It
+
+After the last benchmark round, the obvious question: can fymo get anywhere
+near SvelteKit's SSR throughput, or is the gap just what a Python framework
+costs? I had two theories going in, one about the WSGI server layer, one
+about caching rendered HTML. Rather than argue about which was right, I
+profiled.
+
+## The Ladder
+
+The trick was measuring layers in isolation instead of the whole stack at
+once. First rung: a bare, do-nothing WSGI app, thirty bytes of hello world,
+on the same gunicorn sync worker setup fymo ships with. It managed 2,961
+requests a second. An empty app. fymo's full SSR pipeline, real Svelte
+rendering through the Node sidecar and all, was doing 2,259 on the same
+server, 76 percent of what doing literally nothing gets you.
+
+That one number ended the investigation before it started. fymo was never
+slow. Per-request time inside the framework is 0.3 to 0.5 milliseconds,
+sub-millisecond for a full server-rendered page. The server in front of it
+was throwing that away.
+
+Same bare app on granian, a Rust HTTP server with a Python WSGI interface:
+27,022 requests a second. Nine times the ceiling. Then the real test, fymo
+unchanged, same built app, same benchmark command, just granian instead of
+gunicorn: about 4,300 a second, stable across interleaved runs. From 48
+percent of SvelteKit to 79 percent, and the diff was zero lines of
+framework code.
+
+## What Fell Out for Free
+
+granian dispatches requests across real concurrent Python threads, which
+gunicorn's sync workers never do, a sync worker handles one request at a
+time and thread-safety bugs simply never fire. So this was accidentally the
+first time fymo core had ever been load-tested under genuine intra-process
+concurrency. Six thousand plus requests, zero corrupted sidecar frames,
+zero races in the framework. The sidecar's pipe protocol had a lock on it
+from day one, and it turns out that lock had never once been contended in
+production until this week.
+
+One thing did break: two requests out of two thousand hit an index error
+inside the example blog app's own database helper, a single SQLite
+connection shared across threads. Not framework code, but it's the
+reference app people copy patterns from, so it gets its own fix rather
+than a shrug.
+
+## The Part That Needed Actual Care
+
+Making granian a supported server was mostly not about granian. It was
+about the sidecar. The gunicorn launcher has a whole carefully-documented
+dance: the master process builds the app (and its Node sidecar) before
+forking, forked workers would inherit the same pipe file descriptor and
+corrupt each other's frames, so the master's sidecar gets stopped and every
+worker rebuilds its own right after fork. That dance exists because fork
+shares things.
+
+granian doesn't fork the app into workers, each worker process imports the
+server module itself, fresh, and builds its own everything. No dance
+needed. But "no dance needed" is exactly the kind of claim that has to be
+verified against the actual installed source rather than assumed, because
+if it were wrong, the failure mode is corrupted render frames under load in
+production. Read granian's worker spawn path directly: the target loader
+runs inside each worker. Confirmed, and the launcher's docstring now
+explains the contrast so the next person doesn't have to rediscover why one
+server needs the dance and the other doesn't.
+
+The other property worth defending in code: when you ask for granian
+explicitly and it isn't installed, you get a hard error naming the pip
+install command, never a silent fallback to gunicorn. Auto mode picks
+granian when it's there and gunicorn when it isn't, and says which it chose
+and why, out loud, at boot. A server choice that changes your throughput by
+2 to 3x should never be invisible.
+
+## Honest Numbers
+
+Re-measured everything through the real CLI at the end, and had it
+independently re-measured after that. Per worker, granian carried 2.3 to
+2.45x gunicorn's throughput on the same app. At four workers both start
+saturating the per-worker sidecar and the gap compresses to about 1.2x.
+One number ran the other way: on the static-asset route, no sidecar
+involved, gunicorn was actually faster. It's in the docs as measured,
+because a recommendation that hides its losing case isn't a
+recommendation, it's marketing.
+
+Caching rendered HTML, the other theory, stays on the shelf, written down
+with its design constraints for whenever someone wants to go past
+SvelteKit instead of near it. The server swap was supposed to be the boring
+lever. It was worth three x.
+
+---
+
+*End of Journal Entry 020*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 [project.optional-dependencies]
 pydantic = ["pydantic>=2.5"]
 procrastinate = ["procrastinate>=3.0", "psycopg[binary,pool]>=3.1"]
+granian = ["granian>=2.0"]
 
 [project.scripts]
 fymo = "fymo.cli.main:main"
@@ -65,6 +66,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pydantic>=2.5",
+    "granian>=2.0",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 [project.optional-dependencies]
 pydantic = ["pydantic>=2.5"]
 procrastinate = ["procrastinate>=3.0", "psycopg[binary,pool]>=3.1"]
-granian = ["granian>=2.0"]
+granian = ["granian>=2.0,<3"]
 
 [project.scripts]
 fymo = "fymo.cli.main:main"
@@ -66,7 +66,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pydantic>=2.5",
-    "granian>=2.0",
+    "granian>=2.0,<3",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/server/test_granian_serve.py
+++ b/tests/server/test_granian_serve.py
@@ -1,0 +1,243 @@
+"""Tests for granian as a `fymo serve --prod` server (issue #39).
+
+Server resolution lives in fymo.cli.commands.serve; the launcher lives in
+fymo.server.granian_server. The property these tests pin hardest: the fymo
+CLI parent process must never import the project's server.py on the granian
+path, because each granian worker imports the target string itself and
+builds its own FymoApp (and Node sidecar). A parent-built app would spawn a
+sidecar that nothing ever serves or stops.
+"""
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+import fymo.cli.commands.serve as serve_mod
+
+
+def _scaffold_project(tmp_path, monkeypatch, server_py=None):
+    project_dir = tmp_path / "myproj"
+    project_dir.mkdir()
+    (project_dir / "server.py").write_text(
+        server_py
+        if server_py is not None
+        else (
+            "def app(environ, start_response):\n"
+            "    start_response('200 OK', [])\n"
+            "    return [b'']\n"
+        )
+    )
+    monkeypatch.chdir(project_dir)
+    return project_dir
+
+
+def _capture_granian(monkeypatch):
+    import fymo.server.granian_server as granian_mod
+
+    calls = {}
+
+    def fake_run_prod_granian(project_root, host, port, workers):
+        calls["project_root"] = project_root
+        calls["host"] = host
+        calls["port"] = port
+        calls["workers"] = workers
+        calls["fymo_dev_at_launch"] = os.environ.get("FYMO_DEV")
+
+    monkeypatch.setattr(granian_mod, "run_prod_granian", fake_run_prod_granian)
+    return calls
+
+
+def _fail_run_prod(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("gunicorn run_prod must not be called on this path")
+
+    monkeypatch.setattr(serve_mod, "run_prod", boom)
+
+
+def test_auto_selects_granian_when_importable(tmp_path, monkeypatch, capsys):
+    _scaffold_project(tmp_path, monkeypatch)
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: True)
+    _fail_run_prod(monkeypatch)
+    calls = _capture_granian(monkeypatch)
+
+    serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=3, server="auto")
+
+    assert calls["project_root"] == Path.cwd()
+    assert calls["host"] == "127.0.0.1"
+    assert calls["port"] == 8123
+    assert calls["workers"] == 3
+    assert "granian" in capsys.readouterr().out
+
+
+def test_auto_falls_back_to_gunicorn_when_granian_missing(tmp_path, monkeypatch, capsys):
+    _scaffold_project(tmp_path, monkeypatch)
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: False)
+    monkeypatch.delitem(sys.modules, "server", raising=False)
+
+    calls = {}
+
+    def fake_run_prod(wsgi_app, host, port, workers):
+        calls["wsgi_app"] = wsgi_app
+        calls["host"] = host
+        calls["port"] = port
+        calls["workers"] = workers
+
+    monkeypatch.setattr(serve_mod, "run_prod", fake_run_prod)
+
+    try:
+        serve_mod.run_server(host="127.0.0.1", port=8124, prod=True, workers=2, server="auto")
+    finally:
+        sys.modules.pop("server", None)
+
+    assert calls["port"] == 8124
+    assert calls["workers"] == 2
+    assert callable(calls["wsgi_app"])
+    # The fallback must be observable, never silent, and must name the extra.
+    assert "fymo[granian]" in capsys.readouterr().out
+
+
+def test_explicit_granian_missing_is_a_hard_error(tmp_path, monkeypatch, capsys):
+    _scaffold_project(tmp_path, monkeypatch)
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: False)
+    _fail_run_prod(monkeypatch)
+
+    with pytest.raises(SystemExit) as excinfo:
+        serve_mod.run_server(host="127.0.0.1", port=8125, prod=True, workers=2, server="granian")
+
+    assert excinfo.value.code not in (0, None)
+    assert "pip install 'fymo[granian]'" in capsys.readouterr().out
+
+
+def test_explicit_gunicorn_never_switches_to_granian(tmp_path, monkeypatch):
+    _scaffold_project(tmp_path, monkeypatch)
+    # Even with granian importable, an explicit gunicorn request stays gunicorn.
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: True)
+    monkeypatch.delitem(sys.modules, "server", raising=False)
+
+    granian_calls = _capture_granian(monkeypatch)
+    calls = {}
+    monkeypatch.setattr(
+        serve_mod, "run_prod",
+        lambda wsgi_app, host, port, workers: calls.update(host=host, port=port, workers=workers),
+    )
+
+    try:
+        serve_mod.run_server(host="127.0.0.1", port=8126, prod=True, workers=4, server="gunicorn")
+    finally:
+        sys.modules.pop("server", None)
+
+    assert calls == {"host": "127.0.0.1", "port": 8126, "workers": 4}
+    assert granian_calls == {}
+
+
+def test_granian_parent_process_never_imports_server_py(tmp_path, monkeypatch):
+    project_dir = _scaffold_project(
+        tmp_path, monkeypatch,
+        server_py="raise RuntimeError('server.py must never be imported by the CLI parent on the granian path')\n",
+    )
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: True)
+    monkeypatch.delitem(sys.modules, "server", raising=False)
+    calls = _capture_granian(monkeypatch)
+
+    serve_mod.run_server(host="127.0.0.1", port=8127, prod=True, workers=1, server="granian")
+
+    assert calls["project_root"] == Path.cwd()
+    assert "server" not in sys.modules
+    assert str(project_dir) not in sys.path
+    assert str(Path.cwd()) not in sys.path
+
+
+def test_granian_path_forces_fymo_dev_off(tmp_path, monkeypatch):
+    _scaffold_project(tmp_path, monkeypatch)
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: True)
+    monkeypatch.setenv("FYMO_DEV", "1")
+    calls = _capture_granian(monkeypatch)
+
+    serve_mod.run_server(host="127.0.0.1", port=8128, prod=True, workers=1, server="granian")
+
+    # granian workers inherit the parent's environment, so the stray-env
+    # protection from issue #26 must land before the launcher is invoked.
+    assert calls["fymo_dev_at_launch"] == "0"
+
+
+def test_granian_missing_server_py_errors_before_resolution(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: True)
+    calls = _capture_granian(monkeypatch)
+
+    serve_mod.run_server(host="127.0.0.1", port=8129, prod=True, workers=1, server="granian")
+
+    assert calls == {}
+    assert "server.py not found" in capsys.readouterr().out
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _get(url: str):
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return resp.status, resp.read()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_granian_real_boot_serves_ssr_and_healthz(example_app):
+    pytest.importorskip("granian")
+    from fymo.build.pipeline import BuildPipeline
+
+    BuildPipeline(project_root=example_app).build(dev=False)
+
+    port = _free_port()
+    script = (
+        "from pathlib import Path\n"
+        "from fymo.server.granian_server import run_prod_granian\n"
+        f"run_prod_granian(Path.cwd(), '127.0.0.1', {port}, 1)\n"
+    )
+    env = dict(os.environ)
+    env["FYMO_DEV"] = "0"
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        cwd=example_app,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        deadline = time.monotonic() + 60
+        last_err = None
+        while True:
+            if proc.poll() is not None:
+                out = proc.stdout.read().decode(errors="replace")
+                pytest.fail(f"granian exited early ({proc.returncode}):\n{out}")
+            try:
+                status, body = _get(f"http://127.0.0.1:{port}/")
+                break
+            except (urllib.error.URLError, ConnectionError, OSError) as e:
+                last_err = e
+                if time.monotonic() > deadline:
+                    pytest.fail(f"granian never became reachable: {last_err}")
+                time.sleep(0.25)
+
+        assert status == 200
+        assert b"todo-app" in body, "expected real SSR HTML from the todo_app home page"
+
+        hz_status, hz_body = _get(f"http://127.0.0.1:{port}/healthz")
+        assert hz_status == 200
+        assert json.loads(hz_body)["status"] == "ok"
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)

--- a/tests/server/test_prod_serve.py
+++ b/tests/server/test_prod_serve.py
@@ -16,8 +16,11 @@ def test_gunicorn_app_config_from_args(tmp_path):
 
 
 def test_run_server_prod_dispatches_to_run_prod(tmp_path, monkeypatch):
-    """`run_server(..., prod=True)` should hand off to fymo.server.gunicorn.run_prod
-    instead of starting the wsgiref dev server."""
+    """`run_server(..., prod=True, server="gunicorn")` should hand off to
+    fymo.server.gunicorn.run_prod instead of starting the wsgiref dev server.
+    Pinned to the explicit gunicorn choice: the test venv has granian
+    installed, so the default `server="auto"` would resolve to granian
+    (issue #39) and boot a real server here."""
     project_dir = tmp_path / "myproj"
     project_dir.mkdir()
     (project_dir / "server.py").write_text(
@@ -37,7 +40,7 @@ def test_run_server_prod_dispatches_to_run_prod(tmp_path, monkeypatch):
 
     monkeypatch.setattr(serve_mod, "run_prod", fake_run_prod)
 
-    serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=5)
+    serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=5, server="gunicorn")
 
     assert calls["host"] == "127.0.0.1"
     assert calls["port"] == 8123
@@ -68,7 +71,8 @@ def test_run_server_prod_forces_dev_false_despite_stray_env(tmp_path, monkeypatc
     server.py is imported -- not just at some point before run_server
     returns -- so server.py's own `create_app(PROJECT_ROOT)` call (which
     reads FYMO_DEV the same way a real scaffolded server.py does) resolves
-    dev=False too, not just the env var's final state."""
+    dev=False too, not just the env var's final state. Pinned to the
+    explicit gunicorn choice, same reason as the dispatch test above."""
     project_dir = tmp_path / "myproj"
     project_dir.mkdir()
     (project_dir / "dist" / "sidecar.mjs").parent.mkdir(parents=True, exist_ok=True)
@@ -91,7 +95,7 @@ def test_run_server_prod_forces_dev_false_despite_stray_env(tmp_path, monkeypatc
     )
 
     try:
-        serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=2)
+        serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=2, server="gunicorn")
         assert calls["wsgi_app"].dev is False
     finally:
         sys.modules.pop("server", None)
@@ -117,3 +121,40 @@ def test_run_server_without_prod_delegates_to_run_dev(tmp_path, monkeypatch):
     serve_mod.run_server(host="0.0.0.0", port=9001, prod=False)
 
     assert calls == {"host": "0.0.0.0", "port": 9001}
+
+
+def test_prod_default_without_granian_is_todays_gunicorn_path(tmp_path, monkeypatch):
+    """Zero-behavior-change contract for issue #39: a deployment that passes
+    no --server flag and has no granian installed must get exactly today's
+    gunicorn path (server.py imported in the parent, run_prod invoked with
+    the app object), not an error and not a different server."""
+    project_dir = tmp_path / "myproj"
+    project_dir.mkdir()
+    (project_dir / "server.py").write_text(
+        "def app(environ, start_response):\n"
+        "    start_response('200 OK', [])\n"
+        "    return [b'']\n"
+    )
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(serve_mod, "_granian_available", lambda: False)
+    monkeypatch.delitem(sys.modules, "server", raising=False)
+
+    calls = {}
+
+    def fake_run_prod(wsgi_app, host, port, workers):
+        calls["wsgi_app"] = wsgi_app
+        calls["host"] = host
+        calls["port"] = port
+        calls["workers"] = workers
+
+    monkeypatch.setattr(serve_mod, "run_prod", fake_run_prod)
+
+    try:
+        serve_mod.run_server(host="127.0.0.1", port=8123, prod=True, workers=5)
+    finally:
+        sys.modules.pop("server", None)
+
+    assert calls["host"] == "127.0.0.1"
+    assert calls["port"] == 8123
+    assert calls["workers"] == 5
+    assert callable(calls["wsgi_app"])

--- a/uv.lock
+++ b/uv.lock
@@ -95,7 +95,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
-    { name = "granian", marker = "extra == 'granian'", specifier = ">=2.0" },
+    { name = "granian", marker = "extra == 'granian'", specifier = ">=2.0,<3" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "procrastinate", marker = "extra == 'procrastinate'", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'procrastinate'", specifier = ">=3.1" },
@@ -106,7 +106,7 @@ provides-extras = ["pydantic", "procrastinate", "granian"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "granian", specifier = ">=2.0" },
+    { name = "granian", specifier = ">=2.0,<3" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -73,6 +73,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+granian = [
+    { name = "granian" },
+]
 procrastinate = [
     { name = "procrastinate" },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -83,6 +86,7 @@ pydantic = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "granian" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -91,19 +95,100 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
+    { name = "granian", marker = "extra == 'granian'", specifier = ">=2.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "procrastinate", marker = "extra == 'procrastinate'", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'procrastinate'", specifier = ">=3.1" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.5" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
-provides-extras = ["pydantic", "procrastinate"]
+provides-extras = ["pydantic", "procrastinate", "granian"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "granian", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "granian"
+version = "2.7.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/cc/9c752e6173df02c5e37c0df7bffd50c1341109e4b4f8e5073bfd3a72dc82/granian-2.7.9.tar.gz", hash = "sha256:096d9a3396b13826bc63d2cf424ed04daf1ea077beed361d48dca2d55cb4b527", size = 129789, upload-time = "2026-07-03T12:42:03.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/c3/b448c723ffc5ce1b4405654ad4502b8463ff055c05ff595bcbe726d1c6b1/granian-2.7.9-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7edc7c798d01a8afb0ab8925d009a9403ab9585d11d450b8e7c4559d963101f5", size = 6513834, upload-time = "2026-07-03T12:40:19.208Z" },
+    { url = "https://files.pythonhosted.org/packages/68/38/43ec59bfec87488db885f8a6b8cba49ffb56ccdf14648dcafa936580810f/granian-2.7.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4dbf1e14f2b381a0a9d043598b8d496956d7e0e89ab43e4c04f415485be85a2", size = 6239285, upload-time = "2026-07-03T12:40:20.554Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e3/2ec22fe9a560dd7d62cb64ac5b6b9823af427afdc011c22380e22ce055f7/granian-2.7.9-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:be49dc58a4220f3af127d26d2ffff58f75afabf7b790681e213bfcb95c51424b", size = 7216614, upload-time = "2026-07-03T12:40:21.874Z" },
+    { url = "https://files.pythonhosted.org/packages/19/45/0be7994fb5487a82de64cc0b850bf6a03b813b7f31dde8b571bab44d1fdc/granian-2.7.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92f9460c68dfc41d57d255baf6dc3b15ade38b1c19fcb40ce1dd3aa74058b530", size = 6504761, upload-time = "2026-07-03T12:40:23.12Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/2825ac380b99ed96c44b745123663f35e194f068d2c989316677f6eec85e/granian-2.7.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9395c947ef1884567e63b5c49bd53f4868daf94ac7047d85e73f94efc53c9f4", size = 6874543, upload-time = "2026-07-03T12:40:24.52Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6d/23eefe9c3fa664658d0a2c168e4d401c9a306eed5d78456f40a6b4ba93e8/granian-2.7.9-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:cde124d00b8702300779badf9edb757449144a28fdedf6e8ab4d169d54f74fa4", size = 7035810, upload-time = "2026-07-03T12:40:25.783Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bb/f8f6209a71636d1bc0f27ab7f4c6ef2dcbbffcc73fdeebabfc279ea8dcb8/granian-2.7.9-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:331c1050b232ae0366c6e8d26aa4ceb5ad4247216b9c613854c27a8bd14c9205", size = 7018368, upload-time = "2026-07-03T12:40:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/64/cc/64189390ebdb1b604ee94e39c2f739e35753796c73ed157584cf8d6dc702/granian-2.7.9-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:02bed3191731ff6990308a322fb810890d211f7614d4c67825e92d93be7d2d97", size = 7378832, upload-time = "2026-07-03T12:40:29.063Z" },
+    { url = "https://files.pythonhosted.org/packages/64/51/905ecd8596ac85bc3fa6c118ca33ce77ffe0234caa3a6fa5b9ec825b9b96/granian-2.7.9-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8faaa4e51758cf6d2b3b5b228d1cb9cc4d1be460d59ebb71951435505a2ee48a", size = 6907559, upload-time = "2026-07-03T12:40:30.672Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/b1f1ae9843c6dfcf623401cd6fea8f90a9de9dad4a01de878534f24a3f31/granian-2.7.9-cp311-cp311-win_amd64.whl", hash = "sha256:4918fc299a2b429a92fcee7006c0df63856bcc5e9dfc969be16a04ee1a7b1a81", size = 4035618, upload-time = "2026-07-03T12:40:31.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7d/ea14f692056fc08d625aa62b404c10781393f98eadef0208d2fade1f5028/granian-2.7.9-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e04d86c24948dbf3de0b6b1ac9a9d6c82514f5a6c4f27fe49991e5178a1d0d9f", size = 6534691, upload-time = "2026-07-03T12:40:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/68/6e/6e172bad9a56ee79b9eb530dc45f993159872eb948868c6eb529828d46d8/granian-2.7.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3d741def2ad09c8e30880c909023c6d6b78ebe528c5c2e95de8523d967f625f1", size = 6209984, upload-time = "2026-07-03T12:40:34.666Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/f580baa79fc38c6d0ac83e6047150e66d842e5b2e393acc5188f356c73e4/granian-2.7.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:497c99fc3d4fe0342add24e3c53da78f0d9505ec332dae9075527e00918617d4", size = 7161937, upload-time = "2026-07-03T12:40:36.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ed/600a820132ce60a987091b8688e60fad3276fd63c1b726c329958d5a4148/granian-2.7.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e49f859672fe1e8e062f3be791bec2b3169505719ccf83459ff48aac52ee1d0f", size = 6440102, upload-time = "2026-07-03T12:40:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c2/f38c504bdd150a5f8dc4907309d5467df827401614edabe0d7453e384770/granian-2.7.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a720940970ce47b4b348d4e3c9fefe6ce0a40c46ac851c2e4cc0dcf5bd6e2a7", size = 6951056, upload-time = "2026-07-03T12:40:38.953Z" },
+    { url = "https://files.pythonhosted.org/packages/78/01/f6ece64a623e604eac9024751aaf1fab11bf38483a8563a7e009ffa55e00/granian-2.7.9-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:809ec8a9f44c69c49b158811ad78a3195d5e361662ce93dcb7afb848f5f2fd10", size = 7106920, upload-time = "2026-07-03T12:40:40.311Z" },
+    { url = "https://files.pythonhosted.org/packages/62/18/e6f612945ab888cd7a4ff0d42a51f0d3d274bb1860ef90dfa7386d25ffbb/granian-2.7.9-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ea963e616edba406969579e296f853bee164db23c1a63b8d2268459797c64810", size = 7053385, upload-time = "2026-07-03T12:40:41.6Z" },
+    { url = "https://files.pythonhosted.org/packages/db/01/25eda803061400b4176d7bb3f144948a065dc76299112ac9ec1d91871cc4/granian-2.7.9-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:61270c22d6172fbb6f8e363bad19e8dcaefde27a9b0685bbffaa09835fdf44e3", size = 7346261, upload-time = "2026-07-03T12:40:43.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e3/b3b049d22fc1dedf771410036da06c9bf05f9d24b63474147970ebbb99a0/granian-2.7.9-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b3000658f76ef2069aee455d3a0835e36fb073e8fd6e95d777cc0179eb97f5b2", size = 6991885, upload-time = "2026-07-03T12:40:44.742Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/44/d71bf6b7e40f9d44f67b9b0ed861fb89d0912daf88cdcb2b7c69feb7f6c2/granian-2.7.9-cp312-cp312-win_amd64.whl", hash = "sha256:eecd2aa017aa92bc165a9ad33c494e1cfcbfc68a5f055b43e729749899590867", size = 4066976, upload-time = "2026-07-03T12:40:46.135Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c4/a66d5c6daf849d012e871ed2684a2e7f81c518ce9f9e827f5900d99d5e7e/granian-2.7.9-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:23aa08e4d7563f0acb45424676a7d892a146493b5db0895efb5bc8e5121e3051", size = 6534637, upload-time = "2026-07-03T12:40:47.541Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/5e/27fe98fabcae553e3f5087b46f3185a257ed9ee5d7f145d2fd03309bcb60/granian-2.7.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:233baf237d4d3768b4ca6cb6d26546de242e437e1af6050405dcc4673032977f", size = 6210219, upload-time = "2026-07-03T12:40:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b3/9f72bd1f36bd3825d35eff3bd8d00c7a01affdec91387fec6e33e314dc6d/granian-2.7.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:64eb08bcf4aca0375fae95a27ca2e78e9dfef7ccae8e12daaac8b2f0bd1cc718", size = 7162144, upload-time = "2026-07-03T12:40:50.497Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/21e699362e4ecd56d254519d042316444b34c2048e32869101db9bfb6db7/granian-2.7.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff89b203cebba0780efa0360b6e23520323d05f799a610d4a07a5681067b7249", size = 6440457, upload-time = "2026-07-03T12:40:51.826Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d4/4afb3e49ca32b7b6528c2cde626ff60d43663c3567b500bcfbe40af3ca73/granian-2.7.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4ddd82390b6fb9c025007f7ccd92e99d244211898a7851103f28688889dd905", size = 6950842, upload-time = "2026-07-03T12:40:53.317Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/1d/2a19bce46d187296752c9a54cf833f0472232eb6ad4152e99439163fbd1a/granian-2.7.9-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:18e3f870a8c42500fe6c8d73d24a6888920e2a8740810ef1ddb83b0b67ce643e", size = 7106973, upload-time = "2026-07-03T12:40:54.916Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/36/091e26516a7d9093068665dfeffc61dd87c0cb9b9869ffdf452296ab237b/granian-2.7.9-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5dda81fbf58d8f173b9990e6300525359dc2641b88f03bbbe31cc693db5f530b", size = 7052872, upload-time = "2026-07-03T12:40:56.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/a4dca67e6b68014d548d957735521ce68b2e99a5474722663d048c740063/granian-2.7.9-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:cae7ccfd34519241e92311e966763650f839b07b1195541cb0f5c180ef22df99", size = 7346092, upload-time = "2026-07-03T12:40:58.276Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/842e71b39a3a02a16d49b4495c20150055e0888aec6ceb1b965df3a872a5/granian-2.7.9-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed501eafd6cb3c63924466860bf478ad23691d7ad16678b2069e75b5328a074c", size = 6991558, upload-time = "2026-07-03T12:41:00.072Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2f/51a4db315adbc5e28bf5ac97cb93e04c5e7e6705dc0ef6c8220851453074/granian-2.7.9-cp313-cp313-win_amd64.whl", hash = "sha256:e79316015dd68624e021281b3d0e2d9446f04160db4f14140561fe4c0ffeaaa0", size = 4066887, upload-time = "2026-07-03T12:41:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7f/62673800ed73a85d5b629f493d06a387834196e9463b115ef4fee35d1928/granian-2.7.9-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:9aa2087ae2103e99ba169f53d718258205bf2ace7df87c9b6dd52e3f71a90335", size = 6331598, upload-time = "2026-07-03T12:41:03.07Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/08878d6a5b010e39f168b3cffe5011183eab4464a58144ea5711d22d9888/granian-2.7.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d52c262b5e0d345c0c0684b7536ea42f370a7bbb4720b1b625d60d84d87c81be", size = 6099199, upload-time = "2026-07-03T12:41:04.617Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b3/fc344b4bc668d5f4eae9bddbd0eb8f2517214470dd40d178c6c51d14be22/granian-2.7.9-cp313-cp313t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6d08149dfa9777ba281ddf7d7df7ae5473cf6c2fa8815ac33301a24acf33e875", size = 6299537, upload-time = "2026-07-03T12:41:05.99Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/32/65a9b41f107bf76fd23c6c6102eee6ac1112cb84250408d034517cb415aa/granian-2.7.9-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d019f88e7944c3e3967da833e758c85cb6c35c7a82a8185eba23243b5cf24b7c", size = 7210150, upload-time = "2026-07-03T12:41:07.633Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f3/60413bf1a6f6da32b10a3dcfb45c2d09de2dc2f6829555323239635b6398/granian-2.7.9-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e155eb6d3c8827ef3821c80ae6a5f7a61f37562d121240128ce099e3db06ad2f", size = 6673489, upload-time = "2026-07-03T12:41:09.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a0/6cd1b05e0a868b224232fb203838272cdd3165d16338a847f726b21926e2/granian-2.7.9-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:ac516f3cbdce733578ee91a8139d624a1dccf9ab782fb9f3ab58254ebe6c29ad", size = 6829812, upload-time = "2026-07-03T12:41:10.945Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/72/cbb85914df3e09e9ad6a59406157622a50e64df960e378d1091195a5a0a2/granian-2.7.9-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:73e8fe3d162c66d1eddaee825e59379bbf7a384ff776ae984baf796cf1b81fe3", size = 6976912, upload-time = "2026-07-03T12:41:12.412Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7c/ce3d1ef6f8999106a41d828c88f154b6bc6f700950894613e62a3bb46e2e/granian-2.7.9-cp313-cp313t-musllinux_1_1_armv7l.whl", hash = "sha256:12da3d84a9dce7706a19f6a98e8f7c3624721ff66bc34a60cfc4d58e2d6593b9", size = 7418223, upload-time = "2026-07-03T12:41:13.956Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/2f/38daac752e7384c5da56803a65428ef29a196df8e436082813b391877ef5/granian-2.7.9-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:887f0f1e045314044712a2e3799991c7be0ba4129f6806b82e40f502417694d9", size = 6951268, upload-time = "2026-07-03T12:41:15.646Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/95/4cbe8728c9e609f33ec676e194a6296cd628bfb9d6c1310f4ab06634f09a/granian-2.7.9-cp313-cp313t-win_amd64.whl", hash = "sha256:2836fd595a144be7e70faebddf1ce7b4e0c136a7017d75660b88c8da63c0f0ff", size = 4003202, upload-time = "2026-07-03T12:41:17.072Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fa/b388d36bef00f28f2c99df3ab7a08878116d4d1d654b6f93f7b0ef9cde5b/granian-2.7.9-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:17e6975266757b05fd59163a3b5ccd7a9d50c227b13e58b9e5b47eff0609c17f", size = 6451170, upload-time = "2026-07-03T12:41:18.484Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ac/2fdc222d98960c5d0a1d1970ee52f9f4e3a953b2862d7be8fb043e74e0c1/granian-2.7.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:554543e1085ff6bf60eb0f0e995a8a412e92165e92113f9bae9e1fdfeec2ca72", size = 6169769, upload-time = "2026-07-03T12:41:20.31Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/79/beaa9a25285aea37b7bf9c2fa7357871b51ae1a7ee79501d570386e188ab/granian-2.7.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1f06eb3a1c5ce9bf050e94f37310a6add0410ddee75fc65563e86d1619eea384", size = 7269037, upload-time = "2026-07-03T12:41:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e4/ef1ca00cc17664548427908da36d9a16e29e7adb34318d5173d1c00ecd1c/granian-2.7.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d17720e112e40563bfefa7b8031d37372234b568784c07250322887631f168f8", size = 6539295, upload-time = "2026-07-03T12:41:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c5/80826359e26079665562b362f0a5f05261183a8b423e31c954f110313bb4/granian-2.7.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:607a02fbda1905cc0b0764f09fab1d601299e482ebb1d9722e61ca08742fb0df", size = 6981221, upload-time = "2026-07-03T12:41:24.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/77/d595c9698b7799e28c4dc9a3091d30dbea9e20e9e92926e47f9c974b7a77/granian-2.7.9-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2eb74974682bf8635dff79f356d3fd86193c8c1ebed1baffa75ad1793fddbc7", size = 7131507, upload-time = "2026-07-03T12:41:26.347Z" },
+    { url = "https://files.pythonhosted.org/packages/99/46/5200e2b09feae19b7a96371eb2f1523faf2e99aae60584f286db0263cea6/granian-2.7.9-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:33ba7e10bfd30b196b866a9b4b828c9a108a22325936f7d07def89a6b9f21dce", size = 7067731, upload-time = "2026-07-03T12:41:27.999Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/432aaa769de91176944d3210734e27c223c77b76da359699067cd90d4c65/granian-2.7.9-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:e2cf4c926e99718576e4ba201d884a56b0e62d8ede39c7468b26cbe2d98c30e5", size = 7449207, upload-time = "2026-07-03T12:41:29.481Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/83/8e5e429ebb1465c998403a60e0078784d28b819954c387a9558d99b6c3c5/granian-2.7.9-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:665a82ce3f48a4b5e1f4cc83115d3b9a2647b3f222d072db6716223e6dfc86d2", size = 7031706, upload-time = "2026-07-03T12:41:31.209Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5c/b82a31436c740dd0a87e091998f9c350739cbd260aa3880db6f5418112a7/granian-2.7.9-cp314-cp314-win_amd64.whl", hash = "sha256:74d6e50277621e2faa41931d4ddaeae0735e39a20ebaccc49a2282549a4d5297", size = 4080721, upload-time = "2026-07-03T12:41:32.64Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fb/aa241630b4e987c0b343d08c71e20a89098f9c863a12842afa19930f82a0/granian-2.7.9-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1a9b34e5d46a48fa6f017d6afa546f4d35aa6a2a10737e9c49c5c9108e6a4280", size = 6254314, upload-time = "2026-07-03T12:41:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1c/787f63df68e28b9e5793efd80c7ba9e1a0e77663c921525552ac3b0d9305/granian-2.7.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea97a1928b414a35903667440875e0f0f4d2f7a341e8d198ab57f0b2cb70af28", size = 6078452, upload-time = "2026-07-03T12:41:36.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/60/fcc41cd8f394c12785fc2f9d9843ad4329e90a2468d0aaf3474be3255e90/granian-2.7.9-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:57edbef65585ac69d6ada7b9d7cb6fcd6ebeb2e663833c246f72d3634851f5ac", size = 6298703, upload-time = "2026-07-03T12:41:37.906Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0f/555c2f436cf386614e8197ffc3a27c6e3a812149fd84367d2f988361b4fe/granian-2.7.9-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3e39cdfcd5a0ed8e9e8a5e21cd65085ac3a4c73ac5f258f804aedc729cdfa2bb", size = 7241919, upload-time = "2026-07-03T12:41:39.679Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4c/13bd13b0dcc2697b521e75efbeede7328c0809f3e93e964362fd334c0dd4/granian-2.7.9-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c254a1b2027612f0df6e47e8059fd304cda287be25421e1dced4d6b56fb054c", size = 6673295, upload-time = "2026-07-03T12:41:41.483Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0a/c0b977247bf3dd4efa92903dd316b8089f7e67cb21922e83cdcdd98201f7/granian-2.7.9-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f9669323b5cd90be7565711bc75363eccf75b6aecdbb0b286f1a860199ef800c", size = 6830753, upload-time = "2026-07-03T12:41:42.979Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b2/8f50b2d83452ee3100fcd1b26a5de5206b8befeb9d36b79e6c20d5f6dacd/granian-2.7.9-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:c6475981a0cbf766575a0146bdbe52439185a5040cef2a3969214ca1ef6a5e18", size = 6976795, upload-time = "2026-07-03T12:41:44.6Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3a/bec3533aaaff69a9a984f3fd578a2ca29548c9d8503770b1ba5c2260aecd/granian-2.7.9-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3022cde5c662716db8fe16838ba351e0897768435b9c732afc9a4a7322ed05d5", size = 7420697, upload-time = "2026-07-03T12:41:46.332Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d9/4526cc50a1fe3addcc29fe3c7c676d64046f724a4d8e4e29d76ba7dcbe04/granian-2.7.9-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c7e3193da47554561142be7a58520b36a01f6a2da57a7bcbe61f970fb53cc0c", size = 6950255, upload-time = "2026-07-03T12:41:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/62/aa89482ffbc3e56d533cf8c87a91cfb58c486e6a77c522fa34c9f8874113/granian-2.7.9-cp314-cp314t-win_amd64.whl", hash = "sha256:d2cef5a15afee90683944a3b23694e97d75adeafd59ef85ff3896bc9462695d2", size = 3992366, upload-time = "2026-07-03T12:41:49.523Z" },
+    { url = "https://files.pythonhosted.org/packages/90/82/d67dff2240a0627fb6bca3f0489d3d05a0083d81610c7efb6be71131b94a/granian-2.7.9-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b87dd3e65a4ce09ae2113b3fa36f741aaa2aa6e4c31f16bf67c64b2b7c3ade02", size = 6485972, upload-time = "2026-07-03T12:41:50.981Z" },
+    { url = "https://files.pythonhosted.org/packages/91/5d/5cd74e0568e44bfc3dd946cc7cfa050851e94837905229dd84ddf17a8eae/granian-2.7.9-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:03af38185c3fd321713123fafbeb711ca84a7b221c8d159daa82d7c57cb02141", size = 6183599, upload-time = "2026-07-03T12:41:52.295Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4f/1710313a9b545877a61880177a3b909f195ab31bf1504294256a811f866f/granian-2.7.9-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00530458f3cbfcd922cd8b8c2eb2cc17123ff84850de946a4c4839e35e9b74fd", size = 6984936, upload-time = "2026-07-03T12:41:53.868Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/e15744979d1788aceaa53a0c0bf9d9988f2a9b7400b8b4ea4dc3fdfca99b/granian-2.7.9-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:332a6111fff536dca96776f33bfec9415bf5b66c53f46604b9f2d2b5b7a6036a", size = 7120242, upload-time = "2026-07-03T12:41:55.427Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/76/ac022a2f9bea3df682462941d1a4da73160eb0f29c0a56dd987a8cda5164/granian-2.7.9-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:22caac0f82396d792860f7f0ab6012231b1578ba7e50427306c4f17d1e146dfb", size = 7078500, upload-time = "2026-07-03T12:41:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/6b0540cb5e6de8af77b9cb16911dbbd3ba8737943eeb8555bf2fa92b3019/granian-2.7.9-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:b13dd27d32b4fb2ff8a7fd79f80de78bd706c946a8cb1c6ea8a7b83a56086c5e", size = 7462541, upload-time = "2026-07-03T12:41:58.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/7f/f730949f75f3a79993fb7c2255f9f82376ff83f8c13ec724cc92b668a0ab/granian-2.7.9-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:8adc5757b1f1d3e5ad0f50787f459ea33fb8c4434d3d4c3ad2a0694a761c2ce5", size = 6998862, upload-time = "2026-07-03T12:42:00.143Z" },
+    { url = "https://files.pythonhosted.org/packages/87/78/361ded082262cd1c142bd1cfd591710211148d3ac371eecca81d78c6b803/granian-2.7.9-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:44564f8d0f2971550285f21ff815e75b0c5761a0230d5ef3f05d8af851628ee6", size = 4054196, upload-time = "2026-07-03T12:42:02.01Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #39

## Summary

Profiling (full ladder in #39) showed gunicorn's sync workers cap a bare, do-nothing WSGI app at ~2961 req/s, meaning fymo's full SSR (~2259) was running at 76% of what an empty app gets: the framework was never the bottleneck, the server was. The identical app on granian does ~4300 req/s, zero code changes.

- `fymo serve --prod` gains `--server auto|granian|gunicorn` (default auto: granian when installed, gunicorn otherwise, choice + reason logged at boot, never silent)
- Explicit `--server granian` without granian installed hard-fails naming `pip install 'fymo[granian]'`, no silent substitution
- New `fymo/server/granian_server.py`: each granian worker imports `server:app` itself in its own process, so the careful post-fork sidecar dance `fymo/server/gunicorn.py` needs (forked workers would share the master's Node sidecar pipe and corrupt framing) is structurally unnecessary; verified against granian 2.7.9's actual worker-spawn source, and the module docstring documents the contrast
- granian is an optional extra (`fymo[granian]`, pinned `>=2.0,<3`), gunicorn remains the no-extras default; zero behavior change for existing deployments
- `docs/deployment.md`: server-choice guidance with the real measured numbers, including the one that ran the other way (gunicorn was faster on the sidecar-free static-asset route; the recommendation is scoped to SSR, not overclaimed)

## Test plan

- [x] Full suite: 884 passed, 10 skipped (pre-existing Postgres-gated), 0 failed
- [x] Real granian boot test (not mocked): subprocess boot against a built example app, real SSR HTML + /healthz 200
- [x] Live load verification via the actual CLI, both servers, ab -n 2000 -c 50: zero failed, zero non-2xx, /healthz 200 under load, JSON access logs well-formed (2200+ lines parsed), clean SIGTERM/SIGINT shutdown with zero orphaned sidecar processes
- [x] Numbers independently reproduced by a second reviewer in a separate session: granian 2.45x gunicorn per worker, ~1.2x at 4 workers (both saturate the per-worker sidecar ceiling)
- [x] First genuine concurrency validation of fymo core: granian dispatches across real Python threads (gunicorn sync never does), 6000+ concurrent requests, zero sidecar framing errors, zero framework races
- [x] Independent adversarial task reviews (both tasks) + final whole-branch review: READY, no Critical/Important findings

## Related

- #40: the one race found during load-testing lives in blog_app's example db.py (shared SQLite connection across threads), separate fix, worth landing before granian is promoted as the recommended default
- #41: HTML micro-caching, deliberately shelved with design constraints written down