### PR TITLE
Fix a fresh pip install of fymo being unable to build anything

### DIFF
--- a/fymo/build/js/build.mjs
+++ b/fymo/build/js/build.mjs
@@ -11,7 +11,6 @@
  * Prints:
  *   { ok: true, server: { ... metafile ... } } on stdout
  */
-import { build } from 'esbuild';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -24,9 +23,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const config = JSON.parse(process.argv[2]);
 const routeRuntimePath = path.join(__dirname, 'runtime', 'route.js');
 
-// Resolve esbuild-svelte and svelte-preprocess from the project's own node_modules
-// so that the Svelte version used for compilation matches the one used at SSR runtime.
+// Resolve esbuild, esbuild-svelte, and svelte-preprocess from the project's
+// own node_modules, not fymo's. A bare `import ... from 'esbuild'` resolves
+// against this file's own location, which once fymo is a real pip install
+// (site-packages/fymo/build/js/) never has a node_modules in its ancestry at
+// all. esbuild-svelte and svelte-preprocess already need this treatment so
+// the Svelte version used for compilation matches the one used at SSR
+// runtime; esbuild needs it for the same underlying reason, resolvability
+// from the target project rather than from fymo's own package tree.
 const projectRequire = createRequire(path.join(config.projectRoot, 'package.json'));
+const { build } = await import(pathToFileURL(projectRequire.resolve('esbuild')).href);
 const sveltePlugin = (await import(pathToFileURL(projectRequire.resolve('esbuild-svelte')).href)).default;
 const sveltePreprocess = (await import(pathToFileURL(projectRequire.resolve('svelte-preprocess')).href)).default;
 
@@ -46,6 +52,15 @@ async function buildServer() {
         sourcemap: config.dev ? 'linked' : false,
         metafile: true,
         external: ['$remote/*', '$broadcast/*'],
+        // fymoRoutePlugin resolves `$route` to fymo's own shipped
+        // runtime/route.js, which lives inside fymo's install location, not
+        // the project. Its own `import ... from 'svelte/store'` would
+        // otherwise be resolved against route.js's directory ancestry (same
+        // problem the createRequire calls above solve for esbuild itself),
+        // which is empty for a real pip install. nodePaths is esbuild's
+        // NODE_PATH-style fallback search list, tried once normal ancestor
+        // resolution comes up empty.
+        nodePaths: [path.join(config.projectRoot, 'node_modules')],
         plugins: [
             fymoRoutePlugin({ runtimePath: routeRuntimePath }),
             sveltePlugin({
@@ -74,6 +89,10 @@ async function buildClient() {
         minify: !config.dev,
         sourcemap: config.dev ? 'linked' : false,
         metafile: true,
+        // See buildServer()'s nodePaths comment -- the client bundle also
+        // imports `$route` -> route.js, with the same svelte/store fallback
+        // requirement.
+        nodePaths: [path.join(config.projectRoot, 'node_modules')],
         plugins: [
             fymoRemotePlugin({ remoteDir: path.join(config.distDir, 'client', '_remote') }),
             fymoBroadcastPlugin({ broadcastDir: path.join(config.distDir, 'client', '_broadcast') }),

--- a/fymo/build/js/dev.mjs
+++ b/fymo/build/js/dev.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import * as esbuild from 'esbuild';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -11,13 +10,17 @@ import { fymoRoutePlugin } from './plugins/router.mjs';
 const config = JSON.parse(process.argv[2]);
 const routeRuntimePath = path.join(path.dirname(new URL(import.meta.url).pathname), 'runtime', 'route.js');
 
-// Resolve esbuild-svelte and svelte-preprocess from the project's own
-// node_modules so the Svelte version used to COMPILE components matches the
-// one esbuild bundles for the SSR runtime. Bare imports here would resolve
-// from fymo's own node_modules instead, and any version skew makes the
-// compiler emit lifecycle calls the runtime no longer exports — the bundle
-// then calls `(void 0)()` and every render throws. Mirrors build.mjs.
+// Resolve esbuild, esbuild-svelte, and svelte-preprocess from the project's
+// own node_modules so the Svelte version used to COMPILE components matches
+// the one esbuild bundles for the SSR runtime, and so esbuild itself is even
+// resolvable at all once fymo is a real pip install with no node_modules of
+// its own. Bare imports here would resolve from fymo's own package tree
+// instead (or, for esbuild-svelte/svelte-preprocess, from whatever version
+// happens to sit there, causing a Svelte version skew where the compiler
+// emits lifecycle calls the runtime no longer exports, the bundle then
+// calls `(void 0)()` and every render throws). Mirrors build.mjs.
 const projectRequire = createRequire(path.join(config.projectRoot, 'package.json'));
+const esbuild = await import(pathToFileURL(projectRequire.resolve('esbuild')).href);
 const sveltePlugin = (await import(pathToFileURL(projectRequire.resolve('esbuild-svelte')).href)).default;
 const sveltePreprocess = (await import(pathToFileURL(projectRequire.resolve('svelte-preprocess')).href)).default;
 
@@ -39,6 +42,15 @@ async function makeServerCtx() {
         sourcemap: 'linked',
         metafile: true,
         external: ['$remote/*', '$broadcast/*'],
+        // fymoRoutePlugin resolves `$route` to fymo's own shipped
+        // runtime/route.js, which lives inside fymo's install location, not
+        // the project. Its own `import ... from 'svelte/store'` would
+        // otherwise be resolved against route.js's directory ancestry (same
+        // problem the createRequire calls above solve for esbuild itself),
+        // which is empty for a real pip install. nodePaths is esbuild's
+        // NODE_PATH-style fallback search list, tried once normal ancestor
+        // resolution comes up empty. Mirrors build.mjs.
+        nodePaths: [path.join(config.projectRoot, 'node_modules')],
         plugins: [
             fymoRoutePlugin({ runtimePath: routeRuntimePath }),
             sveltePlugin({ preprocess: sveltePreprocess(), compilerOptions: { generate: 'server', dev: false } }),
@@ -63,6 +75,10 @@ async function makeClientCtx() {
         minify: false,
         sourcemap: 'linked',
         metafile: true,
+        // See makeServerCtx()'s nodePaths comment -- the client bundle also
+        // imports `$route` -> route.js, with the same svelte/store fallback
+        // requirement.
+        nodePaths: [path.join(config.projectRoot, 'node_modules')],
         plugins: [
             fymoRemotePlugin({ remoteDir: path.join(config.distDir, 'client', '_remote') }),
             fymoBroadcastPlugin({ broadcastDir: path.join(config.distDir, 'client', '_broadcast') }),

--- a/fymo/cli/commands/new.py
+++ b/fymo/cli/commands/new.py
@@ -82,10 +82,14 @@ gunicorn>=23.0.0
     "build": "fymo build"
   }},
   "dependencies": {{
+    "devalue": "^5.8.1",
     "svelte": "^5.38.0"
   }},
   "devDependencies": {{
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "esbuild-svelte": "^0.9.0",
+    "svelte-preprocess": "^6.0.3",
+    "typescript": "^5.5.0"
   }}
 }}
 """

--- a/fymo/cli/commands/new.py
+++ b/fymo/cli/commands/new.py
@@ -83,10 +83,10 @@ gunicorn>=23.0.0
   }},
   "dependencies": {{
     "devalue": "^5.8.1",
-    "svelte": "^5.38.0"
+    "svelte": "^5.56.4"
   }},
   "devDependencies": {{
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.25.9",
     "esbuild-svelte": "^0.9.0",
     "svelte-preprocess": "^6.0.3",
     "typescript": "^5.5.0"

--- a/journal/journal_023.md
+++ b/journal/journal_023.md
@@ -1,0 +1,148 @@
+# Journal Entry 023: The Bug That Only Exists Outside This Repo
+
+**Date**: July 16, 2026
+**Focus**: Two filed issues about a fresh `pip install` never being able to build, and a third bug the fix itself surfaced
+**Status**: Shipped
+
+## The Report I Couldn't Reproduce at First
+
+Two issues came in close together, filed by the same person, about the
+same symptom from two different angles. #55: a brand new `fymo new`
+project's `package.json` only listed `svelte` and `esbuild`, so
+`npm install` never pulled in `esbuild-svelte` or `svelte-preprocess`,
+and `fymo build` died immediately looking for a module that was never
+going to be there. #60 was the uglier one: even handed a project whose
+`node_modules` was already complete and known-good, `fymo build` still
+failed, but only if fymo itself was a real `pip install`. Inside this
+monorepo, building anything just worked, every time, no matter what I
+tried to break.
+
+That last part should have been the whole investigation right there.
+Something that only breaks outside the repo it was written in is never
+really about the code you're staring at — it's about where that code
+happens to live on disk.
+
+## Why the Repo Itself Was Lying to Me
+
+`fymo/build/js/build.mjs` opens with `import { build } from 'esbuild'`.
+Perfectly normal-looking line. The part that doesn't show up by reading
+it is *how* Node resolves that: it walks up from the importing file's own
+directory, never from the project being built, never from wherever the
+process happens to be running. Inside this repo, `fymo/build/js/` sits
+underneath the repo root, and the repo root has its own `node_modules`
+with `esbuild` in it. So the bare import always found something. It just
+never found the *right* something on purpose — it found it by geographic
+accident, because this repo's own dev dependencies happened to sit as an
+ancestor of the file doing the importing.
+
+Move that same file into `site-packages/fymo/build/js/`, which is exactly
+where a real `pip install` puts it, and that ancestor walk runs out of
+directories to check long before it reaches anything with `esbuild` in
+it. Doesn't matter how correct the target project's own `node_modules`
+is. The import was never looking there.
+
+The fix pattern already existed a few lines down in the same file, for a
+completely different reason. `esbuild-svelte` and `svelte-preprocess` get
+resolved through `createRequire` pointed at the *project's* own
+`package.json`, so the Svelte version doing the compiling matches the one
+running at SSR time. Nobody had ever needed to do the same thing for
+`esbuild` itself, because inside this repo it was never actually broken.
+Extended that same resolution to `esbuild`, in both `build.mjs` and
+`dev.mjs` — `dev.mjs` imports it as a namespace instead of a single named
+export, so its version pulls in the whole module object instead of just
+destructuring `build` off it, but otherwise it's the identical move.
+
+## Writing a Test That Couldn't Cheat
+
+The dangerous thing about this bug is that almost every existing test in
+this suite runs against the repo's own editable checkout, which means
+almost every existing test would keep passing right through this bug
+without ever noticing it, for the same reason I didn't notice it at
+first. A regression test that exercises the source tree from inside this
+repo proves nothing here.
+
+So the fast test copies `fymo/build/js/` out to a scratch directory with
+no `node_modules` anywhere above it — a pytest tmp dir genuinely has
+none — which stands in for a real install location honestly, not just in
+name. Pointed it at a project directory whose only copy of `esbuild`
+lives in its own `node_modules` (reused from `examples/blog_app`, already
+installed, rather than a real `npm install`). Ran the original code
+against that setup first, on purpose, before writing the fix: it failed
+with the literal `Cannot find package 'esbuild'` error from the bug
+report. Then applied the fix and watched the same test turn green for the
+same reason it had just gone red.
+
+## The Second Bug the First Fix Walked Into
+
+Fixing `esbuild`'s own resolution felt like the whole job. It wasn't. I
+ran the actual quick start end to end to make sure — real wheel, real
+scratch venv, real `pip install`, `fymo new`, symlinked-in known-good
+`node_modules`, `fymo build` — and it still failed. Different error this
+time: `Could not resolve "svelte/store"`.
+
+That import lives in `fymo/build/js/runtime/route.js`, the file behind
+`$route` (which I'd written about in the previous entry, for a completely
+unrelated reason — a store instead of `$state`, specifically to avoid two
+disconnected copies of Svelte's runtime getting bundled). `route.js` also
+ships inside fymo's own package, not the project's. And esbuild's own
+bundler resolves a bare import inside a file it's bundling by walking up
+from that file's directory, the exact same algorithm Node just used to
+break the first time. Same disease, different organ. `createRequire`
+couldn't touch this one — that machinery only helps imports Node itself
+evaluates, and this import is resolved by esbuild's bundler while it's
+turning `route.js` into part of somebody else's built output.
+
+The fix was esbuild's own equivalent of `NODE_PATH`: a `nodePaths` option
+telling it where to look once its normal directory walk comes up empty,
+pointed at the project's `node_modules`. Added it to all four
+build/context calls across `build.mjs` and `dev.mjs`, since both the
+server and client passes touch `$route`. Wrote the failing test the same
+way as the first one — a route that imports `$route`, built from outside
+the repo's own `node_modules` ancestry, watched it fail with the real
+error, then watched it pass.
+
+I hadn't planned to touch this file. It only turned up because I ran the
+actual end-to-end flow instead of stopping once the two tests I'd
+already written went green. If I'd stopped there, the smoke test the
+issues themselves were asking for would have kept failing for a second,
+completely different reason, and I'd have called the job done with the
+documented quick start still broken.
+
+## The Version Numbers I Didn't Actually Check
+
+Independent review caught something smaller but real: the scaffold fix
+for #55 added the missing `devDependencies` correctly, but left `svelte`
+and `esbuild`'s existing version pins untouched — `^5.38.0` and
+`^0.25.0` — while claiming, in both the commit message and a test
+docstring, that the scaffold now matched `examples/blog_app/package.json`
+exactly. It didn't. Blog_app pins `^5.56.4` and `^0.25.9`. I'd read the
+right file earlier in the investigation and then just... didn't carry the
+two numbers that were already present over, only the ones that were
+missing. Caret ranges mean this was never going to break anyone's actual
+`npm install`, but the diff said one thing and did another, and that gap
+was worth closing on its own, not waved off because the practical
+consequence happened to be zero.
+
+## Closing the Loop for Real
+
+Built a real wheel with `uv build`, installed it into a scratch venv that
+had never heard of this repo, ran that venv's own `fymo new`, symlinked
+in `examples/blog_app`'s working `node_modules`, ran that venv's own
+`fymo build`. Manifest, sidecar, both SSR and client output, all there,
+nothing masked by this repo's own directory layout. Also ran a real
+`npm install` against the freshly-scaffolded project by hand, once,
+outside the test suite: fifty packages, zero missing, both dependencies
+that were absent before now present. Turned that same wheel-build-and-
+install sequence into a standing test, symlinking rather than running a
+live `npm install` in CI so it stays fast and doesn't depend on having a
+network connection every time the suite runs.
+
+Three commits: the scaffold fix, the resolution fix, the end-to-end test,
+plus a fourth once review caught the version-pin miss. Full suite: 902
+passing, 10 skipped, same 10 that were already skipped before I touched
+anything — a couple of provider tests that need a real Postgres instance
+sitting somewhere and want nothing to do with this.
+
+---
+
+*End of Journal Entry 023*

--- a/journal/journal_024.md
+++ b/journal/journal_024.md
@@ -1,4 +1,4 @@
-# Journal Entry 023: The Bug That Only Exists Outside This Repo
+# Journal Entry 024: The Bug That Only Exists Outside This Repo
 
 **Date**: July 16, 2026
 **Focus**: Two filed issues about a fresh `pip install` never being able to build, and a third bug the fix itself surfaced
@@ -145,4 +145,4 @@ sitting somewhere and want nothing to do with this.
 
 ---
 
-*End of Journal Entry 023*
+*End of Journal Entry 024*

--- a/tests/build/test_esbuild_resolution.py
+++ b/tests/build/test_esbuild_resolution.py
@@ -1,0 +1,176 @@
+"""Issue #60: fymo/build/js/build.mjs and dev.mjs must resolve `esbuild` from
+the *target project's* own node_modules, not from wherever the .mjs file
+itself happens to live.
+
+A bare `import { build } from 'esbuild'` is resolved by Node against the
+importing file's own directory ancestry, never the project being built or
+process.cwd(). Inside this monorepo that's invisible, because the repo root's
+own node_modules sits as an ancestor of fymo/build/js/ too. Once fymo is a
+real `pip install` (site-packages/fymo/build/js/), that ancestry never
+reaches any node_modules at all.
+
+These tests reproduce that by copying build.mjs (and its plugin/runtime
+dependencies) to a scratch directory with no node_modules anywhere in its
+own ancestry (pytest's tmp_path already guarantees this), simulating a real
+install location, then pointing it at a project whose *only* copy of esbuild
+lives in the project's own node_modules. A bare import can never find it from
+there; the createRequire(project package.json)-based resolution can.
+"""
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import BLOG_APP, REPO_ROOT
+
+BUILD_JS_SRC = REPO_ROOT / "fymo" / "build" / "js"
+
+
+def _install_build_js_outside_repo(tmp_path: Path) -> Path:
+    """Copy fymo/build/js/ to a location with no node_modules ancestor,
+    standing in for a real site-packages/fymo/build/js/ install."""
+    dest = tmp_path / "installed_fymo_pkg" / "js"
+    shutil.copytree(BUILD_JS_SRC, dest)
+    return dest
+
+
+def _make_project_with_only_its_own_esbuild(tmp_path: Path) -> Path:
+    """A project directory whose node_modules is the only place `esbuild`
+    (or esbuild-svelte/svelte-preprocess) can be found. Reuses
+    examples/blog_app's already-installed, known-good node_modules rather
+    than a real `npm install`, matching the existing blog_app/example_app
+    fixture convention in tests/conftest.py."""
+    nm = BLOG_APP / "node_modules"
+    if not nm.is_dir():
+        pytest.skip("examples/blog_app/node_modules not found — run npm install in examples/blog_app/")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "package.json").write_text(json.dumps({"name": "scratch-project", "type": "module"}))
+    (project / "node_modules").symlink_to(nm)
+    return project
+
+
+def _run_build_script(script_path: Path, project_root: Path, dist_dir: Path) -> subprocess.CompletedProcess:
+    config = {
+        "projectRoot": str(project_root),
+        "distDir": str(dist_dir),
+        "routes": [],
+        "clientEntries": {},
+        "dev": False,
+    }
+    return subprocess.run(
+        ["node", str(script_path), json.dumps(config)],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.usefixtures("node_available")
+def test_build_mjs_resolves_esbuild_from_project_not_from_its_own_install_location(tmp_path):
+    installed_js = _install_build_js_outside_repo(tmp_path)
+    project = _make_project_with_only_its_own_esbuild(tmp_path)
+    dist_dir = tmp_path / "dist"
+
+    proc = _run_build_script(installed_js / "build.mjs", project, dist_dir)
+
+    assert "Cannot find package 'esbuild'" not in proc.stdout + proc.stderr
+    assert proc.returncode == 0, f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    result = json.loads(proc.stdout)
+    assert result["ok"] is True
+
+
+@pytest.mark.usefixtures("node_available")
+def test_build_mjs_bundles_route_runtimes_svelte_store_import_from_project(tmp_path):
+    """A second, independently-discovered instance of the same root cause.
+
+    fymo/build/js/runtime/route.js -- resolved by fymoRoutePlugin as the
+    fixed target of every `$route` import -- has its own bare
+    `import { writable } from 'svelte/store'`. It's not loaded by Node at
+    all (createRequire can't help here); esbuild bundles it as ordinary
+    source, and esbuild's own default module resolution walks up from
+    route.js's own directory exactly the way Node's ESM resolver does. Once
+    fymo is a real pip install, route.js's directory ancestry never reaches
+    the target project's node_modules either, so any route that imports
+    `$route` fails to build with "Could not resolve svelte/store", a
+    completely real-world entry point (blog_app's route runtime uses
+    `$route`), not a synthetic one.
+    """
+    installed_js = _install_build_js_outside_repo(tmp_path)
+    project = _make_project_with_only_its_own_esbuild(tmp_path)
+    dist_dir = tmp_path / "dist"
+
+    entry = project / "uses_route.js"
+    entry.write_text("import { route } from '$route';\nexport default route;\n")
+
+    config = {
+        "projectRoot": str(project),
+        "distDir": str(dist_dir),
+        "routes": [{"name": "home", "entryPath": str(entry)}],
+        "clientEntries": {},
+        "dev": False,
+    }
+    proc = subprocess.run(
+        ["node", str(installed_js / "build.mjs"), json.dumps(config)],
+        cwd=project,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Could not resolve" not in proc.stdout + proc.stderr
+    assert proc.returncode == 0, f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    result = json.loads(proc.stdout)
+    assert result["ok"] is True, result.get("error")
+
+
+@pytest.mark.usefixtures("node_available")
+def test_dev_mjs_resolves_esbuild_from_project_not_from_its_own_install_location(tmp_path):
+    installed_js = _install_build_js_outside_repo(tmp_path)
+    project = _make_project_with_only_its_own_esbuild(tmp_path)
+    dist_dir = tmp_path / "dist"
+
+    config = {
+        "projectRoot": str(project),
+        "distDir": str(dist_dir),
+        "routes": [],
+        "clientEntries": {},
+        "dev": True,
+    }
+    proc = subprocess.Popen(
+        ["node", str(installed_js / "dev.mjs"), json.dumps(config)],
+        cwd=project,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # dev.mjs runs a persistent watcher and never exits on its own; a clean
+    # "ready" event on stdout is proof the esbuild.context() calls it makes
+    # at startup (which is where the bare import would have already thrown)
+    # succeeded. If esbuild can't be resolved, the process crashes before
+    # ever reaching this point and stdout hits EOF instead.
+    saw_ready = False
+    deadline = time.time() + 15
+    try:
+        while time.time() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                if proc.poll() is not None:
+                    break
+                continue
+            if '"type":"ready"' in line:
+                saw_ready = True
+                break
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+    stderr_output = proc.stderr.read()
+    assert "Cannot find package 'esbuild'" not in stderr_output
+    assert saw_ready, f"dev.mjs never emitted a ready event; stderr: {stderr_output}"

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -109,3 +109,22 @@ def test_new_scaffolds_package_json_dev_script_using_fymo_dev(tmp_path, monkeypa
     create_project("myapp")
     package_json = json.loads((tmp_path / "myapp" / "package.json").read_text())
     assert package_json["scripts"]["dev"] == "fymo dev"
+
+
+def test_new_scaffolds_package_json_with_full_build_deps(tmp_path, monkeypatch):
+    """Issue #55: a fresh `fymo new` project could never build. fymo/build/js/build.mjs
+    requires esbuild-svelte and svelte-preprocess directly, and app/lib code commonly
+    needs devalue and TypeScript, but the scaffolded package.json only ever listed
+    svelte and esbuild. Bring it in line with examples/blog_app/package.json, the
+    known-good reference every other build-time test in this repo relies on."""
+    import json
+    monkeypatch.chdir(tmp_path)
+    create_project("myapp")
+    package_json = json.loads((tmp_path / "myapp" / "package.json").read_text())
+    assert package_json["dependencies"]["devalue"] == "^5.8.1"
+    assert package_json["dependencies"]["svelte"] == "^5.38.0"
+    dev_deps = package_json["devDependencies"]
+    assert dev_deps["esbuild"] == "^0.25.0"
+    assert dev_deps["esbuild-svelte"] == "^0.9.0"
+    assert dev_deps["svelte-preprocess"] == "^6.0.3"
+    assert dev_deps["typescript"] == "^5.5.0"

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -122,9 +122,9 @@ def test_new_scaffolds_package_json_with_full_build_deps(tmp_path, monkeypatch):
     create_project("myapp")
     package_json = json.loads((tmp_path / "myapp" / "package.json").read_text())
     assert package_json["dependencies"]["devalue"] == "^5.8.1"
-    assert package_json["dependencies"]["svelte"] == "^5.38.0"
+    assert package_json["dependencies"]["svelte"] == "^5.56.4"
     dev_deps = package_json["devDependencies"]
-    assert dev_deps["esbuild"] == "^0.25.0"
+    assert dev_deps["esbuild"] == "^0.25.9"
     assert dev_deps["esbuild-svelte"] == "^0.9.0"
     assert dev_deps["svelte-preprocess"] == "^6.0.3"
     assert dev_deps["typescript"] == "^5.5.0"

--- a/tests/integration/test_fresh_install_smoke.py
+++ b/tests/integration/test_fresh_install_smoke.py
@@ -1,0 +1,119 @@
+"""End-to-end smoke test for issues #55 and #60 together.
+
+Neither issue is visible from inside this monorepo's own editable checkout:
+the repo root's own node_modules and fymo/'s own source tree both happen to
+sit as directory ancestors of everything else, which is exactly what masks
+both bugs in every other test in this suite. tests/integration/test_cli_build.py
+already runs `fymo build` against a real project and passes today, even
+though #60 was very much still open against a real `pip install` -- proof
+that testing from inside the monorepo alone can't catch this class of bug.
+
+This test instead builds a real wheel, pip installs it into a clean scratch
+venv, and drives the actual documented quick start through that venv's own
+`fymo` entrypoint:
+
+    pip install fymo
+    fymo new my_app
+    cd my_app && npm install
+    fymo build
+
+The `npm install` step is stood in for by symlinking in
+examples/blog_app's own already-installed, known-good node_modules (the same
+convention tests/conftest.py's blog_app/example_app fixtures already use)
+rather than a real network install, so this test stays fast and
+network-independent; the scaffold's package.json contents (issue #55) are
+covered by tests/cli/test_new.py's own assertions on the generated file, and
+a real `npm install` against the scaffolded package.json was verified by
+hand while fixing #55 -- 50 packages installed cleanly, all four missing
+devDependencies now present.
+
+Everything (built wheel, scratch venv, scaffolded project, dist output) is
+created under tmp_path and explicitly removed at the end of the test, not
+left for pytest's own tmp_path retention to eventually prune.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import BLOG_APP, REPO_ROOT
+
+
+@pytest.mark.usefixtures("node_available")
+def test_fresh_pip_install_new_and_build_end_to_end(tmp_path):
+    nm = BLOG_APP / "node_modules"
+    if not nm.is_dir():
+        pytest.skip("examples/blog_app/node_modules not found — run npm install in examples/blog_app/")
+    if shutil.which("uv") is None:
+        pytest.skip("uv not on PATH — needed to build the wheel and create the scratch venv")
+
+    dist_dir = tmp_path / "wheel_dist"
+    venv_dir = tmp_path / "venv"
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    try:
+        build_proc = subprocess.run(
+            ["uv", "build", "--wheel", "--out-dir", str(dist_dir)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert build_proc.returncode == 0, f"uv build failed\nstdout: {build_proc.stdout}\nstderr: {build_proc.stderr}"
+        wheels = list(dist_dir.glob("*.whl"))
+        assert len(wheels) == 1, f"expected exactly one wheel, found: {wheels}"
+        wheel = wheels[0]
+
+        venv_proc = subprocess.run(
+            ["uv", "venv", str(venv_dir)],
+            capture_output=True,
+            text=True,
+        )
+        assert venv_proc.returncode == 0, f"uv venv failed\nstdout: {venv_proc.stdout}\nstderr: {venv_proc.stderr}"
+        venv_python = venv_dir / "bin" / "python"
+        venv_fymo = venv_dir / "bin" / "fymo"
+
+        install_proc = subprocess.run(
+            ["uv", "pip", "install", "--python", str(venv_python), str(wheel)],
+            capture_output=True,
+            text=True,
+        )
+        assert install_proc.returncode == 0, f"pip install failed\nstdout: {install_proc.stdout}\nstderr: {install_proc.stderr}"
+        assert venv_fymo.is_file(), "fymo entrypoint not installed into the scratch venv"
+
+        new_proc = subprocess.run(
+            [str(venv_fymo), "new", "my_app"],
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+        )
+        assert new_proc.returncode == 0, f"fymo new failed\nstdout: {new_proc.stdout}\nstderr: {new_proc.stderr}"
+        project = work_dir / "my_app"
+        assert (project / "package.json").is_file()
+
+        package_json = json.loads((project / "package.json").read_text())
+        dev_deps = package_json["devDependencies"]
+        assert "esbuild-svelte" in dev_deps
+        assert "svelte-preprocess" in dev_deps
+        assert "typescript" in dev_deps
+        assert "devalue" in package_json["dependencies"]
+
+        (project / "node_modules").symlink_to(nm)
+
+        build_run_proc = subprocess.run(
+            [str(venv_fymo), "build"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+        )
+        assert "Cannot find package 'esbuild'" not in build_run_proc.stdout + build_run_proc.stderr
+        assert build_run_proc.returncode == 0, (
+            f"fymo build failed against a real pip install\n"
+            f"stdout: {build_run_proc.stdout}\nstderr: {build_run_proc.stderr}"
+        )
+        assert (project / "dist" / "manifest.json").is_file()
+        assert (project / "dist" / "sidecar.mjs").is_file()
+    finally:
+        shutil.rmtree(tmp_path, ignore_errors=True)


### PR DESCRIPTION
## Summary

Closes #55 and #60 together, they're two layers of the same broken flow: a fresh `pip install fymo`, `fymo new`, `npm install`, `fymo build` cannot work today.

- #55: the scaffolded package.json was missing esbuild-svelte, svelte-preprocess, typescript, and devalue, and had version pins that had drifted from what examples/blog_app actually ships and builds with.
- #60: build.mjs and dev.mjs both had a bare `import ... from 'esbuild'`, which Node resolves against the importing file's own location, not the target project. Inside the monorepo this is invisible since fymo's own node_modules sits as a directory ancestor of everything; for a real pip install it never resolves. Fixed the same way esbuild-svelte/svelte-preprocess already are, via createRequire against the project's own package.json.
- A third bug found while verifying end to end: `$route`'s runtime module (route.js) has its own bare `import { writable } from 'svelte/store'`, resolved by esbuild itself rather than Node, hitting the identical dead end. Fixed via esbuild's nodePaths option pointed at the project's node_modules.

## Test plan

- [x] New fast test isolating the resolution bug without a full wheel build
- [x] New true end to end smoke test: builds a real wheel, pip installs it into a scratch venv, runs that venv's own fymo new / fymo build
- [x] Independent review caught a version-pin inconsistency in the scaffold fix, corrected with its own test
- [x] Full suite green, including the existing $route reactive-state tests (confirmed unaffected by the nodePaths change)