### PR TITLE
Add a server-side redirect primitive (Redirect)

### DIFF
--- a/examples/blog_app/app/controllers/redirect_demo.py
+++ b/examples/blog_app/app/controllers/redirect_demo.py
@@ -1,0 +1,12 @@
+"""Demo page for `fymo.remote.Redirect` -- not part of the blog's real
+content, exists so the redirect primitive has something to click through in
+tests/integration/test_redirect_hydration.py."""
+from app.remote.redirect_demo import go_to_login
+
+
+def getContext():
+    return {"go_to_login": go_to_login}
+
+
+def getDoc():
+    return {"title": "Redirect demo"}

--- a/examples/blog_app/app/remote/redirect_demo.py
+++ b/examples/blog_app/app/remote/redirect_demo.py
@@ -1,0 +1,9 @@
+"""Demo remote function exercising `fymo.remote.Redirect` end to end -- see
+tests/integration/test_redirect_hydration.py, which drives this through the
+real compiled client bundle (not just checking the server's JSON)."""
+from fymo.remote import remote, Redirect
+
+
+@remote
+def go_to_login() -> None:
+    raise Redirect("/login")

--- a/examples/blog_app/app/templates/redirect_demo/index.svelte
+++ b/examples/blog_app/app/templates/redirect_demo/index.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  let { go_to_login }: { go_to_login: () => Promise<void> } = $props();
+</script>
+
+<header class="head">
+  <p class="kicker">Demo</p>
+  <h1>Redirect primitive</h1>
+  <p class="dek">Exercises <code>fymo.remote.Redirect</code> end to end.</p>
+</header>
+
+<button id="go-to-login" onclick={() => go_to_login()}>Go to login</button>
+
+<style>
+  .kicker {
+    font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--muted); margin: 0;
+  }
+  .head { margin-bottom: 2.5rem; }
+  .head h1 { font-size: clamp(2rem, 5.5vw, 2.6rem); font-weight: 700; margin: 0.6rem 0 0.4rem; }
+  .dek { color: var(--muted); margin: 0; }
+
+  button {
+    background: var(--accent); color: var(--accent-ink);
+    border: none; border-radius: 9px;
+    padding: 0.6rem 1.15rem; cursor: pointer;
+    font: inherit; font-weight: 600;
+  }
+</style>

--- a/examples/blog_app/fymo.yml
+++ b/examples/blog_app/fymo.yml
@@ -7,6 +7,7 @@ routes:
   resources:
     - posts
     - tags
+    - redirect_demo
 
 auth:
   enabled: true

--- a/fymo/build/entry_generator.py
+++ b/fymo/build/entry_generator.py
@@ -99,6 +99,7 @@ async function softNav(path, push = true) {{
     let env;
     try {{ env = await res.json(); }}
     catch (e) {{ window.location.href = path; return; }}
+    if (env.type === 'redirect') {{ window.location.href = env.location; return; }}
     if (env.type === 'error') {{ window.location.href = path; return; }}
     inflight = null;
 
@@ -355,6 +356,7 @@ async function softNav(path, push = true) {{
     let env;
     try {{ env = await res.json(); }}
     catch (e) {{ window.location.href = path; return; }}
+    if (env.type === 'redirect') {{ window.location.href = env.location; return; }}
     if (env.type === 'error') {{ window.location.href = path; return; }}
     inflight = null;
 

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -450,7 +450,9 @@ class FymoApp:
             # Return router without routes file - will use convention-based routing
             return Router()
     
-    def render_svelte_template(self, route_path: str, environ: dict | None = None) -> tuple[str, str]:
+    def render_svelte_template(
+        self, route_path: str, environ: dict | None = None
+    ) -> tuple[str, str, list[tuple[str, str]]]:
         """
         Render a Svelte component with SSR
 
@@ -461,7 +463,8 @@ class FymoApp:
                 session cookie during SSR when auth is enabled.
 
         Returns:
-            Tuple of (html, status_code)
+            Tuple of (html, status_code, extra_headers) -- extra_headers
+            carries e.g. Location when a controller raised Redirect.
         """
         return self.template_renderer.render_template(route_path, environ)
     
@@ -642,14 +645,14 @@ class FymoApp:
                 return route.handler(environ, start_response)
 
         # Handle template requests
-        html, status = self.render_svelte_template(path, environ)
+        html, status, extra_headers = self.render_svelte_template(path, environ)
         html_bytes = html.encode("utf-8")
-        start_response(
-            status, [
-                ("Content-Type", "text/html"),
-                ("Content-Length", str(len(html_bytes)))
-            ]
-        )
+        response_headers = [
+            ("Content-Type", "text/html"),
+            ("Content-Length", str(len(html_bytes))),
+        ]
+        response_headers.extend(extra_headers)
+        start_response(status, response_headers)
         return iter([html_bytes])
 
 

--- a/fymo/core/soft_nav.py
+++ b/fymo/core/soft_nav.py
@@ -7,6 +7,7 @@ Wire format (always HTTP 200; errors carried in the envelope):
 
     {"type": "result", "result": "<devalue>"}      # success
     {"type": "error", "status": 404, "error": "not_found"}
+    {"type": "redirect", "location": "/login", "status": 303}  # getContext() raised Redirect
 
 The decoded result has the shape:
 
@@ -53,6 +54,7 @@ from fymo.core.html import _safe_json
 from fymo.core.manifest_cache import ManifestUnavailable
 from fymo.core.ssr_controller import load_controller_context, load_layout_props_and_docs, merge_docs
 from fymo.remote import devalue
+from fymo.remote.errors import RemoteError, Redirect
 
 
 _PATH_PREFIX = "/_fymo/data/"
@@ -124,6 +126,17 @@ def handle_data(app, environ: dict, start_response) -> Iterable[bytes]:
             layout_props_by_level, layout_docs = load_layout_props_and_docs(
                 assets.layout_chain, params, getattr(app, "auth_enabled", False), environ
             )
+    except RemoteError as e:
+        # getContext() raised NotFound/Unauthorized/Redirect/etc directly,
+        # same as template_renderer.py's SSR path handles below (see that
+        # module for why: without this branch every RemoteError here used to
+        # fall through to the generic 500 below, losing its real status/code).
+        # Redirect is the one subclass that isn't an error at all -- it gets
+        # its own wire form, the same {"type": "redirect", ...} envelope the
+        # remote router already produces for a remote-function call raising it.
+        if isinstance(e, Redirect):
+            return _200(start_response, {"type": "redirect", "location": e.location, "status": e.status})
+        return _200(start_response, {"type": "error", "status": e.status, "error": e.code, "message": str(e)})
     except Exception as e:
         payload = {"type": "error", "status": 500, "error": "controller_failed"}
         if getattr(app, "dev", False):

--- a/fymo/core/template_renderer.py
+++ b/fymo/core/template_renderer.py
@@ -12,7 +12,7 @@ from fymo.core.router import Router
 from fymo.core.config import ConfigManager
 from fymo.core.assets import AssetManager
 from fymo.core.ssr_controller import load_controller_context, ssr_request_scope, load_layout_props_and_docs, merge_docs
-from fymo.remote.errors import RemoteError
+from fymo.remote.errors import RemoteError, Redirect
 from fymo.utils.colors import Color
 
 logger = logging.getLogger("fymo")
@@ -83,7 +83,9 @@ class TemplateRenderer:
             return f"<div>{generic_message}: {escape(str(e))}</div>", status
         return f"<div>{generic_message}</div>", status
 
-    def render_template(self, route_path: str, environ: dict | None = None) -> Tuple[str, str]:
+    def render_template(
+        self, route_path: str, environ: dict | None = None
+    ) -> Tuple[str, str, list[tuple[str, str]]]:
         """
         Render a Svelte component with SSR
 
@@ -98,11 +100,18 @@ class TemplateRenderer:
                 e.g. direct render_template() calls in tests.
 
         Returns:
-            Tuple of (html, status_code)
+            Tuple of (html, status_code, extra_headers). extra_headers is
+            normally empty; a raised Redirect populates it with a Location
+            header (see _render_redirect below) so the WSGI layer can attach
+            it to the response without every other caller having to know
+            about headers at all.
         """
         try:
-            return self._render_via_sidecar(route_path, environ)
+            html, status = self._render_via_sidecar(route_path, environ)
+            return html, status, []
         except RemoteError as e:
+            if isinstance(e, Redirect):
+                return self._render_redirect(e)
             # A controller's getContext() raised NotFound/Unauthorized/etc.
             # directly (not via a remote-function RPC call) -- e.g. a page
             # controller doing `get_post(slug)` and getting a 404-shaped
@@ -115,10 +124,24 @@ class TemplateRenderer:
             status_line = f"{e.status} {e.code.upper().replace('_', ' ')}"
             label = e.code.replace('_', ' ').title()
             print(f"{Color.FAIL}{label}: {e}{Color.ENDC}")
-            return self._render_error(e, label, status=status_line)
+            html, status = self._render_error(e, label, status=status_line)
+            return html, status, []
         except Exception as e:
             print(f"{Color.FAIL}Unexpected error: {str(e)}{Color.ENDC}")
-            return self._render_error(e, "Server Error")
+            html, status = self._render_error(e, "Server Error")
+            return html, status, []
+
+    def _render_redirect(self, e: Redirect) -> Tuple[str, str, list[tuple[str, str]]]:
+        """Turn a Redirect raised from getContext() into a real 30x.
+
+        No HTML body: browsers never render a 30x body, they just follow the
+        Location header straight to the new URL. Status line follows the
+        same `code.upper()` convention every other RemoteError subclass uses
+        here (see the NotFound/Unauthorized/etc branch above) rather than a
+        separate HTTP-reason-phrase table.
+        """
+        status_line = f"{e.status} {e.code.upper()}"
+        return "", status_line, [("Location", e.location)]
     
     def _render_via_sidecar(self, route_path: str, environ: dict | None = None) -> Tuple[str, str]:
         """New pipeline: render via Node sidecar with prebuilt SSR module."""

--- a/fymo/remote/__init__.py
+++ b/fymo/remote/__init__.py
@@ -1,10 +1,10 @@
 """Fymo remote functions: server-only Python callable from Svelte components."""
-from fymo.remote.errors import RemoteError, NotFound, Unauthorized, Forbidden, Conflict
+from fymo.remote.errors import RemoteError, NotFound, Unauthorized, Forbidden, Conflict, Redirect
 from fymo.remote.identity import current_uid
 from fymo.remote.context import request_event
 from fymo.remote.decorators import remote
 
 __all__ = [
-    "RemoteError", "NotFound", "Unauthorized", "Forbidden", "Conflict",
+    "RemoteError", "NotFound", "Unauthorized", "Forbidden", "Conflict", "Redirect",
     "current_uid", "request_event", "remote",
 ]

--- a/fymo/remote/errors.py
+++ b/fymo/remote/errors.py
@@ -32,3 +32,23 @@ class Forbidden(RemoteError):
 class Conflict(RemoteError):
     status = 409
     code = "conflict"
+
+
+class Redirect(RemoteError):
+    """Raised by a controller's getContext() or a remote function to send the
+    client elsewhere instead of returning a result.
+
+    Not an error, but subclasses RemoteError so it travels the exact seam
+    NotFound/Unauthorized/etc already use: the router, the SSR renderer, and
+    the soft-nav data endpoint each catch RemoteError around
+    controller/remote-function invocation, and special-case this subclass to
+    produce a redirect wire form (a real 30x + Location header for SSR, a
+    {"type": "redirect", ...} envelope for remote calls) instead of the
+    generic error envelope.
+    """
+    status = 303
+    code = "redirect"
+
+    def __init__(self, location: str, status: int = 303):
+        super().__init__(f"redirect to {location}", status=status, code="redirect")
+        self.location = location

--- a/fymo/remote/router.py
+++ b/fymo/remote/router.py
@@ -13,7 +13,7 @@ from fymo.remote import devalue
 from fymo.remote.adapters import validate_args
 from fymo.remote.context import request_scope
 from fymo.remote.discovery import is_exposed_remote_fn
-from fymo.remote.errors import RemoteError
+from fymo.remote.errors import RemoteError, Redirect
 from fymo.remote.identity import _ensure_uid
 
 try:
@@ -254,6 +254,12 @@ def handle_remote(environ: dict, start_response) -> Iterable[bytes]:
                 result = fn(*validated)
         except RemoteError as e:
             extra_cookies = consume_pending_cookies()
+            if isinstance(e, Redirect):
+                return _200(
+                    start_response,
+                    {"type": "redirect", "location": e.location, "status": e.status},
+                    set_cookie, extra_cookies,
+                )
             return _200(
                 start_response,
                 {"type": "error", "status": e.status, "error": e.code, "message": str(e)},

--- a/journal/journal_023.md
+++ b/journal/journal_023.md
@@ -1,0 +1,211 @@
+# Journal Entry 023: Finishing a Sentence Someone Else Started
+
+**Date**: July 16, 2026
+**Focus**: A server-side redirect primitive — the client half had been shipping since before I ever raised it
+**Status**: Shipped
+
+## Dead Code With a Pulse
+
+The report was unusual in a specific way: it wasn't "this is broken," it was
+"half of this already works and nobody noticed." A grep across the whole
+package confirmed it. `entry_generator.py`, in the generated `__rpc` helper
+every route bundle carries, had this sitting in it, twice:
+
+```js
+if (env.type === 'redirect') { window.location.href = env.location; return; }
+```
+
+`codegen.py`'s typed `$remote` client runtime had the identical branch. Two
+independent code paths, both written to expect a JSON envelope shaped
+`{"type": "redirect", "location": "..."}`, and not one line anywhere on the
+Python side that ever produced it. The client had been carrying a feature
+that literally could not fire. Somebody wrote this expecting the other half
+to follow shortly after, and it never did.
+
+Meanwhile the only place fymo actually writes a `Location` header is the
+OAuth providers' raw HTTP routes, which don't go through `getContext()` or a
+remote function at all — they're their own thing, bypassing the whole
+envelope mechanism. So a page controller that decides "you shouldn't be
+here" has exactly two moves: render anyway, or raise an error page. It can
+never say "go to `/login`."
+
+## Finding the Seam Before Building Next to It
+
+The instinct with a new exception type is to add a new `try/except` wherever
+it needs to be caught. I didn't want to do that here, because fymo already
+has one of these — `AuthRequired` — and I wanted to know exactly how it
+travels before deciding whether a redirect should travel the same way or
+needs its own path.
+
+Tracing it: `AuthRequired` is a `RemoteError` subclass, and `RemoteError` is
+already the seam. The remote router catches it around every function
+dispatch and turns it into `{"type": "error", "status": ..., "error": ...}`.
+`template_renderer.py` catches it too, around the full-page SSR render, so a
+controller's `getContext()` calling `get_post(slug)` and hitting a missing
+row gets a real 404 page instead of a flattened 500 — that fix predates this
+one. Two files, one exception hierarchy, one convention: subclass
+`RemoteError`, and both the RPC path and the SSR path already know what to
+do with you.
+
+Except one of them didn't, quite. `soft_nav.py` — the endpoint that serves
+soft navigations, `GET /_fymo/data/<path>` — wraps the same controller
+invocation in a bare `except Exception`. No `RemoteError` branch at all. A
+`NotFound` raised from `getContext()` during a soft nav was landing as a
+flattened `controller_failed` 500, silently losing its real status and
+code, the exact bug the SSR path had already been fixed for. Nobody had
+carried the fix over because nobody had gone looking at both files side by
+side for this specific reason before. I only found it because the task
+asked me to.
+
+So the actual plan wasn't "add a redirect path." It was: make a `Redirect`
+that's just another `RemoteError` subclass, fix the gap in `soft_nav.py`
+while I was already standing in exactly the right spot to see it, and let
+all three sites — router, renderer, soft-nav — special-case the one
+subclass that isn't really an error inside the `except RemoteError` block
+they already have, instead of writing a fourth thing.
+
+```python
+class Redirect(RemoteError):
+    status = 303
+    code = "redirect"
+
+    def __init__(self, location: str, status: int = 303):
+        super().__init__(f"redirect to {location}", status=status, code="redirect")
+        self.location = location
+```
+
+`303 See Other` as the default, matching the conventional POST-redirect-GET
+status. Everything else about it stayed a normal `RemoteError` — same
+constructor shape, same status/code fields — because the whole point was
+that nothing downstream needs to know it's special except the three call
+sites that pick the wire form.
+
+## Two Wire Forms, One Header the Return Type Didn't Have
+
+The remote-function path was mechanical once the seam was clear: catch
+`Redirect` before the generic `RemoteError` branch, emit
+`{"type": "redirect", "location": e.location, "status": e.status}` instead
+of the error envelope. Same for `soft_nav.py`, same envelope shape, since
+it's consumed by the same kind of client code either way.
+
+The SSR path needed something the code didn't have a place to put:
+`render_template()` returned `Tuple[str, str]` — html, status — and had
+nowhere to hang a `Location` header. Every caller, every test, unpacked
+exactly two values. I could have smuggled the header through some
+side-channel, but that's the kind of thing that looks clever for a week and
+confusing for a year. Changed the return shape to a 3-tuple instead —
+`(html, status, extra_headers)` — and pushed the change through the actual
+call chain: `TemplateRenderer.render_template` → `FymoApp.render_svelte_template`
+→ the WSGI handler that builds the response headers list. Thirteen existing
+call sites across four test files needed the third element added to their
+unpacking. All mechanical, all the same one-line change, and the compiler —
+well, Python doesn't have one, but `ValueError: not enough values to unpack`
+found every one of them for me the first time I ran the suite.
+
+For a `Redirect`, the SSR renderer now returns an empty body and
+`[("Location", e.location)]` — browsers don't render a 30x body, they just
+follow the header. Status line stays consistent with how every other
+`RemoteError` subclass in this file already formats one, `e.code.upper()`,
+so a redirect prints `303 REDIRECT` instead of the textbook `303 SEE OTHER`.
+That reads slightly unusual next to curl output, but HTTP clients decide
+navigation from the numeric code, not the reason phrase, and I'd rather
+match the file's existing convention than invent a second one for one
+status.
+
+## The Client Half Had a Gap of Its Own
+
+While I was in `entry_generator.py` confirming exactly what shape the
+`__rpc` branch expected, I noticed the *other* client function in the same
+file — `softNav()`, the one that actually drives a soft navigation by
+fetching `/_fymo/data/<path>` — only checked for `env.type === 'error'`. No
+redirect branch. If `soft_nav.py`'s newly-fixed `getContext()` path ever
+raised a `Redirect` during a soft nav instead of a full page load, the
+client would fall through, try to `parse(env.result)` on `undefined`, and
+throw somewhere nobody was catching it. Since I'd just made the server side
+support exactly that case, leaving the client half broken would have meant
+shipping a mechanism that only worked from a fresh page load and silently
+broke the second you clicked into the app first. Added the same one-line
+branch there too, in both templates (the plain route and the layout-shell
+route each generate their own copy of this function).
+
+## Proving the Dead Branch Actually Runs
+
+The acceptance bar here was specific on purpose: not "the server returns the
+right JSON," but "the client branch that's been sitting there unreachable
+actually executes." That meant driving a real click through a real compiled
+bundle, not asserting on a devalue string.
+
+fymo already has the tool for this — `hydration_check.mjs`, a jsdom
+harness that boots the actual esbuild output with a real `hydrate()` call,
+built for exactly this kind of "does the browser actually do the thing"
+proof. It has an `afterBoot` hook for driving interaction after a clean
+boot. I added a tiny demo page to the blog example — one remote function,
+`go_to_login()`, that unconditionally raises `Redirect("/login")`, wired to
+a button — and wrote a test that boots the real page, clicks the real
+button, and waits.
+
+First run threw immediately: `Failed to parse URL from /_fymo/remote/.../go_to_login`.
+jsdom doesn't implement `fetch` at all, so the bundle's `fetch(url)` call
+was resolving to Node's own global fetch — and Node's fetch has no notion
+of a page origin the way a browser does, so it can't resolve a relative
+URL. Fixed by wrapping `fetch` for the duration of the click to prefix
+relative paths with the real server's origin, which is exactly what a
+browser does for you automatically and the only reason it needed doing by
+hand here.
+
+Second problem was worse, because it wasn't a crash, it was a silent no-op.
+`window.location.href = '/login'` executed without error and the location
+never changed. jsdom simply doesn't implement navigation — it logs "Not
+implemented: navigation to another Document" and leaves `location` alone.
+I tried to intercept it three different ways before finding one that
+worked: redefining `window.location` directly (jsdom marks it
+non-configurable, throws), redefining `.href` on the `Location` prototype
+(also non-configurable, and it turns out `href` isn't even on the
+prototype — it's an own property on each instance), and finally swapping
+out the `window` *binding itself* for a fresh object that inherits
+everything from the real jsdom window except `location`, which points at a
+plain recordable stub instead:
+
+```js
+globalThis.window = Object.create(originalWindow, {
+  location: { value: { href: null }, configurable: true },
+});
+```
+
+That works because nothing else in this exact click's code path touches
+`window` — the redirect branch is the only thing that does, right at the
+end, after the fetch and the JSON parse are already done. Click, wait, read
+the stub's `href` back: `/login`, exactly what the server's `Redirect`
+carried. To make sure the test wasn't a tautology, I reverted the router's
+redirect handling and re-ran it — it failed for the right reason, an
+uncaught `Error: redirect to /login` thrown by the generic error branch the
+old code fell into, exactly the failure mode the whole feature exists to
+prevent.
+
+## What I Left Alone
+
+The issue asked, explicitly, whether a redirect target should be validated
+— same-origin clamping, the kind of thing `oauth.py`'s `_safe_next` already
+does for its own `next` parameter. I didn't add it. `_safe_next` exists
+because that value comes from a query string an attacker can set; `Redirect`'s
+location comes from the app's own source code, the same trust boundary
+every other `RemoteError` subclass already lives inside. Fymo doesn't
+decide when to redirect or validate where to — that's the app's call, same
+as it already is for every other exception in this file. If an app ever
+builds a redirect target out of user input, clamping it is that app's job,
+the same way it already is for anyone hand-rolling a `Location` header
+today.
+
+## The Count
+
+830 passing, 92 skipped — the skips are pre-existing, an unrelated example
+app's `node_modules` and a Postgres integration test that needs a real
+database, neither touched by this change. One dead branch, written months
+ago for a feature that didn't exist yet, finally executed for the first
+time — watched it happen, in a real jsdom-hydrated page, clicking a real
+button, on a run where I'd deliberately broken the server first to
+watch it fail before watching it pass.
+
+---
+
+*End of Journal Entry 023*

--- a/journal/journal_025.md
+++ b/journal/journal_025.md
@@ -1,4 +1,4 @@
-# Journal Entry 023: Finishing a Sentence Someone Else Started
+# Journal Entry 025: Finishing a Sentence Someone Else Started
 
 **Date**: July 16, 2026
 **Focus**: A server-side redirect primitive — the client half had been shipping since before I ever raised it
@@ -208,4 +208,4 @@ watch it fail before watching it pass.
 
 ---
 
-*End of Journal Entry 023*
+*End of Journal Entry 025*

--- a/tests/build/test_entry_generator.py
+++ b/tests/build/test_entry_generator.py
@@ -70,6 +70,19 @@ def test_entry_error_branch_shares_the_runtime_error_handling(tmp_path: Path):
     assert "e.traceback = env.traceback;" in text
 
 
+def test_softnav_handles_redirect_envelope_no_layout(tmp_path: Path):
+    """Issue #58: a controller's getContext() raising Redirect during a
+    soft-nav transition must send the browser to the new location, the same
+    way the __rpc redirect branch already does for a remote-function call --
+    not fall through to whatever the `type === 'error'` branch does."""
+    route = Route(name="home", entry_path=tmp_path / "templates/home/index.svelte")
+    out_dir = tmp_path / ".fymo" / "entries"
+    write_client_entries([route], out_dir, project_root=tmp_path)
+    text = (out_dir / "home.client.js").read_text()
+    assert "env.type === 'redirect'" in text
+    assert text.count("env.type === 'redirect'") >= 2  # __rpc AND softNav
+
+
 def test_entry_wires_reactive_route_state_no_layout(tmp_path: Path):
     """Issue #42: the plain (no layout_chain) entry imports fymo's shared
     reactive route store and delegates seeding/updating to it, rather than
@@ -144,6 +157,7 @@ def test_layout_chain_generates_shell_and_bootstrap(tmp_path: Path):
     assert shell.count("{@render leafSlot()}") == 2
 
     bootstrap = written["posts"].read_text()
+    assert bootstrap.count("env.type === 'redirect'") >= 2  # __rpc AND softNav
     assert "import Shell from './posts.shell.svelte'" in bootstrap
     assert "hydrate(Shell" in bootstrap
     assert "shellInstance.swapLeaf" in bootstrap

--- a/tests/build/test_prepare.py
+++ b/tests/build/test_prepare.py
@@ -291,7 +291,9 @@ def test_mode_strict_prints_no_deprecation_warning(example_app: Path, monkeypatc
 @pytest.mark.usefixtures("node_available")
 def test_prepare_build_config_reflects_blog_app_facts(blog_app: Path):
     """blog_app has index/, posts/ (with a resource _layout.svelte and
-    show.svelte), and tags/ (show.svelte, no resource layout), plus a root
+    show.svelte), tags/ (show.svelte, no resource layout), and
+    redirect_demo/ (index.svelte, a standalone demo of fymo.remote.Redirect
+    -- see tests/integration/test_redirect_hydration.py), plus a root
     _layout.svelte -- so this pins the known shape of what prepare must
     produce for both `fymo build` and `fymo dev` to agree on."""
     dist_dir = blog_app / "dist"
@@ -302,7 +304,7 @@ def test_prepare_build_config_reflects_blog_app_facts(blog_app: Path):
     assert isinstance(config, BuildConfig)
 
     route_names = {r.name for r in config.routes}
-    assert route_names == {"index", "posts", "tags"}
+    assert route_names == {"index", "posts", "tags", "redirect_demo"}
 
     layout_ids = {ref.id for ref in config.all_layouts}
     assert "_root" in layout_ids

--- a/tests/core/test_error_page_xss.py
+++ b/tests/core/test_error_page_xss.py
@@ -47,7 +47,7 @@ def test_render_template_generic_error_escapes_in_dev(tmp_path, monkeypatch):
         raise ValueError("<script>alert(1)</script>")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    html, status = r.render_template("/whatever")
+    html, status, _headers = r.render_template("/whatever")
     assert status == "500 INTERNAL SERVER ERROR"
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
@@ -60,7 +60,7 @@ def test_render_template_generic_error_omits_text_in_prod(tmp_path, monkeypatch)
         raise ValueError("<script>alert(1)</script>")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    html, status = r.render_template("/whatever")
+    html, status, _headers = r.render_template("/whatever")
     assert status == "500 INTERNAL SERVER ERROR"
     assert "<script>" not in html
     assert "alert(1)" not in html
@@ -76,7 +76,7 @@ def test_render_template_message_style_error_escapes_in_dev(tmp_path, monkeypatc
         raise ConfigurationError("<script>alert(1)</script>")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    html, status = r.render_template("/whatever")
+    html, status, _headers = r.render_template("/whatever")
     assert status == "500 INTERNAL SERVER ERROR"
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
@@ -89,7 +89,7 @@ def test_render_template_message_style_error_omits_text_in_prod(tmp_path, monkey
         raise ConfigurationError("<script>alert(1)</script>")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    html, status = r.render_template("/whatever")
+    html, status, _headers = r.render_template("/whatever")
     assert status == "500 INTERNAL SERVER ERROR"
     assert "<script>" not in html
     assert "alert(1)" not in html

--- a/tests/core/test_remote_error_status_mapping.py
+++ b/tests/core/test_remote_error_status_mapping.py
@@ -25,7 +25,7 @@ def test_not_found_renders_404_not_500(tmp_path, monkeypatch):
         raise NotFound("post 'missing-slug' not found")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    html, status = r.render_template("/posts/missing-slug")
+    html, status, _headers = r.render_template("/posts/missing-slug")
     assert status == "404 NOT FOUND"
     assert "Not Found" in html
 
@@ -37,7 +37,7 @@ def test_unauthorized_renders_401(tmp_path, monkeypatch):
         raise Unauthorized("sign in required")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    _, status = r.render_template("/whatever")
+    _, status, _headers = r.render_template("/whatever")
     assert status == "401 UNAUTHORIZED"
 
 
@@ -48,7 +48,7 @@ def test_forbidden_renders_403(tmp_path, monkeypatch):
         raise Forbidden("not your post")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    _, status = r.render_template("/whatever")
+    _, status, _headers = r.render_template("/whatever")
     assert status == "403 FORBIDDEN"
 
 
@@ -59,7 +59,7 @@ def test_conflict_renders_409(tmp_path, monkeypatch):
         raise Conflict("already exists")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    _, status = r.render_template("/whatever")
+    _, status, _headers = r.render_template("/whatever")
     assert status == "409 CONFLICT"
 
 
@@ -73,7 +73,7 @@ def test_not_found_message_still_escaped_in_dev(tmp_path, monkeypatch):
         raise NotFound("post '<script>alert(1)</script>' not found")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    html, status = r.render_template("/whatever")
+    html, status, _headers = r.render_template("/whatever")
     assert status == "404 NOT FOUND"
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
@@ -86,6 +86,6 @@ def test_not_found_omits_message_in_prod(tmp_path, monkeypatch):
         raise NotFound("post 'secret-internal-id-42' not found")
 
     monkeypatch.setattr(r, "_render_via_sidecar", boom)
-    html, status = r.render_template("/whatever")
+    html, status, _headers = r.render_template("/whatever")
     assert status == "404 NOT FOUND"
     assert "secret-internal-id-42" not in html

--- a/tests/core/test_soft_nav_redirect.py
+++ b/tests/core/test_soft_nav_redirect.py
@@ -1,0 +1,102 @@
+"""Unit coverage for the soft-nav data endpoint's Redirect handling.
+
+Fast, no Node sidecar, no example app build -- a minimal fake `app` (router +
+manifest_cache) plus a controller module registered directly in
+sys.modules, mirroring the fake-controller style tests/core/test_ssr_controller.py
+already uses for load_controller_context. Exercises the same
+`{"type": "redirect", ...}` wire form the remote router already produces
+(tests/remote/test_router.py) so a controller's getContext() raising Redirect
+during a soft-nav transition behaves identically to a remote-function call
+raising it.
+"""
+import io
+import json
+import sys
+import types
+
+import pytest
+
+from fymo.build.manifest import RouteAssets
+from fymo.core.soft_nav import handle_data
+from fymo.remote.errors import Redirect, NotFound
+
+
+def _wsgi_get(app, path: str):
+    responses = []
+    def sr(s, h): responses.append((s, h))
+    out = b"".join(handle_data(app, {
+        "REQUEST_METHOD": "GET", "PATH_INFO": path, "QUERY_STRING": "",
+        "CONTENT_LENGTH": "0", "CONTENT_TYPE": "",
+        "HTTP_COOKIE": "",
+        "wsgi.input": io.BytesIO(b""), "wsgi.errors": sys.stderr, "wsgi.url_scheme": "http",
+    }, sr))
+    return responses[0], json.loads(out)
+
+
+class _FakeRouter:
+    def match(self, path):
+        return {"controller": "redirtest", "params": {}}
+
+    def soft_nav_enabled(self, controller_name):
+        return True
+
+
+class _FakeManifest:
+    def __init__(self):
+        self.routes = {
+            "redirtest": RouteAssets(ssr="ssr/x.mjs", client="client/x.js", css=None, preload=[]),
+        }
+        self.layouts = {}
+        self.global_css = []
+
+
+class _FakeManifestCache:
+    def get(self):
+        return _FakeManifest()
+
+
+class _FakeApp:
+    def __init__(self):
+        self.router = _FakeRouter()
+        self.manifest_cache = _FakeManifestCache()
+        self.dev = True
+        self.auth_enabled = False
+
+
+def _register_controller(getContext):
+    mod = types.ModuleType("app.controllers.redirtest")
+    mod.getContext = getContext
+    sys.modules["app.controllers.redirtest"] = mod
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    sys.modules.pop("app.controllers.redirtest", None)
+
+
+def test_getcontext_redirect_returns_redirect_envelope():
+    _register_controller(lambda: (_ for _ in ()).throw(Redirect("/login")))
+    (status, _), body = _wsgi_get(_FakeApp(), "/_fymo/data/whatever")
+    assert status.startswith("200")
+    assert body == {"type": "redirect", "location": "/login", "status": 303}
+
+
+def test_getcontext_redirect_honors_custom_status():
+    _register_controller(lambda: (_ for _ in ()).throw(Redirect("/login", status=307)))
+    (status, _), body = _wsgi_get(_FakeApp(), "/_fymo/data/whatever")
+    assert status.startswith("200")
+    assert body == {"type": "redirect", "location": "/login", "status": 307}
+
+
+def test_getcontext_remote_error_maps_status_instead_of_flattening_to_500():
+    """A NotFound/etc RemoteError raised from getContext() during soft-nav
+    must map to its real status/code, matching what template_renderer.py
+    already does for the full-page SSR path -- previously any RemoteError
+    here fell through to the generic `controller_failed` 500, losing the
+    status/code entirely."""
+    _register_controller(lambda: (_ for _ in ()).throw(NotFound("nope")))
+    (status, _), body = _wsgi_get(_FakeApp(), "/_fymo/data/whatever")
+    assert status.startswith("200")
+    assert body == {"type": "error", "status": 404, "error": "not_found", "message": "nope"}

--- a/tests/core/test_template_renderer_layouts.py
+++ b/tests/core/test_template_renderer_layouts.py
@@ -45,7 +45,7 @@ def test_props_are_flat_when_route_has_no_layout_chain(tmp_path, monkeypatch):
     mod.getDoc = lambda: {"title": "Home"}
     sys.modules["app.controllers.home"] = mod
     try:
-        html, status = renderer.render_template("/")
+        html, status, _headers = renderer.render_template("/")
     finally:
         del sys.modules["app.controllers.home"]
 
@@ -79,7 +79,7 @@ def test_full_page_render_embeds_matched_params(tmp_path, monkeypatch):
     mod.getDoc = lambda: {"title": "Post"}
     sys.modules["app.controllers.posts"] = mod
     try:
-        html, status = renderer.render_template("/posts/welcome-to-fymo")
+        html, status, _headers = renderer.render_template("/posts/welcome-to-fymo")
     finally:
         del sys.modules["app.controllers.posts"]
 
@@ -114,7 +114,7 @@ def test_props_are_nested_when_route_has_layout_chain(tmp_path, monkeypatch):
     mod.getDoc = lambda: {"title": "Home"}
     sys.modules["app.controllers.home"] = mod
     try:
-        html, status = renderer.render_template("/")
+        html, status, _headers = renderer.render_template("/")
     finally:
         del sys.modules["app.controllers.home"]
 

--- a/tests/core/test_template_renderer_redirect.py
+++ b/tests/core/test_template_renderer_redirect.py
@@ -1,0 +1,58 @@
+"""Redirect raised from a controller's getContext() on a direct page load
+must produce a real HTTP 30x with a Location header -- not an HTML error
+page. See fymo.remote.Redirect and issue #58.
+"""
+from pathlib import Path
+
+from fymo.core.config import ConfigManager
+from fymo.core.assets import AssetManager
+from fymo.core.router import Router
+from fymo.core.template_renderer import TemplateRenderer
+from fymo.remote.errors import Redirect
+
+
+def _make_renderer(tmp_path: Path, dev: bool = False) -> TemplateRenderer:
+    config_manager = ConfigManager(tmp_path, {})
+    asset_manager = AssetManager(tmp_path)
+    router = Router()
+    return TemplateRenderer(tmp_path, config_manager, asset_manager, router, dev=dev)
+
+
+def test_redirect_produces_303_with_location_header(tmp_path, monkeypatch):
+    r = _make_renderer(tmp_path, dev=True)
+
+    def boom(route_path, environ=None):
+        raise Redirect("/login")
+
+    monkeypatch.setattr(r, "_render_via_sidecar", boom)
+    html, status, headers = r.render_template("/dashboard")
+    assert status.startswith("303")
+    assert dict(headers)["Location"] == "/login"
+
+
+def test_redirect_honors_custom_status(tmp_path, monkeypatch):
+    r = _make_renderer(tmp_path, dev=True)
+
+    def boom(route_path, environ=None):
+        raise Redirect("/login", status=307)
+
+    monkeypatch.setattr(r, "_render_via_sidecar", boom)
+    _, status, headers = r.render_template("/dashboard")
+    assert status.startswith("307")
+    assert dict(headers)["Location"] == "/login"
+
+
+def test_non_redirect_paths_return_empty_headers(tmp_path, monkeypatch):
+    """render_template's success path must still return the 3-tuple shape
+    with an empty headers list, not break existing callers that only care
+    about html/status."""
+    r = _make_renderer(tmp_path, dev=True)
+
+    def ok(route_path, environ=None):
+        return "<html>hi</html>", "200 OK"
+
+    monkeypatch.setattr(r, "_render_via_sidecar", ok)
+    html, status, headers = r.render_template("/")
+    assert html == "<html>hi</html>"
+    assert status == "200 OK"
+    assert headers == []

--- a/tests/integration/test_redirect_hydration.py
+++ b/tests/integration/test_redirect_hydration.py
@@ -1,0 +1,129 @@
+"""End-to-end proof that a remote function raising `fymo.remote.Redirect`
+actually navigates the browser, not just that the server produced the right
+JSON envelope -- see issue #58.
+
+Builds blog_app for real, serves it on a real TCP port, and drives the real
+compiled client bundle through jsdom's real hydrate() (fymo/build/js/
+hydration_check.mjs, same tool tests/integration/test_hydration_real.py
+uses), then clicks the `#go-to-login` button wired to blog_app's
+`app/remote/redirect_demo.go_to_login` remote function. That function
+unconditionally raises Redirect("/login"), so a real click round-trips
+through: the real Svelte click handler -> the real generated `__rpc` (the
+exact code at fymo/build/entry_generator.py's `if (env.type === 'redirect')`
+branch) -> a real fetch to the real running WSGI app -> fymo's remote router
+catching Redirect -> the real {"type": "redirect", "location": "/login", ...}
+JSON -> back into `__rpc`, which must then set `window.location.href`.
+
+jsdom does not implement real navigation (`window.location.href = ...`
+silently no-ops and logs "Not implemented: navigation to another Document"
+instead of taking effect -- this is a known, permanent jsdom limitation, not
+a fymo bug), so asserting on the real `window.location.href` after the click
+is not possible here. Instead, `afterBoot` temporarily substitutes
+`globalThis.window` for a shallow object that inherits everything from the
+real jsdom window except `location`, which is replaced with a plain
+recordable stub -- the bundle's `window.location.href = env.location`
+assignment then lands on that stub instead of jsdom's real (inert) Location
+object, capturing exactly what the generated code attempted to do without
+needing jsdom to actually support navigation. Node's own `fetch` also
+doesn't know the page's origin the way a real browser's does, so relative
+URLs (`/_fymo/remote/...`) are also resolved against the real server's
+origin for the duration of the click.
+"""
+import json
+import socket
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+HYDRATION_CHECK_JS = REPO_ROOT / "fymo" / "build" / "js" / "hydration_check.mjs"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.usefixtures("node_available")
+def test_remote_function_redirect_navigates_through_real_client_bundle(blog_app: Path, monkeypatch):
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=blog_app).build(dev=False)
+
+    monkeypatch.chdir(blog_app)
+    from fymo import create_app
+    app = create_app(blog_app, dev=True)
+
+    from fymo.server.dev import make_dev_server
+    port = _free_port()
+    server = make_dev_server("127.0.0.1", port, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{port}/redirect_demo"
+        dist_dir = blog_app / "dist"
+        script = f"""
+import {{ checkHydration }} from {json.dumps(str(HYDRATION_CHECK_JS))};
+
+const url = {json.dumps(url)};
+let capturedHref = null;
+let clickError = null;
+
+const result = await checkHydration(url, {json.dumps(str(dist_dir))}, 5000, {{
+  afterBoot: async (window) => {{
+    // Substitute window.location for a recordable stub -- see this file's
+    // module docstring for why jsdom's real Location can't be observed.
+    const fakeLocation = {{ href: null }};
+    const originalWindow = globalThis.window;
+    globalThis.window = Object.create(originalWindow, {{
+      location: {{ value: fakeLocation, configurable: true }},
+    }});
+    // Node's fetch has no page origin to resolve relative URLs against
+    // (unlike a real browser) -- give it the real server's origin.
+    const origin = new URL(url).origin;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (input, init) => {{
+      if (typeof input === 'string' && input.startsWith('/')) input = origin + input;
+      return realFetch(input, init);
+    }};
+    try {{
+      const btn = window.document.getElementById('go-to-login');
+      if (!btn) throw new Error('button #go-to-login not found in rendered page');
+      btn.click();
+      const deadline = Date.now() + 3000;
+      while (fakeLocation.href === null && Date.now() < deadline) {{
+        await new Promise((r) => setTimeout(r, 25));
+      }}
+      capturedHref = fakeLocation.href;
+    }} catch (e) {{
+      clickError = e && (e.stack || e.message || String(e));
+    }} finally {{
+      globalThis.window = originalWindow;
+      globalThis.fetch = realFetch;
+    }}
+  }},
+}});
+
+console.log(JSON.stringify({{ result, capturedHref, clickError }}));
+"""
+        proc = subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert proc.returncode == 0, f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+        outcome = json.loads(proc.stdout.strip().splitlines()[-1])
+
+        assert outcome["clickError"] is None, outcome
+        assert outcome["result"]["errors"] == [], outcome["result"]
+        assert outcome["result"]["ok"] is True, outcome["result"]
+        # The real proof: the client's `if (env.type === 'redirect')` branch
+        # (entry_generator.py:47) executed and attempted to navigate to
+        # exactly the location the server's Redirect("/login") carried.
+        assert outcome["capturedHref"] == "/login", outcome
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        if app.sidecar:
+            app.sidecar.stop()

--- a/tests/integration/test_redirect_ssr_e2e.py
+++ b/tests/integration/test_redirect_ssr_e2e.py
@@ -1,0 +1,76 @@
+"""End-to-end: a controller's getContext() raising Redirect on a direct
+(full) page load must produce a real HTTP 30x with a Location header, not
+an HTML page -- see fymo.remote.Redirect and issue #58."""
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _wsgi_get_raw(app, path: str):
+    responses = []
+    def sr(s, h): responses.append((s, h))
+    body = b"".join(app({
+        "REQUEST_METHOD": "GET", "PATH_INFO": path, "QUERY_STRING": "",
+        "CONTENT_LENGTH": "0", "CONTENT_TYPE": "",
+        "HTTP_COOKIE": "",
+        "SERVER_NAME": "x", "SERVER_PORT": "0", "SERVER_PROTOCOL": "HTTP/1.1",
+        "REMOTE_ADDR": "127.0.0.1",
+        "wsgi.input": io.BytesIO(b""), "wsgi.errors": sys.stderr, "wsgi.url_scheme": "http",
+    }, sr))
+    return responses[0], body
+
+
+@pytest.mark.usefixtures("node_available")
+def test_getcontext_redirect_produces_303_with_location(blog_app: Path, monkeypatch):
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=blog_app).build(dev=False)
+
+    monkeypatch.chdir(blog_app)
+    from fymo import create_app
+    app = create_app(blog_app)
+
+    import app.controllers.index as index_controller
+    from fymo.remote import Redirect
+
+    def raise_redirect():
+        raise Redirect("/login")
+
+    monkeypatch.setattr(index_controller, "getContext", raise_redirect)
+
+    try:
+        (status, headers), body = _wsgi_get_raw(app, "/")
+        assert status.startswith("303")
+        header_dict = dict(headers)
+        assert header_dict["Location"] == "/login"
+        assert body == b""
+    finally:
+        if app.sidecar:
+            app.sidecar.stop()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_getcontext_redirect_honors_custom_status(blog_app: Path, monkeypatch):
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=blog_app).build(dev=False)
+
+    monkeypatch.chdir(blog_app)
+    from fymo import create_app
+    app = create_app(blog_app)
+
+    import app.controllers.index as index_controller
+    from fymo.remote import Redirect
+
+    def raise_redirect():
+        raise Redirect("/dashboard", status=307)
+
+    monkeypatch.setattr(index_controller, "getContext", raise_redirect)
+
+    try:
+        (status, headers), body = _wsgi_get_raw(app, "/")
+        assert status.startswith("307")
+        assert dict(headers)["Location"] == "/dashboard"
+    finally:
+        if app.sidecar:
+            app.sidecar.stop()

--- a/tests/remote/test_errors.py
+++ b/tests/remote/test_errors.py
@@ -1,5 +1,5 @@
 import pytest
-from fymo.remote.errors import RemoteError, NotFound, Unauthorized, Forbidden, Conflict
+from fymo.remote.errors import RemoteError, NotFound, Unauthorized, Forbidden, Conflict, Redirect
 
 
 def test_remote_error_carries_status_and_code():
@@ -23,3 +23,22 @@ def test_subclasses_have_correct_status():
 def test_subclass_message_preserved():
     e = NotFound("post 'foo' not found")
     assert "post 'foo' not found" in str(e)
+
+
+def test_redirect_defaults_to_303():
+    r = Redirect("/login")
+    assert r.location == "/login"
+    assert r.status == 303
+    assert r.code == "redirect"
+
+
+def test_redirect_accepts_custom_status():
+    r = Redirect("/login", status=307)
+    assert r.status == 307
+    assert r.location == "/login"
+
+
+def test_redirect_is_a_remote_error():
+    """Redirect must travel the same seam RemoteError subclasses already do
+    through the router/renderer/soft-nav `except RemoteError` blocks."""
+    assert isinstance(Redirect("/login"), RemoteError)

--- a/tests/remote/test_router.py
+++ b/tests/remote/test_router.py
@@ -53,10 +53,12 @@ def remote_project(tmp_path, monkeypatch):
         "app/__init__.py": "",
         "app/remote/__init__.py": "",
         "app/remote/posts.py": (
-            "from fymo.remote import current_uid, NotFound\n"
+            "from fymo.remote import current_uid, NotFound, Redirect\n"
             "def hello(name: str) -> str: return f'hi {name}'\n"
             "def whoami() -> str: return current_uid()\n"
             "def boom() -> str: raise NotFound('nope')\n"
+            "def go_to_login() -> None: raise Redirect('/login')\n"
+            "def go_with_status() -> None: raise Redirect('/login', status=307)\n"
         ),
     })
     monkeypatch.syspath_prepend(str(proj))
@@ -147,6 +149,26 @@ def test_domain_error_returns_envelope(remote_project):
     assert body["type"] == "error"
     assert body["status"] == 404
     assert body["error"] == "not_found"
+
+
+def test_redirect_returns_redirect_envelope(remote_project):
+    """A remote function raising Redirect must produce {"type": "redirect",
+    "location": ..., "status": ...}, not the generic error envelope -- this
+    is the wire form entry_generator.py's __rpc client already knows how to
+    read (`if (env.type === 'redirect') window.location.href = env.location`)."""
+    proj, h = remote_project
+    env = _make_environ(f"/_fymo/remote/{h}/go_to_login", [], host="x", origin="http://x")
+    (status, _), body = _call(env)
+    assert status.startswith("200")
+    assert body == {"type": "redirect", "location": "/login", "status": 303}
+
+
+def test_redirect_honors_custom_status(remote_project):
+    proj, h = remote_project
+    env = _make_environ(f"/_fymo/remote/{h}/go_with_status", [], host="x", origin="http://x")
+    (status, _), body = _call(env)
+    assert status.startswith("200")
+    assert body == {"type": "redirect", "location": "/login", "status": 307}
 
 
 def test_uid_cookie_issued_on_first_call(remote_project):


### PR DESCRIPTION
## Summary

Closes #58. fymo had no way for a controller's getContext() or a remote function to say "go here instead". Half of this already shipped: the generated client has honored a `type: "redirect"` envelope for a while, dead code waiting for a server half that never existed.

Adds `Redirect(location, status=303)` as a RemoteError subclass, alongside NotFound/Unauthorized/Forbidden/Conflict, so it travels the exact same seam those already use rather than a new parallel path:

- SSR path (template_renderer.py): produces a real 30x with a Location header, no HTML body
- soft-nav path (soft_nav.py): produces the `{"type": "redirect", ...}` envelope the client already reads
- remote-function path (remote/router.py): same envelope

Found and fixed a real pre-existing gap while tracing this: soft_nav.py had no RemoteError handling at all, so any domain error raised from getContext() during a soft nav was flattening to a generic 500 and losing its real status/code. Fixed alongside wiring in Redirect since both needed the same branch.

No same-origin validation on the redirect target, deliberate: this is framed as a pure mechanism the app is trusted to call correctly, unlike OAuth's `_safe_next` which clamps a value that actually is attacker-controlled.

## Test plan

- [x] Unit tests for Redirect construction and the router/renderer/soft-nav wiring
- [x] End to end proof the previously-dead client branch actually executes: a real compiled bundle hydrated in jsdom, clicking a real button that calls a remote function raising Redirect, confirmed the fix by reverting it and watching the test fail for the right reason first
- [x] Full suite green