### PR TITLE
fymo jobs-worker --dev: stop requiring FYMO_DEV=1 by hand

### DIFF
--- a/fymo/cli/commands/jobs_worker.py
+++ b/fymo/cli/commands/jobs_worker.py
@@ -14,7 +14,7 @@ from fymo.jobs import init_job_provider
 from fymo.utils.colors import Color
 
 
-def run_jobs_worker(project_root: Optional[Path] = None) -> None:
+def run_jobs_worker(project_root: Optional[Path] = None, dev: bool = False) -> None:
     """Build the project's configured JobProvider and run its worker loop.
 
     Blocks forever under normal operation (e.g. Procrastinate's default
@@ -22,8 +22,23 @@ def run_jobs_worker(project_root: Optional[Path] = None) -> None:
     raw traceback — if the configured provider has no separate worker
     process (e.g. the default `threaded`) or is misconfigured (e.g.
     `procrastinate` with no `DATABASE_URL`).
+
+    `dev=True` (the --dev CLI flag) makes this command authoritative about
+    dev mode, the same treatment `fymo dev` got: it sets FYMO_DEV=1 in this
+    process's own environment before anything reads it, so .env loading and
+    every other FYMO_DEV consumer agree, with no manual export required.
+    The worker is a separate OS process from `fymo dev`, so it can never
+    inherit that session's flag, and .env can't bootstrap it (the flag has
+    to be known before .env is loaded). dev=False means no opinion, not
+    "force prod": an exported FYMO_DEV=1 keeps working exactly as before
+    the flag existed.
     """
+    import os
+
     project_root = Path(project_root) if project_root else Path.cwd()
+
+    if dev:
+        os.environ["FYMO_DEV"] = "1"
 
     # Resolved before ConfigManager so both this dev-only .env load and
     # ConfigManager's ${VAR} interpolation of fymo.yml see the same env,

--- a/fymo/cli/main.py
+++ b/fymo/cli/main.py
@@ -64,10 +64,12 @@ def dev_cmd(host, port):
 
 
 @cli.command(name="jobs-worker")
-def jobs_worker_cmd():
+@click.option("--dev", is_flag=True, default=False,
+              help="Run in dev mode (sets FYMO_DEV=1, enables .env loading)")
+def jobs_worker_cmd(dev):
     """Run the configured job provider's worker loop (e.g. Procrastinate)."""
     from fymo.cli.commands.jobs_worker import run_jobs_worker
-    run_jobs_worker()
+    run_jobs_worker(dev=dev)
 
 
 def main():

--- a/journal/journal_021.md
+++ b/journal/journal_021.md
@@ -1,0 +1,52 @@
+# Journal Entry 021: The Flag the Worker Couldn't Inherit
+
+**Date**: July 15, 2026
+**Focus**: fymo jobs-worker --dev, and a test leak worth remembering
+**Status**: Shipped
+
+## The Ugly Prefix
+
+Running the worker locally against a project whose secrets live in .env
+failed with a missing DATABASE_URL, and the fix was typing
+`FYMO_DEV=1 fymo jobs-worker` every time. It worked, which almost made it
+worse, an ugly thing that works tends to stay forever.
+
+The web side got cured of this exact disease already: `fymo dev` used to
+depend on the caller exporting the flag too, and the fix then was making
+the command authoritative about its own mode. The worker never got the
+same treatment, and it can't borrow the web process's flag either, it's a
+separate OS process, launched separately, inheriting nothing. And .env
+can't bootstrap it, since the flag has to be known before .env is loaded
+at all. Chicken, meet egg.
+
+So: `fymo jobs-worker --dev`. Sets the flag itself, first thing, before
+anything reads it. Default is off on purpose, a forgotten flag on a
+production worker must not quietly start reading whatever .env happens to
+be lying around in the container. And omitting the flag means no opinion
+rather than force-prod, so everyone currently exporting the variable by
+hand keeps working unchanged.
+
+## The Leak
+
+The change was four lines. The interesting bug was in my own test for it.
+
+The test deleted FYMO_DEV from the environment up front, using the test
+framework's env helper with the don't-complain-if-missing option, then ran
+the worker with the new flag, which wrote FYMO_DEV=1 into the real
+process environment, exactly as designed. Here's the trap: deleting a
+variable that was already absent registers nothing to undo. The helper
+restores what it changed, and it had changed nothing. So the 1 my test
+wrote outlived the test, and two middleware tests far away in the suite
+started failing, rate limiting and HSTS quietly flipped to their dev
+behavior by a flag leaked from a test about job workers.
+
+In isolation everything passed, only the full suite caught it, which is
+the entire argument for running the full suite even for a four-line
+change. Fixed with an explicit snapshot-and-restore fixture and a comment
+explaining the trap, because this exact leak pattern has now shown up in
+this codebase more than once, and the next person deserves to find the
+warning where they'd write the bug.
+
+---
+
+*End of Journal Entry 021*

--- a/tests/cli/test_jobs_worker.py
+++ b/tests/cli/test_jobs_worker.py
@@ -12,6 +12,22 @@ from fymo.storage import reset_storage_provider
 
 
 @pytest.fixture(autouse=True)
+def _restore_fymo_dev():
+    """run_jobs_worker(dev=True) writes FYMO_DEV=1 into this process's real
+    environment (that's its documented job). monkeypatch.delenv on a var
+    that was already absent registers no undo, so without an explicit
+    snapshot/restore here the flag would leak into every later test in the
+    suite and silently flip middleware defaults (rate limiting, HSTS) to
+    their dev behavior."""
+    before = os.environ.get("FYMO_DEV")
+    yield
+    if before is None:
+        os.environ.pop("FYMO_DEV", None)
+    else:
+        os.environ["FYMO_DEV"] = before
+
+
+@pytest.fixture(autouse=True)
 def _reset():
     reset_job_provider()
     reset_storage_provider()
@@ -140,3 +156,50 @@ def test_jobs_worker_leaves_storage_uninitialized_when_not_configured(tmp_path: 
 
     with pytest.raises(RuntimeError, match="storage is not initialized"):
         get_storage_provider()
+
+
+def test_dev_flag_sets_fymo_dev_and_loads_dotenv(tmp_path, monkeypatch):
+    """Issue #44: `fymo jobs-worker --dev` must be authoritative about dev
+    mode (set FYMO_DEV=1 itself, same treatment fymo dev got in #26) so a
+    developer never has to prefix the command with FYMO_DEV=1 by hand.
+    Proven the same way as the FYMO_DEV-env test above: fymo.yml only
+    parses if .env got loaded first."""
+    monkeypatch.delenv("FYMO_TEST_WORKER_DEVFLAG", raising=False)
+    monkeypatch.delenv("FYMO_DEV", raising=False)
+    (tmp_path / ".env").write_text("FYMO_TEST_WORKER_DEVFLAG=loaded\n")
+    (tmp_path / "fymo.yml").write_text("name: ${FYMO_TEST_WORKER_DEVFLAG}\n")
+
+    with pytest.raises(SystemExit):
+        run_jobs_worker(tmp_path, dev=True)
+
+    assert os.environ.get("FYMO_DEV") == "1"
+    assert os.environ["FYMO_TEST_WORKER_DEVFLAG"] == "loaded"
+
+
+def test_without_dev_flag_stays_prod_and_ignores_dotenv(tmp_path, monkeypatch):
+    """Default must remain off: a forgotten flag on a prod worker must not
+    silently start reading a stray .env lying around in the container."""
+    monkeypatch.delenv("FYMO_TEST_WORKER_NOFLAG", raising=False)
+    monkeypatch.delenv("FYMO_DEV", raising=False)
+    (tmp_path / ".env").write_text("FYMO_TEST_WORKER_NOFLAG=should-not-load\n")
+
+    with pytest.raises(SystemExit):
+        run_jobs_worker(tmp_path)
+
+    assert "FYMO_TEST_WORKER_NOFLAG" not in os.environ
+    assert os.environ.get("FYMO_DEV") != "1"
+
+
+def test_dev_flag_false_does_not_override_existing_fymo_dev_env(tmp_path, monkeypatch):
+    """Omitting --dev means "no opinion", not "force prod": FYMO_DEV=1
+    exported in the shell must keep working exactly as before the flag
+    existed (backward compatibility with every current setup)."""
+    monkeypatch.delenv("FYMO_TEST_WORKER_ENVSTILL", raising=False)
+    monkeypatch.setenv("FYMO_DEV", "1")
+    (tmp_path / ".env").write_text("FYMO_TEST_WORKER_ENVSTILL=loaded\n")
+    (tmp_path / "fymo.yml").write_text("name: ${FYMO_TEST_WORKER_ENVSTILL}\n")
+
+    with pytest.raises(SystemExit):
+        run_jobs_worker(tmp_path)
+
+    assert os.environ["FYMO_TEST_WORKER_ENVSTILL"] == "loaded"


### PR DESCRIPTION
Closes #44

## Summary

Running the worker locally against a project whose config lives in .env required prefixing the command with `FYMO_DEV=1` by hand, since the worker is a separate OS process (inherits nothing from `fymo dev`) and .env can't bootstrap the flag (it must be known before .env loads).

- `fymo jobs-worker --dev` sets `FYMO_DEV=1` in its own environment first thing, same authoritative-about-its-own-mode treatment `fymo dev` got in #26
- Off by default: a forgotten flag on a prod worker must never silently read a stray .env in the container
- Omitting the flag means no opinion, not force-prod: an exported `FYMO_DEV=1` keeps working exactly as before

## Test plan

- [x] TDD: new test written first, watched fail with the exact expected TypeError
- [x] Real CLI end-to-end both directions: `--dev` resolves fymo.yml's `${VAR}` from .env and reaches the provider stage; without it, the same project fails on the unresolved var
- [x] Backward-compat pinned: env-var path unchanged, no-flag prod path ignores .env
- [x] Full suite 887 passed, 10 skipped, 0 failed — including a real leak the full run caught: the feature writes FYMO_DEV into the live environment, which escaped monkeypatch (delenv on an absent var registers no undo) and flipped two distant middleware tests into dev behavior; fixed with an explicit snapshot/restore fixture documenting the trap