### PR TITLE
Fix remote router's empty-payload fallback to match devalue encoding

### DIFF
--- a/fymo/remote/router.py
+++ b/fymo/remote/router.py
@@ -221,7 +221,9 @@ def handle_remote(environ: dict, start_response) -> Iterable[bytes]:
     try:
         body = json.loads(raw or b"{}")
         payload_b64 = body.get("payload", "")
-        payload_str = _b64url_decode(payload_b64) if payload_b64 else "[1,[]]"
+        # "[[]]" is devalue.stringify([]): a missing/empty payload means a
+        # zero-arg call, so the fallback must parse to an empty args list.
+        payload_str = _b64url_decode(payload_b64) if payload_b64 else "[[]]"
         args = devalue.parse(payload_str)
         if not isinstance(args, list):
             raise ValueError("payload must devalue-parse to a list of args")

--- a/journal/journal_023.md
+++ b/journal/journal_023.md
@@ -1,0 +1,63 @@
+# Journal Entry 023: Four Characters That Were Wrong Since 0.6.0
+
+**Date**: July 16, 2026
+**Focus**: The remote router's empty-payload fallback never actually encoded "no arguments"
+**Status**: Shipped
+
+## A Bug Nobody Hit Through the Front Door
+
+The remote router has a fallback for requests that omit the `payload`
+field: instead of erroring on the missing key, it substitutes a hardcoded
+devalue string meant to represent an empty args list, so a zero-arg
+function can be called with a bare `{}` body. Considerate design. Except
+the hardcoded string was `"[1,[]]"`, and `devalue.parse("[1,[]]")` returns
+the integer `1`, not `[]`. Two lines later the router checks
+`isinstance(args, list)`, the integer fails the check, and the whole
+considerate fallback collapses into a `bad_payload` 400 for exactly the
+caller it was written to accommodate.
+
+The correct encoding is `"[[]]"` — that's literally what
+`devalue.stringify([])` produces. I verified both claims in a REPL before
+touching anything, because a bug report that says "this constant is wrong,
+here's the right one" deserves thirty seconds of confirmation rather than
+blind trust, even when it's my own report.
+
+Nobody noticed for seven versions because the generated `$remote` client
+always sends a real, properly encoded payload, so the fallback string sat
+there unexecuted by any legitimate traffic. The only people who ever
+reached it were people poking at an endpoint with curl — which is
+precisely the audience a fallback like this exists for. It failed only
+and exactly for its intended users. There's something almost elegant
+about that.
+
+## The Fix and the Proof
+
+The fix is four characters. The work was making sure those four characters
+are pinned down forever: two failing tests first — one for an omitted
+`payload` key, one for `"payload": ""`, both against a zero-arg function
+through the real WSGI handler — watched them fail with the exact
+`bad_payload` envelope from the report, then changed the constant and
+watched them pass. Plus a third test that pins the invariant itself:
+`devalue.stringify([]) == "[[]]"` round-trips to `[]`, so if the devalue
+encoding ever changes shape, the test that breaks will point at the
+dependency rather than leaving the fallback to silently rot again.
+
+Then the part that actually mattered for a curl-shaped bug: I scaffolded a
+throwaway app with a zero-arg `ping()` remote function, built it for real,
+served it with wsgiref on a live port, and hit it with actual curl three
+ways — bare `{}`, explicit empty payload, and no body at all. All three
+came back `{"type": "result", "result": "[\"pong\"]"}`. That's the exact
+command sequence from the bug report, running against a real socket,
+returning the answer it should have returned since 0.6.0.
+
+## The Count
+
+787 passing, 123 skipped, zero failed. One constant, three tests, and a
+reminder that the code paths nobody exercises are the ones that stay wrong
+the longest — the fallback was written with care, reviewed presumably, and
+shipped broken for over half a year because the string in it looked
+plausible and nothing ever parsed it.
+
+---
+
+*End of Journal Entry 023*

--- a/tests/remote/test_router.py
+++ b/tests/remote/test_router.py
@@ -149,6 +149,52 @@ def test_domain_error_returns_envelope(remote_project):
     assert body["error"] == "not_found"
 
 
+def _make_environ_raw_body(path: str, body_obj: dict, *, host: str = "x", origin: str = "http://x"):
+    """Like _make_environ but takes the JSON body verbatim, so tests can
+    exercise requests that omit or empty the 'payload' field entirely."""
+    raw = json.dumps(body_obj).encode()
+    return {
+        "REQUEST_METHOD": "POST",
+        "PATH_INFO": path,
+        "CONTENT_LENGTH": str(len(raw)),
+        "CONTENT_TYPE": "application/json",
+        "HTTP_COOKIE": "",
+        "HTTP_HOST": host,
+        "HTTP_ORIGIN": origin,
+        "wsgi.url_scheme": "http",
+        "REMOTE_ADDR": "127.0.0.1",
+        "wsgi.input": io.BytesIO(raw),
+    }
+
+
+def test_omitted_payload_dispatches_zero_arg_function(remote_project):
+    """Issue #46: a bare {} body (no 'payload' key) must be treated as an
+    empty args list. The fallback used to be the string "[1,[]]", which
+    devalue-parses to the integer 1, not [], so every zero-arg call that
+    relied on the fallback 400ed with bad_payload instead of dispatching."""
+    proj, h = remote_project
+    env = _make_environ_raw_body(f"/_fymo/remote/{h}/whoami", {})
+    (status, _), body = _call(env)
+    assert status.startswith("200")
+    assert body["type"] == "result", body
+
+
+def test_empty_string_payload_dispatches_zero_arg_function(remote_project):
+    """Same fallback path as an omitted key: "payload": "" is falsy."""
+    proj, h = remote_project
+    env = _make_environ_raw_body(f"/_fymo/remote/{h}/whoami", {"payload": ""})
+    (status, _), body = _call(env)
+    assert status.startswith("200")
+    assert body["type"] == "result", body
+
+
+def test_fallback_matches_devalue_empty_list_encoding():
+    """Pins the invariant the fallback string depends on: devalue's own
+    encoding of an empty args list round-trips to []."""
+    assert devalue.stringify([]) == "[[]]"
+    assert devalue.parse("[[]]") == []
+
+
 def test_uid_cookie_issued_on_first_call(remote_project):
     proj, h = remote_project
     env = _make_environ(f"/_fymo/remote/{h}/whoami", [], host="x", origin="http://x")


### PR DESCRIPTION
## Summary

The router's fallback for a POST that omits (or empties) the payload field was the hardcoded string `"[1,[]]"`, which devalue-parses to the integer 1, not an empty list, so the router's own isinstance check rejected it with a bad_payload 400. Every zero-arg remote function called with a bare `{}` body failed, which is exactly the hand-testing-with-curl audience the fallback exists for. The generated $remote client always sends a real payload, so intended-client traffic never hit this. Wrong since the fallback was introduced in 0.6.0.

Fix: `"[1,[]]"` becomes `"[[]]"` (which is literally `devalue.stringify([])`).

Closes #46

## Test plan

- [x] Failing tests first: omitted payload key and `"payload": ""` against a zero-arg function through the real WSGI handler, both failing with the exact bad_payload envelope from the report
- [x] Invariant-pinning test: `devalue.stringify([]) == "[[]]"` round-trips to `[]`
- [x] Full suite green (787 passed)
- [x] Live check: real `fymo build` + wsgiref server, actual curl three ways (bare `{}`, empty payload, no body), all dispatch and return the result envelope