### PR TITLE
Add fymo jobs-status: read-only job state visibility

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -54,6 +54,57 @@ warning suggesting `@task` be added. Real implementation that a task calls
 into belongs in `app/support/`, not underscore-prefixed helpers living next
 to the task in the same module.
 
+## Job status visibility and app-level progress tracking
+
+`fymo jobs-status` prints whatever the configured `JobProvider` knows about
+job state: counts by status, then the most recent jobs (id, task, status,
+queued-at). It reads the provider's own bookkeeping — for `procrastinate`
+that's the status procrastinate already tracks in its own Postgres tables,
+so "is this job stuck" no longer means hand-querying `procrastinate_jobs`.
+Pass `--dev` if `DATABASE_URL` lives in `.env` (same flag semantics as
+`fymo jobs-worker --dev`), and `--limit N` to change how many recent jobs
+are listed.
+
+Not every provider tracks state. The status surface is an optional pair of
+read-only methods on the provider seam (`job_counts()` /
+`list_recent_jobs(limit)`, `fymo/jobs/providers/base.py`); returning `None`
+means "this provider doesn't track job state", and the CLI then exits with
+a message saying so instead of printing an empty report. The default
+`threaded` provider returns `None` deliberately: its executor state lives
+inside the web process, and `fymo jobs-status` runs as its own OS process,
+so the only numbers it could ever report would be a fresh provider's zeros.
+
+### What fymo deliberately does not track
+
+fymo does not track job **progress or results** — not for procrastinate,
+not for any provider. A submitted job is fire-and-forget from the caller's
+side: no return value, no progress percentage, no result payload. This is
+the same boundary `fymo.jobs` has had from the start, kept on purpose:
+progress is app domain data (what "40% done" means is different for a
+video encode and a crawl), and any fymo-owned progress store would just be
+a second, worse database next to the one the app already has.
+`fymo jobs-status` surfaces queue *state* (queued/running/failed) because
+the provider already tracks it; it does not invent job *progress*.
+
+### The app-level progress convention
+
+A job that needs observable progress writes it to the app's own storage,
+keyed by an id the submitter chose, and readers poll or subscribe:
+
+1. The submitter (usually a remote function) creates a row in an app table
+   (e.g. `job_runs(id, kind, status, progress, detail, updated_at)`) and
+   passes that row's id to `submit()` as a normal task argument.
+2. The task updates that row as it goes — status transitions, a progress
+   counter, a result reference when done, the error message on failure —
+   inside the task body, exactly like any other database write.
+3. The browser reads it back through a remote function that queries the
+   row, or live via an `app/broadcasts` channel the task publishes to
+   (the jobs worker process already initializes broadcasts for this).
+
+This keeps progress in the place that survives restarts, is queryable with
+plain SQL, and renders with the same `$remote`/`$broadcast` machinery every
+other page uses — no fymo-specific progress API to learn or outgrow.
+
 ## `$route`: reactive current-route state
 
 `location.pathname` read inside `$effect` never re-runs after a soft

--- a/fymo/cli/commands/jobs_status.py
+++ b/fymo/cli/commands/jobs_status.py
@@ -48,13 +48,24 @@ def run_jobs_status(
     provider_config = config_manager.get_jobs_config().get("provider")
     provider = init_job_provider(project_root, provider_config)
 
+    # Both status methods are read through getattr for the same reason
+    # close() is below: the registry never required BaseJobProvider
+    # subclassing, so a duck-typed provider written against the pre-status
+    # contract simply lacks them, and that means "tracks nothing", not an
+    # AttributeError traceback.
+    counts_fn = getattr(provider, "job_counts", None)
+    recent_fn = getattr(provider, "list_recent_jobs", None)
     try:
-        counts = provider.job_counts()
-        recent = provider.list_recent_jobs(limit) if counts is not None else None
-    except RuntimeError as e:
-        # Misconfiguration (missing DATABASE_URL, missing extra) reports as
-        # a clear message, not a raw traceback, the same contract as the
-        # jobs-worker command.
+        counts = counts_fn() if counts_fn is not None else None
+        recent = recent_fn(limit) if (recent_fn is not None and counts is not None) else None
+    except Exception as e:
+        # Misconfiguration (missing DATABASE_URL, missing extra) raises
+        # RuntimeError, but backend failures surface as other Exception
+        # subclasses too: procrastinate wraps every psycopg error, missing
+        # tables and unreachable servers included, in its own plain
+        # ConnectorException, and a status query against a database the
+        # worker has never touched is this command's most likely first
+        # run. All of it reports as a clear message, not a raw traceback.
         Color.print_error(str(e))
         raise SystemExit(1)
     finally:

--- a/fymo/cli/commands/jobs_status.py
+++ b/fymo/cli/commands/jobs_status.py
@@ -1,0 +1,109 @@
+"""`fymo jobs-status`: print what the configured JobProvider knows about
+job state, counts by status first, then the most recent jobs.
+
+Read-only, answers "is this job stuck" without hand-querying Postgres
+(issue #52). Like `fymo jobs-worker` it deliberately does not construct a
+full FymoApp (it only needs the configured JobProvider), and unlike the
+worker it also skips broadcasts/storage/logging setup, since it never
+executes a job, it only reads the provider's own bookkeeping.
+
+A provider that doesn't track job state (the default `threaded`, or any
+custom provider keeping the base's None defaults) exits with status 1 and
+a clear message: that absence is a documented provider property, not a
+fymo oversight (see docs/conventions.md, "Job status visibility").
+"""
+from pathlib import Path
+from typing import Optional
+
+from fymo.core.config import ConfigManager
+from fymo.jobs import init_job_provider
+from fymo.utils.colors import Color
+
+
+def run_jobs_status(
+    project_root: Optional[Path] = None, limit: int = 10, dev: bool = False,
+) -> None:
+    """Build the project's configured JobProvider and print its status
+    surface (job_counts()/list_recent_jobs()).
+
+    `dev=True` (the --dev CLI flag) gets the same treatment as
+    `fymo jobs-worker --dev`: it sets FYMO_DEV=1 in this process before
+    anything reads it, so .env loading works, which matters here because
+    DATABASE_URL usually lives in .env during development.
+    """
+    import os
+
+    project_root = Path(project_root) if project_root else Path.cwd()
+
+    if dev:
+        os.environ["FYMO_DEV"] = "1"
+
+    # Same ordering as run_jobs_worker: .env must be loaded (dev-only)
+    # before ConfigManager interpolates ${VAR} references in fymo.yml.
+    from fymo.core.config import env_truthy, load_dotenv
+    if env_truthy("FYMO_DEV"):
+        load_dotenv(project_root)
+
+    config_manager = ConfigManager(project_root)
+    provider_config = config_manager.get_jobs_config().get("provider")
+    provider = init_job_provider(project_root, provider_config)
+
+    try:
+        counts = provider.job_counts()
+        recent = provider.list_recent_jobs(limit) if counts is not None else None
+    except RuntimeError as e:
+        # Misconfiguration (missing DATABASE_URL, missing extra) reports as
+        # a clear message, not a raw traceback, the same contract as the
+        # jobs-worker command.
+        Color.print_error(str(e))
+        raise SystemExit(1)
+    finally:
+        # This process is done with the provider either way: release its
+        # connection instead of leaving it to interpreter shutdown.
+        # Guarded because close() joined the seam after custom providers
+        # existed; one written against the older contract may lack it.
+        close = getattr(provider, "close", None)
+        if close is not None:
+            close()
+
+    if counts is None:
+        Color.print_error(
+            f"the {provider.id!r} job provider does not track job state — "
+            "there is nothing to report. Providers backed by a durable "
+            "queue (e.g. 'procrastinate') support `fymo jobs-status`; see "
+            "docs/conventions.md for the app-level progress convention."
+        )
+        raise SystemExit(1)
+
+    Color.print_info(f"Job status ({provider.id})")
+    status_width = max((len(s) for s in counts), default=0)
+    for status, count in counts.items():
+        print(f"  {status:<{status_width}}  {count}")
+
+    print()
+    Color.print_info(f"Recent jobs (newest first, up to {limit})")
+    if recent is None:
+        print("  this provider does not list individual jobs")
+        return
+    if not recent:
+        print("  (none)")
+        return
+
+    rows = [
+        (
+            record.id,
+            record.task_name,
+            record.status,
+            record.queued_at.isoformat(sep=" ", timespec="seconds")
+            if record.queued_at else "-",
+        )
+        for record in recent
+    ]
+    headers = ("ID", "TASK", "STATUS", "QUEUED AT")
+    widths = [
+        max(len(headers[col]), *(len(row[col]) for row in rows))
+        for col in range(len(headers))
+    ]
+    print("  " + "  ".join(h.ljust(w) for h, w in zip(headers, widths)))
+    for row in rows:
+        print("  " + "  ".join(cell.ljust(w) for cell, w in zip(row, widths)))

--- a/fymo/cli/commands/jobs_status.py
+++ b/fymo/cli/commands/jobs_status.py
@@ -66,7 +66,18 @@ def run_jobs_status(
         # ConnectorException, and a status query against a database the
         # worker has never touched is this command's most likely first
         # run. All of it reports as a clear message, not a raw traceback.
-        Color.print_error(str(e))
+        # The cause chain is included because ConnectorException's own
+        # message is just "Database error.", the actionable part (which
+        # table is missing, which host was unreachable) lives in the
+        # chained psycopg exception underneath.
+        parts: list = []
+        current: Optional[BaseException] = e
+        while current is not None and len(parts) < 4:
+            text = str(current).strip()
+            if text and text not in parts:
+                parts.append(text)
+            current = current.__cause__ or current.__context__
+        Color.print_error(" | ".join(parts) or type(e).__name__)
         raise SystemExit(1)
     finally:
         # This process is done with the provider either way: release its

--- a/fymo/cli/main.py
+++ b/fymo/cli/main.py
@@ -73,7 +73,7 @@ def jobs_worker_cmd(dev):
 
 
 @cli.command(name="jobs-status")
-@click.option("--limit", "-n", default=10, type=int,
+@click.option("--limit", "-n", default=10, type=click.IntRange(min=1),
               help="How many recent jobs to show")
 @click.option("--dev", is_flag=True, default=False,
               help="Run in dev mode (sets FYMO_DEV=1, enables .env loading)")

--- a/fymo/cli/main.py
+++ b/fymo/cli/main.py
@@ -72,6 +72,17 @@ def jobs_worker_cmd(dev):
     run_jobs_worker(dev=dev)
 
 
+@cli.command(name="jobs-status")
+@click.option("--limit", "-n", default=10, type=int,
+              help="How many recent jobs to show")
+@click.option("--dev", is_flag=True, default=False,
+              help="Run in dev mode (sets FYMO_DEV=1, enables .env loading)")
+def jobs_status_cmd(limit, dev):
+    """Show job counts by status and the most recent jobs."""
+    from fymo.cli.commands.jobs_status import run_jobs_status
+    run_jobs_status(limit=limit, dev=dev)
+
+
 def main():
     """Main entry point"""
     try:

--- a/fymo/jobs/providers/base.py
+++ b/fymo/jobs/providers/base.py
@@ -16,10 +16,37 @@ branches on provider *type*, it just calls the two hooks:
     Procrastinate); in-process providers like ThreadedJobProvider have
     nothing to run here since submit() already does the work. Backs the
     `fymo jobs-worker` CLI command.
+  * job_counts()     - read-only status surface: how many jobs the
+    provider's own bookkeeping holds per status (e.g. todo/doing/failed).
+    Returns None when the provider doesn't track job state at all (the
+    inert default), as distinct from an empty dict, which means "tracked,
+    and there are no jobs". Backs the `fymo jobs-status` CLI command.
+  * list_recent_jobs() - the other half of the status surface: the newest
+    jobs as JobRecord rows, newest first. None again means "not tracked";
+    a provider may implement job_counts() without this and the CLI
+    degrades gracefully.
+  * close()          - release any connections the provider holds. Inert
+    by default; matters for short-lived processes (`fymo jobs-status`)
+    where a pooled connection torn down at interpreter shutdown is noisy.
+    A closed provider must reconnect transparently on the next call.
 """
 from __future__ import annotations
 
-from typing import Callable, Dict, Protocol, runtime_checkable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Dict, List, Optional, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    """One job as reported by a provider's status surface. `id` is a string
+    because it's provider-native (procrastinate's bigserial, a UUID, ...);
+    `queued_at` is None when the provider doesn't record enqueue time."""
+
+    id: str
+    task_name: str
+    status: str
+    queued_at: Optional[datetime]
 
 
 @runtime_checkable
@@ -29,6 +56,9 @@ class JobProvider(Protocol):
     def register_tasks(self, tasks: Dict[str, Callable]) -> None: ...
     def submit(self, task_name: str, *args, **kwargs) -> None: ...
     def run_worker(self) -> None: ...
+    def job_counts(self) -> Optional[Dict[str, int]]: ...
+    def list_recent_jobs(self, limit: int = 10) -> Optional[List[JobRecord]]: ...
+    def close(self) -> None: ...
 
 
 class BaseJobProvider:
@@ -48,3 +78,15 @@ class BaseJobProvider:
             "only providers backed by a durable queue (e.g. 'procrastinate') "
             "support `fymo jobs-worker`"
         )
+
+    def job_counts(self) -> Optional[Dict[str, int]]:
+        """None: this provider doesn't track job state (see module docstring)."""
+        return None
+
+    def list_recent_jobs(self, limit: int = 10) -> Optional[List[JobRecord]]:
+        """None: this provider doesn't track job state (see module docstring)."""
+        return None
+
+    def close(self) -> None:
+        """Nothing held by default (see module docstring)."""
+        pass

--- a/fymo/jobs/providers/procrastinate.py
+++ b/fymo/jobs/providers/procrastinate.py
@@ -11,11 +11,32 @@ from __future__ import annotations
 import inspect
 import logging
 import os
-from typing import Callable, Dict
+from typing import Callable, Dict, List
 
-from fymo.jobs.providers.base import BaseJobProvider
+from fymo.jobs.providers.base import BaseJobProvider, JobRecord
 
 _DEFAULT_ENV_VAR = "DATABASE_URL"
+
+# The statuses procrastinate's list_queues() aggregates report (its
+# 'aborting' enum value is legacy, unused since procrastinate 3.0).
+_STATUSES = ("todo", "doing", "succeeded", "failed", "cancelled", "aborted")
+
+# list_recent_jobs() can't come from procrastinate's public JobManager API:
+# list_jobs() has no LIMIT (it fetches the whole table, which delete_old_jobs
+# may never have pruned) and its Job model carries no enqueue timestamp.
+# Both live in procrastinate's documented schema instead: the jobs row plus
+# its 'deferred' event (procrastinate_events records every transition; the
+# insert trigger writes 'deferred' when a job is first queued).
+_RECENT_JOBS_QUERY = """
+SELECT j.id,
+       j.task_name,
+       j.status,
+       (SELECT MIN(e.at) FROM procrastinate_events e
+         WHERE e.job_id = j.id AND e.type = 'deferred') AS queued_at
+  FROM procrastinate_jobs j
+ ORDER BY j.id DESC
+ LIMIT %(limit)s
+"""
 
 
 class DropProcrastinateJobErrorRecord(logging.Filter):
@@ -139,6 +160,41 @@ class ProcrastinateJobProvider(BaseJobProvider):
             worker_logger.addFilter(DropProcrastinateJobErrorRecord())
 
         app.run_worker(**kwargs)
+
+    def job_counts(self) -> Dict[str, int]:
+        """Sum procrastinate's own per-queue status aggregates (public
+        JobManager.list_queues() API) into one counts-by-status dict."""
+        counts = dict.fromkeys(_STATUSES, 0)
+        for queue_stats in self._get_app().job_manager.list_queues():
+            for status in _STATUSES:
+                counts[status] += queue_stats[status]
+        return counts
+
+    def list_recent_jobs(self, limit: int = 10) -> List[JobRecord]:
+        """Newest jobs first, straight from procrastinate's job table (see
+        _RECENT_JOBS_QUERY for why this bypasses the public API), through
+        the same opened sync connector submit() uses."""
+        rows = self._get_app().connector.execute_query_all(
+            _RECENT_JOBS_QUERY, limit=limit,
+        )
+        return [
+            JobRecord(
+                id=str(row["id"]),
+                task_name=row["task_name"],
+                status=row["status"],
+                queued_at=row["queued_at"],
+            )
+            for row in rows
+        ]
+
+    def close(self) -> None:
+        """Close the cached sync app's connector and drop the cache so the
+        next call reconnects. Matters for short-lived processes (`fymo
+        jobs-status`): psycopg's pool complains loudly when it's left to be
+        torn down by interpreter shutdown instead of closed explicitly."""
+        if self._app is not None:
+            self._app.close()
+            self._app = None
 
     def _get_app(self):
         if self._app is None:

--- a/fymo/jobs/providers/threaded.py
+++ b/fymo/jobs/providers/threaded.py
@@ -6,6 +6,14 @@ provider, and the fallback default for a project that hasn't configured
 durability trade-off `fymo.jobs` always had: a job dies if the process
 restarts mid-run. Use `ProcrastinateJobProvider` for anything that needs
 to survive a restart or scale independently of the web tier.
+
+Deliberately keeps the base's None for job_counts()/list_recent_jobs()
+(i.e. "job state is not tracked"): the executor's state lives inside the
+web process, and `fymo jobs-status` runs as its own OS process, so the
+fresh provider it builds could only ever report zeros. None makes the
+CLI say "not tracked" instead, which is the honest answer. Apps that
+need visibility into threaded jobs should follow the app-level progress
+convention (docs/conventions.md) or switch to a durable provider.
 """
 from __future__ import annotations
 

--- a/journal/journal_024.md
+++ b/journal/journal_024.md
@@ -1,0 +1,125 @@
+# Journal Entry 024: The Queue You Could Only Read With psql
+
+**Date**: July 16, 2026
+**Focus**: `fymo jobs-status` — surfacing job state the providers already track (issue #52)
+**Status**: Shipped
+
+## The Complaint Was Fair
+
+Issue #52 came straight from lived pain: on a real project, answering
+"is this job stuck" meant opening psql, reading `pg_stat_activity`,
+checking whether an app table row had moved, and tailing worker logs,
+every single time. The irritating part is that the information was
+sitting right there the whole time. Procrastinate keeps a status column
+on every job it has ever queued. fymo just never handed anyone a way to
+look at it, and the docstring in `fymo/jobs/__init__.py` saying "job
+state is not tracked here" read less like a design boundary and more
+like an excuse.
+
+So the shape of the fix was clear before I wrote anything: don't build a
+tracking system, build a window into the tracking that already exists.
+
+## An Optional Seam, Not a New Obligation
+
+The `JobProvider` seam got two read-only methods, `job_counts()` and
+`list_recent_jobs(limit)`, with base defaults that return `None`.
+`None` means "this provider doesn't track job state", and it's
+deliberately distinct from an empty dict or empty list, which mean
+"tracked, and there's nothing there". That distinction is the whole
+contract: the CLI can tell "no jobs" apart from "no idea", and existing
+custom providers stay valid without writing a line, because the inert
+default answers for them honestly.
+
+Procrastinate's implementation is half public API, half not, and I want
+to be precise about why. Counts come from `JobManager.list_queues()`,
+which procrastinate exposes exactly for this, per-queue aggregates by
+status, summed across queues. The recent-jobs list is where the public
+API let me down twice: `list_jobs()` has no LIMIT (it fetches the whole
+table, which `delete_old_jobs` may never have pruned), and its `Job`
+model carries no enqueue timestamp at all. Both things live in
+procrastinate's documented schema though, so `list_recent_jobs()` is one
+query against `procrastinate_jobs` joined to the `procrastinate_events`
+row the insert trigger writes when a job is first deferred. That
+'deferred' event is the queued-at time. I don't love bypassing the
+public API, but I wrote down exactly why next to the query, so if a
+future procrastinate grows a proper paginated listing, the fallback has
+its own eviction notice attached.
+
+## The Trap in "Implement What You Can"
+
+The threaded provider almost got a real implementation. The executor
+knows how many jobs are queued and running; wiring up counters would
+have been an afternoon. Then I walked through who would actually call
+this, and the whole idea fell apart: `fymo jobs-status` runs as its own
+OS process. The executor whose state matters lives inside the web
+process. The provider the CLI builds is a fresh one, three seconds old,
+with an empty pool. Any counts it reported would always, structurally,
+be zero, and a status command that confidently prints zeros while your
+web process churns through a backlog is worse than no command at all.
+
+So threaded returns `None`, on purpose, with the reasoning written into
+the class docstring. The CLI turns that into an exit-1 message pointing
+at the durable providers and the docs. Sometimes the honest feature is
+a well-worded refusal.
+
+## The Bug Only the Real Binary Showed
+
+Tests were green the whole way, and then the first real run against a
+throwaway Postgres container printed the status table beautifully and
+followed it with a `PythonFinalizationError` traceback from psycopg's
+connection pool. The provider's sync connector had never been closed
+anywhere, and it never mattered before, because the only process that
+opened it was the long-lived web server. A CLI that exits milliseconds
+after connecting is a different animal: the pool was getting torn down
+by interpreter shutdown, and Python 3.14 objects loudly to joining
+threads that late.
+
+The fix grew the seam by one more method, `close()`, inert by default,
+and on procrastinate it closes the cached app and drops it so a later
+call reconnects transparently. The CLI calls it in a finally block,
+guarded with getattr because a custom provider written against last
+week's contract won't have it. What sticks with me is that no unit test
+would have caught this, the noise only exists at interpreter shutdown
+of a short-lived process. Running the actual binary against an actual
+database is not a formality.
+
+## Watching It Earn Its Keep
+
+The best moment of the day was accidental. While demoing the command
+end to end, I pointed a worker with only a `boom` task at a database
+that still held `add_numbers` jobs from the test suite. The worker
+failed them all with "Task cannot be imported", and `fymo jobs-status`
+showed it instantly: `failed 6`, newest rows on top, each with its
+queued-at time. That is, beat for beat, the debugging session the issue
+author described doing by hand in psql, except it took one command.
+
+## Where the Boundary Now Sits, In Writing
+
+The issue asked for three things and explicitly said that if any were
+scoped out, the docs should say so rather than leave the absence
+looking like an oversight. So docs/conventions.md now has the whole
+position: the status command for what providers track, the statement
+that fymo does not and will not track job progress or results (progress
+is app domain data; a fymo-owned progress store would be a second,
+worse database next to the one the app already has), and the convention
+for apps that want progress anyway: a `job_runs` row keyed by an id the
+submitter chose, updated by the task, read back through a remote
+function or a broadcast channel. The web-reachable status view stayed
+out of scope. It drags in auth and exposure questions that deserve
+their own issue instead of riding along on this one.
+
+## The Count
+
+800 passing, up from 784, and 127 skipped without a database. With
+`TEST_DATABASE_URL` pointing at the throwaway container the
+procrastinate suite runs for real: the counts test watches two jobs go
+todo to succeeded through an actual worker, and the close test proves a
+closed provider reconnects instead of bricking. The tests I care most
+about are the two that pin the `None` contract, because that's the line
+between "fymo doesn't know" and "fymo pretends to know", and this whole
+issue existed because pretending is what hand-written psql sessions are
+made of.
+
+---
+
+*End of Journal Entry 024*

--- a/tests/cli/test_jobs_status.py
+++ b/tests/cli/test_jobs_status.py
@@ -1,0 +1,192 @@
+"""Tests for the `fymo jobs-status` CLI command."""
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pytest
+
+from fymo.cli.commands.jobs_status import run_jobs_status
+from fymo.jobs import reset_job_provider
+from fymo.jobs.providers.base import BaseJobProvider, JobRecord
+
+
+class StubTrackingProvider(BaseJobProvider):
+    """A provider that tracks job state, referenced from fymo.yml by its
+    dotted path (same escape hatch test_registry.py exercises) so the CLI
+    is tested through the real config -> registry -> provider path."""
+
+    id = "stub-tracking"
+    last_limit: Optional[int] = None
+
+    def job_counts(self) -> Dict[str, int]:
+        return {"todo": 2, "doing": 1, "succeeded": 40, "failed": 3}
+
+    def list_recent_jobs(self, limit: int = 10) -> List[JobRecord]:
+        type(self).last_limit = limit
+        return [
+            JobRecord(
+                id="42", task_name="send_email", status="succeeded",
+                queued_at=datetime(2026, 7, 16, 10, 0, 0, tzinfo=timezone.utc),
+            ),
+            JobRecord(id="41", task_name="crunch", status="todo", queued_at=None),
+        ]
+
+
+class StubCountsOnlyProvider(BaseJobProvider):
+    """Counts but no per-job listing; the CLI must degrade gracefully."""
+
+    id = "stub-counts-only"
+
+    def job_counts(self) -> Dict[str, int]:
+        return {"todo": 0, "doing": 0}
+
+
+class StubClosableProvider(BaseJobProvider):
+    """Records close() so the CLI's connection-release contract is testable."""
+
+    id = "stub-closable"
+    closed = False
+
+    def job_counts(self) -> Dict[str, int]:
+        return {"todo": 0}
+
+    def close(self) -> None:
+        type(self).closed = True
+
+
+@pytest.fixture(autouse=True)
+def _restore_fymo_dev():
+    """Same reasoning as tests/cli/test_jobs_worker.py: run_jobs_status(dev=True)
+    writes FYMO_DEV=1 into the real environment, and monkeypatch can't undo
+    a set on a var that was absent before the test."""
+    before = os.environ.get("FYMO_DEV")
+    yield
+    if before is None:
+        os.environ.pop("FYMO_DEV", None)
+    else:
+        os.environ["FYMO_DEV"] = before
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_job_provider()
+    StubTrackingProvider.last_limit = None
+    StubClosableProvider.closed = False
+    yield
+    reset_job_provider()
+
+
+def test_reports_a_clear_error_for_the_default_threaded_provider(tmp_path: Path, capsys):
+    """No fymo.yml `jobs:` section => ThreadedJobProvider, which doesn't
+    track job state, so the CLI should exit non-zero saying so, not print
+    an empty (and misleading) report."""
+    with pytest.raises(SystemExit) as exc_info:
+        run_jobs_status(tmp_path)
+
+    assert exc_info.value.code == 1
+    assert "does not track job state" in capsys.readouterr().out
+
+
+def test_reports_a_clear_error_when_procrastinate_is_configured_but_database_url_is_missing(
+    tmp_path: Path, capsys, monkeypatch
+):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    (tmp_path / "fymo.yml").write_text("jobs:\n  provider: procrastinate\n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_jobs_status(tmp_path)
+
+    assert exc_info.value.code == 1
+    assert "DATABASE_URL" in capsys.readouterr().out
+
+
+def test_prints_counts_and_recent_jobs_from_a_tracking_provider(tmp_path: Path, capsys):
+    (tmp_path / "fymo.yml").write_text(
+        "jobs:\n"
+        "  provider:\n"
+        "    class: tests.cli.test_jobs_status.StubTrackingProvider\n"
+    )
+
+    run_jobs_status(tmp_path)
+
+    out = capsys.readouterr().out
+    assert "stub-tracking" in out
+    assert "todo" in out and "2" in out
+    assert "succeeded" in out and "40" in out
+    # Recent-jobs table: id, task name, status, queued-at all visible.
+    assert "42" in out and "send_email" in out
+    assert "2026-07-16 10:00:00" in out
+    # A job with no queued-at timestamp renders a placeholder, not "None".
+    assert "crunch" in out and "None" not in out
+
+
+def test_passes_the_limit_through_to_the_provider(tmp_path: Path):
+    (tmp_path / "fymo.yml").write_text(
+        "jobs:\n"
+        "  provider:\n"
+        "    class: tests.cli.test_jobs_status.StubTrackingProvider\n"
+    )
+
+    run_jobs_status(tmp_path, limit=3)
+
+    assert StubTrackingProvider.last_limit == 3
+
+
+def test_degrades_gracefully_when_the_provider_only_reports_counts(tmp_path: Path, capsys):
+    (tmp_path / "fymo.yml").write_text(
+        "jobs:\n"
+        "  provider:\n"
+        "    class: tests.cli.test_jobs_status.StubCountsOnlyProvider\n"
+    )
+
+    run_jobs_status(tmp_path)
+
+    out = capsys.readouterr().out
+    assert "todo" in out
+    assert "does not list individual jobs" in out
+
+
+def test_closes_the_provider_when_done(tmp_path: Path):
+    """A status read is a short-lived process, so the provider's database
+    connection must be released explicitly, not left to interpreter
+    shutdown (psycopg's pool complains loudly there on Python 3.14)."""
+    (tmp_path / "fymo.yml").write_text(
+        "jobs:\n"
+        "  provider:\n"
+        "    class: tests.cli.test_jobs_status.StubClosableProvider\n"
+    )
+
+    run_jobs_status(tmp_path)
+
+    assert StubClosableProvider.closed
+
+
+def test_dev_flag_sets_fymo_dev_and_loads_dotenv(tmp_path: Path, monkeypatch):
+    """Same contract `fymo jobs-worker --dev` has (issue #44): DATABASE_URL
+    usually lives in .env during dev, so jobs-status must be able to load
+    it the same way. Proven the same way as test_jobs_worker.py: fymo.yml
+    only parses if .env got loaded first."""
+    monkeypatch.delenv("FYMO_TEST_STATUS_DEVFLAG", raising=False)
+    monkeypatch.delenv("FYMO_DEV", raising=False)
+    (tmp_path / ".env").write_text("FYMO_TEST_STATUS_DEVFLAG=loaded\n")
+    (tmp_path / "fymo.yml").write_text("name: ${FYMO_TEST_STATUS_DEVFLAG}\n")
+
+    # Default threaded provider => SystemExit(1), but only after fymo.yml
+    # parsed, which requires the .env var to be present.
+    with pytest.raises(SystemExit):
+        run_jobs_status(tmp_path, dev=True)
+
+    assert os.environ.get("FYMO_DEV") == "1"
+    assert os.environ["FYMO_TEST_STATUS_DEVFLAG"] == "loaded"
+
+
+def test_without_dev_flag_ignores_dotenv(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FYMO_TEST_STATUS_NOFLAG", raising=False)
+    monkeypatch.delenv("FYMO_DEV", raising=False)
+    (tmp_path / ".env").write_text("FYMO_TEST_STATUS_NOFLAG=should-not-load\n")
+
+    with pytest.raises(SystemExit):
+        run_jobs_status(tmp_path)
+
+    assert "FYMO_TEST_STATUS_NOFLAG" not in os.environ

--- a/tests/cli/test_jobs_status.py
+++ b/tests/cli/test_jobs_status.py
@@ -190,3 +190,75 @@ def test_without_dev_flag_ignores_dotenv(tmp_path: Path, monkeypatch):
         run_jobs_status(tmp_path)
 
     assert "FYMO_TEST_STATUS_NOFLAG" not in os.environ
+
+
+class StubBrokenBackendProvider(BaseJobProvider):
+    """Simulates procrastinate's ConnectorException shape: a provider whose
+    backend raises a plain Exception subclass (missing tables, unreachable
+    database), which is the likely first run of a read-only status command
+    against a database the worker has never touched."""
+
+    id = "stub-broken-backend"
+
+    def job_counts(self):
+        raise ConnectionError("relation \"procrastinate_jobs\" does not exist")
+
+
+class OldContractProvider:
+    """Duck-typed provider written against the pre-status JobProvider
+    protocol (register_tasks/submit/run_worker), no BaseJobProvider
+    subclassing (the registry never required it), so it has neither
+    job_counts nor list_recent_jobs nor close."""
+
+    id = "old-contract"
+
+    def register_tasks(self, tasks):
+        return None
+
+    def submit(self, task_name, *args, **kwargs):
+        return None
+
+    def run_worker(self):
+        return None
+
+
+def test_backend_exception_reports_cleanly_not_a_traceback(tmp_path: Path, capsys):
+    (tmp_path / "fymo.yml").write_text(
+        "jobs:\n"
+        "  provider:\n"
+        "    class: tests.cli.test_jobs_status.StubBrokenBackendProvider\n"
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_jobs_status(tmp_path)
+
+    assert exc_info.value.code == 1
+    assert "procrastinate_jobs" in capsys.readouterr().out
+
+
+def test_old_contract_provider_without_status_methods_reports_cleanly(tmp_path: Path, capsys):
+    (tmp_path / "fymo.yml").write_text(
+        "jobs:\n"
+        "  provider:\n"
+        "    class: tests.cli.test_jobs_status.OldContractProvider\n"
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_jobs_status(tmp_path)
+
+    assert exc_info.value.code == 1
+    assert "does not track job state" in capsys.readouterr().out
+
+
+def test_cli_wrapper_rejects_nonpositive_limit(tmp_path: Path, monkeypatch):
+    """Through the real click command: a nonpositive -n must be rejected by
+    click itself, before it can reach the provider's SQL LIMIT."""
+    from click.testing import CliRunner
+    from fymo.cli.main import cli
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    for bad in ("0", "-1"):
+        result = runner.invoke(cli, ["jobs-status", "-n", bad])
+        assert result.exit_code == 2, result.output
+        assert "not in the range" in result.output or "Invalid value" in result.output

--- a/tests/cli/test_jobs_status.py
+++ b/tests/cli/test_jobs_status.py
@@ -262,3 +262,33 @@ def test_cli_wrapper_rejects_nonpositive_limit(tmp_path: Path, monkeypatch):
         result = runner.invoke(cli, ["jobs-status", "-n", bad])
         assert result.exit_code == 2, result.output
         assert "not in the range" in result.output or "Invalid value" in result.output
+
+
+class StubChainedErrorProvider(BaseJobProvider):
+    """procrastinate's ConnectorException str() is just "Database error.",
+    the useful part (missing table, bad password, unreachable host) lives
+    in the chained psycopg cause; the CLI must surface it."""
+
+    id = "stub-chained-error"
+
+    def job_counts(self):
+        try:
+            raise ValueError('relation "procrastinate_jobs" does not exist')
+        except ValueError as cause:
+            raise ConnectionError("Database error.") from cause
+
+
+def test_backend_exception_message_includes_the_chained_cause(tmp_path: Path, capsys):
+    (tmp_path / "fymo.yml").write_text(
+        "jobs:\n"
+        "  provider:\n"
+        "    class: tests.cli.test_jobs_status.StubChainedErrorProvider\n"
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_jobs_status(tmp_path)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Database error." in out
+    assert "procrastinate_jobs" in out

--- a/tests/jobs/providers/test_base.py
+++ b/tests/jobs/providers/test_base.py
@@ -24,3 +24,19 @@ def test_base_provider_run_worker_raises_a_clear_error():
     provider = BaseJobProvider()
     with pytest.raises(RuntimeError, match="has no separate worker process"):
         provider.run_worker()
+
+
+def test_base_provider_job_counts_returns_none():
+    """None is the seam's documented "this provider doesn't track job
+    state" signal, and the default, so existing custom providers stay
+    valid without implementing the status surface."""
+    assert BaseJobProvider().job_counts() is None
+
+
+def test_base_provider_list_recent_jobs_returns_none():
+    assert BaseJobProvider().list_recent_jobs() is None
+    assert BaseJobProvider().list_recent_jobs(limit=5) is None
+
+
+def test_base_provider_close_is_inert_by_default():
+    BaseJobProvider().close()  # must not raise

--- a/tests/jobs/providers/test_procrastinate.py
+++ b/tests/jobs/providers/test_procrastinate.py
@@ -117,3 +117,82 @@ def test_run_worker_drains_the_queue_and_returns_when_wait_is_false(database_url
     provider.run_worker(wait=False, listen_notify=False)
 
     assert result == {"sum": 5}
+
+
+def test_job_counts_tracks_a_job_from_todo_to_succeeded(database_url, monkeypatch):
+    """The status seam against real procrastinate state. The database (and
+    its procrastinate_jobs table) persists across tests and runs, so assert
+    on deltas rather than absolute numbers."""
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    from fymo.jobs.providers.procrastinate import ProcrastinateJobProvider
+
+    def add_numbers(a, b):
+        pass
+
+    provider = ProcrastinateJobProvider()
+    provider.register_tasks({"add_numbers": add_numbers})
+
+    before = provider.job_counts()
+    provider.submit("add_numbers", 1, b=2)
+    provider.submit("add_numbers", 3, b=4)
+    queued = provider.job_counts()
+    assert queued["todo"] - before["todo"] == 2
+
+    provider.run_worker(wait=False, listen_notify=False)
+    drained = provider.job_counts()
+    assert drained["todo"] == before["todo"]
+    assert drained["succeeded"] - before["succeeded"] == 2
+
+
+def test_list_recent_jobs_returns_newest_first_with_queued_at(database_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    from datetime import datetime, timedelta, timezone
+    from fymo.jobs.providers.procrastinate import ProcrastinateJobProvider
+
+    def add_numbers(a, b):
+        pass
+
+    provider = ProcrastinateJobProvider()
+    provider.register_tasks({"add_numbers": add_numbers})
+    provider.submit("add_numbers", 1, b=2)
+    provider.submit("add_numbers", 3, b=4)
+
+    recent = provider.list_recent_jobs(limit=2)
+
+    assert len(recent) == 2
+    assert int(recent[0].id) > int(recent[1].id)  # newest first
+    for record in recent:
+        assert record.task_name == "add_numbers"
+        assert record.status == "todo"
+        assert record.queued_at is not None
+        assert datetime.now(timezone.utc) - record.queued_at < timedelta(minutes=5)
+
+
+def test_close_releases_the_connection_and_a_later_call_reconnects(database_url, monkeypatch):
+    """The CLI closes the provider when done (a short-lived process must
+    not leave psycopg's pool to be torn down by interpreter shutdown);
+    closing must not brick the provider for a later call."""
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    from fymo.jobs.providers.procrastinate import ProcrastinateJobProvider
+
+    provider = ProcrastinateJobProvider()
+    provider.register_tasks({})
+
+    assert provider.job_counts() is not None
+    provider.close()
+    assert provider.job_counts() is not None  # reconnects transparently
+
+
+def test_list_recent_jobs_respects_the_limit(database_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    from fymo.jobs.providers.procrastinate import ProcrastinateJobProvider
+
+    def add_numbers(a, b):
+        pass
+
+    provider = ProcrastinateJobProvider()
+    provider.register_tasks({"add_numbers": add_numbers})
+    for i in range(3):
+        provider.submit("add_numbers", i, b=i)
+
+    assert len(provider.list_recent_jobs(limit=1)) == 1

--- a/tests/jobs/providers/test_procrastinate_no_db.py
+++ b/tests/jobs/providers/test_procrastinate_no_db.py
@@ -29,6 +29,27 @@ def test_run_worker_with_missing_database_url_raises_a_clear_error(monkeypatch):
         provider.run_worker()
 
 
+def test_job_counts_with_missing_database_url_raises_a_clear_error(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    provider = ProcrastinateJobProvider()
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        provider.job_counts()
+
+
+def test_list_recent_jobs_with_missing_database_url_raises_a_clear_error(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    provider = ProcrastinateJobProvider()
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        provider.list_recent_jobs()
+
+
+def test_close_before_any_connection_is_a_no_op(monkeypatch):
+    """close() must be safe on a provider that never connected (the CLI
+    calls it unconditionally in a finally block)."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    ProcrastinateJobProvider().close()  # must not raise
+
+
 def test_missing_procrastinate_package_raises_an_install_hint(monkeypatch):
     """`jobs: provider: procrastinate` without `pip install
     fymo[procrastinate]` must say exactly that — not ModuleNotFoundError.
@@ -43,3 +64,7 @@ def test_missing_procrastinate_package_raises_an_install_hint(monkeypatch):
         provider.submit("x")
     with pytest.raises(RuntimeError, match=r"fymo\[procrastinate\]"):
         provider.run_worker()
+    with pytest.raises(RuntimeError, match=r"fymo\[procrastinate\]"):
+        provider.job_counts()
+    with pytest.raises(RuntimeError, match=r"fymo\[procrastinate\]"):
+        provider.list_recent_jobs()

--- a/tests/jobs/providers/test_threaded.py
+++ b/tests/jobs/providers/test_threaded.py
@@ -38,3 +38,14 @@ def test_submit_raises_on_unknown_task():
 
 def test_id_is_threaded():
     assert ThreadedJobProvider().id == "threaded"
+
+
+def test_job_counts_returns_none():
+    """Deliberate: the executor's state lives inside the web process, and
+    `fymo jobs-status` runs as its own OS process, so a fresh provider
+    there would always report zeros, worse than saying "not tracked"."""
+    assert ThreadedJobProvider().job_counts() is None
+
+
+def test_list_recent_jobs_returns_none():
+    assert ThreadedJobProvider().list_recent_jobs() is None


### PR DESCRIPTION
## Summary

"Is this job stuck" had exactly one answer: connect to Postgres and look, by hand, every time, even though procrastinate tracks job status internally. This surfaces it through fymo.

- Optional status seam on the JobProvider contract (`job_counts()`, `list_recent_jobs(limit)`, `close()`), with None meaning "this provider doesn't track state" as a documented property, not an error
- Procrastinate implementation: counts via the public `JobManager.list_queues()` aggregates, recent jobs via one indexed query against the documented schema (the public `list_jobs()` has no LIMIT and its Job model has no enqueue timestamp)
- Threaded provider deliberately returns None: the CLI is a separate OS process from the web process holding the executor, so any counters it computed would always be a fresh provider's zeros
- New `fymo jobs-status` CLI command: counts by status, then a recent-jobs table, `--limit/-n` and `--dev` (same .env semantics as jobs-worker), clean exit-1 messages for "tracks nothing" and every backend failure (including procrastinate's ConnectorException with its psycopg cause chain surfaced, so a missing-tables first run tells you what to fix)
- docs/conventions.md: job status visibility section plus the app-level progress-tracking convention, making the "fymo does not track job state" boundary an explicit decision
- Web-reachable status endpoint from the issue deliberately deferred

Closes #52

## Test plan

- [x] TDD throughout; 20 new tests (4 Postgres-gated, matching the existing TEST_DATABASE_URL pattern), full suite 804 passed / 127 skipped
- [x] Independent review verified the SQL against the installed procrastinate 3.9.0 schema, including the retry re-defer edge case ('deferred' event is insert-only, retries write 'deferred_for_retry')
- [x] Live, real binary against real Postgres in Docker: threaded exits 1 cleanly; missing DATABASE_URL exits 1 naming the var; reachable Postgres without tables exits 1 naming the missing relation; schema applied, two real jobs deferred and shown as todo, worker ran, status showed boom failed / fine succeeded