### PR TITLE
Gate Clerk/OIDC/OAuth behind pip extras, fail at boot when missing

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -349,6 +349,25 @@ in `fymo.yml` -- the config block above is the entire setup.
 provider is unaffected: only an entry that both sets `required: auto` and
 points at a provider overriding the hook gets the conditional behavior.
 
+### Auth provider extras: password stays in base, Clerk/OIDC/OAuth are opt-in
+
+The password provider (`hashlib.scrypt`, stdlib-only) is the one real login
+built into fymo -- a bare `pip install fymo` with `auth.enabled: true` and
+no `providers:` list logs a user in with zero extra installs. Clerk, OIDC,
+and OAuth providers live behind named extras instead:
+
+```sh
+pip install 'fymo[clerk]'   # ClerkProvider: pyjwt[crypto] for RS256/JWKS
+pip install 'fymo[oidc]'    # OIDCProvider: stdlib-only today, named for consistency
+pip install 'fymo[oauth]'   # GoogleProvider/OAuthProvider: same, stdlib-only today
+```
+
+`type: clerk` without `fymo[clerk]` installed is a hard error at
+`FymoApp` construction (app startup), naming the exact install command --
+never a silent fallback to a disabled or half-working auth setup. Same
+posture as the granian check above: refuse to start rather than fail on
+someone's first login attempt in production.
+
 ## Worker sizing
 
 `--workers` means OS processes under **both** servers, and each worker

--- a/fymo/auth/providers/clerk.py
+++ b/fymo/auth/providers/clerk.py
@@ -8,11 +8,33 @@ seam. First sight of a subject provisions a local user.
 Production verification is RS256-over-JWKS, which needs a crypto library, so
 the verifier is injectable: the default lazily uses PyJWT (optional dep) when
 present, and tests inject a fake. Core stays dependency-free.
+
+Packaging (issue #59): pyjwt[crypto] ships as the `fymo[clerk]` extra, never
+a hard dependency of fymo itself. A caller supplying their own verify=
+(every test in this package does) never needs it at all. When the default
+verifier is going to be used, its presence is checked eagerly in __init__,
+at provider construction, which fymo.yml's `type: clerk` reaches from
+FymoApp.__init__, so a missing extra is a loud boot-time failure instead
+of surfacing only the first time someone logs in.
+
+Migration note: before this extra existed, `type: clerk` worked from a bare
+`pip install fymo` as long as pyjwt[crypto] happened to already be present.
+There is no separate deprecation-warning phase for that "present but never
+declared via the extra" state. At runtime there is no reliable way to tell
+"installed because fymo[clerk] was requested" apart from "installed some
+other way" (pip/uv don't record per-dependency install provenance anywhere
+`importlib.metadata` exposes), so a warning aimed only at the second case
+would either misfire on properly-installed extras or never fire at all.
+Both states behave identically here: the deps are present, verification
+works, nothing is disabled. The actual fix is the loud failure above for the
+one state that matters, truly missing, which is strictly better than
+today's silent-until-first-login gap regardless of how someone got pyjwt.
 """
 from __future__ import annotations
 
 import base64
 import os
+from importlib.util import find_spec
 from typing import Callable, Optional
 
 from fymo.auth.context import get_user_store
@@ -25,6 +47,17 @@ Verifier = Callable[[str], Optional[dict]]
 
 _ISSUER_ENV = "CLERK_ISSUER"
 _PUBLISHABLE_KEY_ENV = "PUBLIC_CLERK_PUBLISHABLE_KEY"
+_INSTALL_HINT = "pip install 'fymo[clerk]'"
+
+
+def _pyjwt_available() -> bool:
+    """Whether the default JWKS verifier can actually run: pyjwt itself, plus
+    a real crypto backend for RS256 (pyjwt's `cryptography` extra: `import
+    jwt` alone succeeds without it, RS256 only fails once you try to use it).
+    find_spec (not a real import) so checking never has the side effect of
+    loading either package, and tests can monkeypatch this one function
+    instead of faking module presence in sys.modules."""
+    return find_spec("jwt") is not None and find_spec("cryptography") is not None
 
 
 def _issuer_from_publishable_key(key: str) -> Optional[str]:
@@ -72,7 +105,14 @@ class ClerkProvider(BaseProvider):
         self.jwks_url = jwks_url
         self.audience = audience
         self.cookie_name = cookie_name
-        self._verify = verify or _jwks_verifier(jwks_url, issuer, audience)
+        if verify is None:
+            if not _pyjwt_available():
+                raise RuntimeError(
+                    "Clerk auth (type: clerk) needs the 'pyjwt[crypto]' package "
+                    f"for RS256/JWKS verification. Install it with: {_INSTALL_HINT}"
+                )
+            verify = _jwks_verifier(jwks_url, issuer, audience)
+        self._verify = verify
 
     @classmethod
     def from_config(cls, opts: dict) -> "ClerkProvider":
@@ -126,17 +166,20 @@ class ClerkProvider(BaseProvider):
 
 
 def _jwks_verifier(jwks_url: str, issuer: str, audience: Optional[str]) -> Verifier:
-    """Default RS256/JWKS verifier. Requires the optional `pyjwt[crypto]` extra;
-    raises a clear error at first use if it isn't installed."""
+    """Default RS256/JWKS verifier. Requires the optional `pyjwt[crypto]` extra
+    (fymo[clerk]); ClerkProvider.__init__ already refused to build this closure
+    at all if `_pyjwt_available()` was False, so the ImportError branch below
+    is defense in depth for a partial/corrupted install rather than the
+    primary guard: it should not be reachable in the normal missing-extra
+    case, that fails earlier and louder, at boot."""
 
     def verify(token: str) -> Optional[dict]:
         try:
             import jwt
             from jwt import PyJWKClient
-        except ImportError as e:  # pragma: no cover - exercised only without the extra
+        except ImportError as e:  # pragma: no cover - _pyjwt_available already guards this
             raise RuntimeError(
-                "Clerk token verification needs the 'pyjwt[crypto]' package; "
-                "install it or pass a custom verify= to ClerkProvider"
+                f"Clerk token verification needs the 'pyjwt[crypto]' package. Install it with: {_INSTALL_HINT}"
             ) from e
         try:
             signing_key = PyJWKClient(jwks_url).get_signing_key_from_jwt(token)

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -338,7 +338,13 @@ class FymoApp:
 
         # Build the configured providers and install their session resolvers.
         # Defaults to [password]; extra providers (OAuth, token) come from
-        # auth.providers in fymo.yml.
+        # auth.providers in fymo.yml. Deliberately unguarded: a provider that
+        # needs an optional extra (e.g. ClerkProvider needing pyjwt[crypto],
+        # issue #59) raises RuntimeError from its own __init__/from_config
+        # when that extra isn't installed, and that propagates straight out
+        # of FymoApp.__init__ here. Refusing to start beats booting with
+        # auth half-wired and only discovering the gap at someone's first
+        # login attempt.
         from fymo.auth.providers.registry import (
             build_providers, install_providers, system_remote_modules,
         )

--- a/journal/journal_023.md
+++ b/journal/journal_023.md
@@ -1,0 +1,179 @@
+# Journal Entry 023: The Extra That Was Already Half-Built
+
+**Date**: July 16, 2026
+**Focus**: Locking auth packaging before more providers land — password stays in base, Clerk/OIDC/OAuth move behind named extras, `type: clerk` fails at boot instead of at first login
+**Status**: Shipped
+
+## The Debate I Wanted to Avoid Having Three More Times
+
+Two providers exist today (Clerk, and the Google/OIDC family), a third
+kind is clearly coming, and every one of them was going to ask the same
+question: does this ship in base fymo, or does it live behind an extra?
+Rather than relitigate that per provider, the plan was to answer it once,
+write it down, and make the answer actually true in code — not just true
+in a paragraph somewhere. Password stays in base because it's really
+`hashlib.scrypt`, zero external deps, the one real login a newcomer gets
+for free. Clerk needs `pyjwt[crypto]` for RS256-over-JWKS verification.
+OIDC and OAuth are pure `urllib`, no deps at all. None of that was in
+dispute — it's what "in dispute" turned out to mean underneath that was
+the actual work.
+
+## Half-Built Was Generous
+
+Opening `clerk.py` expecting to wire a dependency check from scratch, I
+found the lazy import already sitting there:
+
+```python
+def verify(token: str) -> Optional[dict]:
+    try:
+        import jwt
+        from jwt import PyJWKClient
+    except ImportError as e:
+        raise RuntimeError(
+            "Clerk token verification needs the 'pyjwt[crypto]' package; "
+            "install it or pass a custom verify= to ClerkProvider"
+        ) from e
+```
+
+Right idea, wrong moment. That closure only runs when a request actually
+carries a token and something calls `resolve_session()` — meaning a
+misconfigured production deploy would boot clean, serve pages, look
+completely healthy, and only discover the missing dependency the first
+time a real user tried to log in. For an auth system, that's close to the
+worst possible timing: the failure mode is invisible until someone hits it
+live.
+
+The fix wasn't a new mechanism, it was moving one check earlier. The
+`__init__` already decides, once, whether to hand `resolve_session` a
+custom `verify=` or build the default JWKS verifier:
+
+```python
+self._verify = verify or _jwks_verifier(jwks_url, issuer, audience)
+```
+
+That `or` is exactly the moment fymo commits to needing pyjwt. Everything
+after it — the whole request path — was too late to be the place that
+finds out.
+
+## Two Modules, Not One
+
+Writing the availability check, I almost wrote `find_spec("jwt") is not
+None` and stopped there. Reading PyJWT's own source first turned up why
+that's incomplete: `jwt/algorithms.py` wraps its `cryptography` import in
+its own try/except and just flips a `has_crypto` flag to `False` when it's
+missing. Plain `import jwt` succeeds with zero crypto backend installed —
+it only breaks once you actually ask for RS256, which is exactly what
+Clerk's JWKS verification does. `pyjwt[crypto]` is really two packages
+under one extra name. The check has to be both:
+
+```python
+def _pyjwt_available() -> bool:
+    return find_spec("jwt") is not None and find_spec("cryptography") is not None
+```
+
+`find_spec` over an actual `import` on purpose — checking availability
+shouldn't have the side effect of loading either module, and it gave the
+tests a single function to monkeypatch instead of needing to fake entries
+in `sys.modules` and hope nothing else in the same process cached a real
+import first.
+
+## Borrowing Someone Else's Already-Solved Problem
+
+This exact shape of problem — an optional production dependency, a hard
+error when someone explicitly asks for something that needs it, a message
+naming the fix — had already been solved once in this codebase, for
+granian (`fymo serve --prod --server granian`, issue #39). Same pattern:
+a small `_available()` helper using `find_spec`, monkeypatched directly in
+tests rather than physically uninstalling anything from the shared dev
+venv. I copied that shape instead of inventing my own, down to the
+`monkeypatch.setattr(mod, "_x_available", lambda: False)` idiom in the
+tests. Consistency wasn't the only reason — it also meant not having to
+convince myself a new isolation strategy was actually safe across the rest
+of the suite. Borrowed confidence, not just borrowed code.
+
+## The Migration Question I Decided Not to Build a Feature For
+
+The issue asked for something specific: today, `type: clerk` works from a
+bare `pip install fymo` as long as pyjwt happens to already be installed,
+no extra required. Formalizing the extra shouldn't silently strand anyone
+already running that way — the ask was one release with a deprecation
+warning for that in-between case, then a hard failure later.
+
+I sat with this longer than the rest of the change combined, because the
+honest answer is that "in-between case" isn't a state I can detect. At
+runtime, "pyjwt is installed because `fymo[clerk]` was requested" and
+"pyjwt is installed because it happened to be lying around" look
+identical — same `find_spec` result, same import, same everything. Neither
+pip nor uv record, anywhere `importlib.metadata` exposes, which extra of
+which package caused a given install. I went looking for a workaround —
+inspecting installed distribution metadata, checking `RECORD` files,
+anything — and came up empty in any way that wouldn't be fragile and
+tool-dependent (pip vs uv record installs differently enough that I didn't
+trust it to hold up).
+
+So I didn't build the warning. Writing one that fires whenever pyjwt is
+present-but-technically-undeclared would misfire forever on everyone who
+did the extra installation correctly — a permanent nag aimed at users who
+did nothing wrong, in service of a transition window that's supposed to
+end. What I built instead: the one thing that's actually true regardless
+of how someone got there. Deps present, real crypto verification, nothing
+disabled. Deps genuinely absent, loud failure at boot, naming the fix.
+Both states behave exactly like they did before this change for anyone
+who already has pyjwt; the only thing that changed is what happens when
+it's actually missing, which used to be silence until first login and is
+now immediate and unambiguous. I wrote the reasoning directly into
+`clerk.py`'s docstring rather than leaving it as a decision only I
+remembered making.
+
+## Proving It, Not Just Testing It
+
+The unit tests were the easy half — monkeypatch `_pyjwt_available` false,
+construct a `ClerkProvider`, assert the `RuntimeError` names `pip install
+'fymo[clerk]'`. The part I didn't want to fake was whether the *real*
+crypto path still works once the extra is actually installed, so I added
+`pyjwt[crypto]` to the dev dependency group specifically so a real test
+could exercise it: generate an actual RSA keypair, sign a real JWT, fake
+only the network JWKS fetch (the one thing that would otherwise need a
+live HTTPS endpoint), and let the genuine PyJWT/cryptography decode path
+run against it, both accepting a valid token and rejecting a tampered one
+and a wrong-issuer one.
+
+Then I didn't trust that either, because everything up to that point still
+ran inside one dev venv that happens to have everything installed at
+once, which is exactly the kind of environment that can't tell you
+whether packaging boundaries are real or just accidentally true. Built an
+actual wheel with `uv build`, spun up a genuinely clean venv with nothing
+in it but fymo's base dependencies, and pointed `FymoApp` at a project
+configured for `type: clerk`. It refused to start, naming the install
+command, with pyjwt truly absent from `sys.path` — not mocked absent,
+actually absent. Then installed `fymo[clerk]` into that same clean venv
+and ran it again: booted clean, `ClerkProvider` installed, auth enabled.
+That's the sequence the issue actually asked for, and I wanted to have
+watched it happen outside the test suite's own bubble at least once
+before calling it proven.
+
+## What Didn't Need Solving
+
+OIDC and OAuth got named extras too — `fymo[oidc]`, `fymo[oauth]` — even
+though both are pure `urllib` today and need nothing. Tempting to skip
+that as premature, but the cost of naming them now is zero and the
+alternative is worse: a user reading docs sees `fymo[clerk]` exists and
+has no idea whether `fymo[oidc]` is a thing they should also expect, or
+whether OIDC just doesn't need one. Naming the whole family now means a
+future real dependency for either slots into an extra that already has
+the name users would type, instead of introducing a new naming
+convention later. Wrote that reasoning down next to the empty extras in
+`pyproject.toml` rather than leaving it to look like an oversight.
+
+## The Count
+
+799 passing, 123 skipped, zero failed — the skips are the usual
+`node_modules`-not-installed and no-live-Postgres cases this worktree
+doesn't have, not anything from this change. Twelve new tests directly
+covering the packaging boundary, three more pinning the actual extras
+shape in `pyproject.toml`, plus the two from-a-real-wheel boot checks run
+by hand outside pytest entirely.
+
+---
+
+*End of Journal Entry 023*

--- a/journal/journal_026.md
+++ b/journal/journal_026.md
@@ -1,4 +1,4 @@
-# Journal Entry 023: The Extra That Was Already Half-Built
+# Journal Entry 026: The Extra That Was Already Half-Built
 
 **Date**: July 16, 2026
 **Focus**: Locking auth packaging before more providers land — password stays in base, Clerk/OIDC/OAuth move behind named extras, `type: clerk` fails at boot instead of at first login
@@ -176,4 +176,4 @@ by hand outside pytest entirely.
 
 ---
 
-*End of Journal Entry 023*
+*End of Journal Entry 026*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,15 @@ classifiers = [
 pydantic = ["pydantic>=2.5"]
 procrastinate = ["procrastinate>=3.0", "psycopg[binary,pool]>=3.1"]
 granian = ["granian>=2.0,<3"]
+# Clerk verifies RS256 JWTs over JWKS, which needs a real crypto backend.
+clerk = ["pyjwt[crypto]>=2.0"]
+# oidc/oauth (fymo/auth/providers/oauth.py) are pure stdlib urllib today and
+# pull in nothing extra. Named anyway so the three provider extras form one
+# discoverable family (fymo[clerk], fymo[oidc], fymo[oauth]) and so a future
+# dependency for either can be added here without changing what users type
+# to get it.
+oidc = []
+oauth = []
 
 [project.scripts]
 fymo = "fymo.cli.main:main"
@@ -67,6 +76,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pydantic>=2.5",
     "granian>=2.0,<3",
+    "pyjwt[crypto]>=2.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/auth/test_clerk_packaging.py
+++ b/tests/auth/test_clerk_packaging.py
@@ -1,0 +1,142 @@
+"""Auth packaging boundary (issue #59): the password provider stays a
+zero-dependency default; Clerk's JWKS verification needs pyjwt[crypto],
+shipped as the `fymo[clerk]` extra. Its absence must fail loudly the moment
+a ClerkProvider is built (i.e. at FymoApp boot, via
+fymo/auth/providers/registry.py), not the first time someone tries to log
+in — see tests/core/test_auth_boot_extras.py for the full FymoApp-level
+proof of that.
+"""
+import sys
+
+import pytest
+
+from fymo.auth.providers.clerk import ClerkProvider, _pyjwt_available
+from fymo.auth.providers.password import PasswordProvider
+from fymo.auth.providers.registry import build_providers
+
+
+def test_build_providers_default_is_password_only():
+    providers = build_providers(None)
+    assert len(providers) == 1
+    assert isinstance(providers[0], PasswordProvider)
+
+
+def test_password_only_app_never_imports_pyjwt_or_cryptography():
+    """Zero-extras acceptance criterion. The dev environment has pyjwt and
+    cryptography installed (so the real-crypto test below can exercise
+    them), so this only proves anything if we first evict them and confirm
+    the password-only path never pulls them back in."""
+    for name in ("jwt", "cryptography"):
+        sys.modules.pop(name, None)
+    build_providers(None)
+    build_providers(["password"])
+    assert "jwt" not in sys.modules
+    assert "cryptography" not in sys.modules
+
+
+def test_clerk_construction_fails_loudly_when_pyjwt_missing(monkeypatch):
+    monkeypatch.setattr("fymo.auth.providers.clerk._pyjwt_available", lambda: False)
+    with pytest.raises(RuntimeError, match=r"pip install 'fymo\[clerk\]'"):
+        ClerkProvider(issuer="https://x.clerk.accounts.dev", jwks_url="https://x/jwks")
+
+
+def test_clerk_construction_succeeds_when_pyjwt_available(monkeypatch):
+    monkeypatch.setattr("fymo.auth.providers.clerk._pyjwt_available", lambda: True)
+    prov = ClerkProvider(issuer="https://x.clerk.accounts.dev", jwks_url="https://x/jwks")
+    assert prov.issuer == "https://x.clerk.accounts.dev"
+
+
+def test_clerk_construction_with_explicit_verify_skips_the_pyjwt_check(monkeypatch):
+    """A caller supplying its own verify= (every test in test_clerk.py does
+    this) never touches the lazy JWKS verifier, so construction must not
+    require pyjwt at all -- the check only guards the default verifier."""
+    def _boom():
+        raise AssertionError("_pyjwt_available must not be called when verify= is given")
+
+    monkeypatch.setattr("fymo.auth.providers.clerk._pyjwt_available", _boom)
+    ClerkProvider(issuer="https://x", jwks_url="https://x/jwks", verify=lambda tok: None)
+
+
+def test_build_providers_from_config_fails_loudly_when_pyjwt_missing(monkeypatch):
+    """The same failure must surface through the fymo.yml config path
+    (registry.build_providers), which is what FymoApp.__init__ actually
+    calls -- not just through direct ClerkProvider() construction."""
+    monkeypatch.setenv("CLERK_ISSUER", "https://x.clerk.accounts.dev")
+    monkeypatch.setattr("fymo.auth.providers.clerk._pyjwt_available", lambda: False)
+    with pytest.raises(RuntimeError, match=r"pip install 'fymo\[clerk\]'"):
+        build_providers([{"type": "clerk"}])
+
+
+def test_pyjwt_available_reflects_real_environment():
+    """Sanity check on the detector itself, unmocked: this dev environment
+    has pyjwt[crypto] installed (added as a dev dependency specifically so
+    the real-crypto tests below get exercised instead of skipped), so the
+    real check must report True."""
+    assert _pyjwt_available() is True
+
+
+# --- Real crypto path: proves `pip install 'fymo[clerk]'` restores today's
+# behavior identically, not just that construction doesn't raise. ---
+jwt = pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+
+def test_jwks_verifier_round_trips_a_genuinely_signed_token(monkeypatch):
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from jwt import PyJWKClient
+
+    from fymo.auth.providers.clerk import _jwks_verifier
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = jwt.encode(
+        {"sub": "user-1", "iss": "https://x.clerk.accounts.dev", "aud": "my-app",
+         "email": "a@example.com", "email_verified": True},
+        private_key, algorithm="RS256", headers={"kid": "test-key"},
+    )
+
+    class _FakeSigningKey:
+        def __init__(self, key):
+            self.key = key
+
+    # Only the network JWKS fetch is faked (no real HTTP call); the actual
+    # RS256 decode + signature verification below runs for real through the
+    # installed pyjwt/cryptography.
+    monkeypatch.setattr(
+        PyJWKClient, "get_signing_key_from_jwt",
+        lambda self, tok: _FakeSigningKey(private_key.public_key()),
+    )
+
+    verify = _jwks_verifier("https://x/jwks", "https://x.clerk.accounts.dev", "my-app")
+
+    claims = verify(token)
+    assert claims is not None
+    assert claims["sub"] == "user-1"
+    assert claims["email"] == "a@example.com"
+
+    tampered = token[:-4] + ("AAAA" if not token.endswith("AAAA") else "BBBB")
+    assert verify(tampered) is None
+
+
+def test_jwks_verifier_rejects_wrong_issuer(monkeypatch):
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from jwt import PyJWKClient
+
+    from fymo.auth.providers.clerk import _jwks_verifier
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = jwt.encode(
+        {"sub": "user-1", "iss": "https://not-the-configured-issuer.example", "aud": "my-app"},
+        private_key, algorithm="RS256", headers={"kid": "test-key"},
+    )
+
+    class _FakeSigningKey:
+        def __init__(self, key):
+            self.key = key
+
+    monkeypatch.setattr(
+        PyJWKClient, "get_signing_key_from_jwt",
+        lambda self, tok: _FakeSigningKey(private_key.public_key()),
+    )
+
+    verify = _jwks_verifier("https://x/jwks", "https://x.clerk.accounts.dev", "my-app")
+    assert verify(token) is None

--- a/tests/core/test_auth_boot_extras.py
+++ b/tests/core/test_auth_boot_extras.py
@@ -1,0 +1,116 @@
+"""FymoApp boot-time behavior for auth providers that need an optional
+extra (issue #59). `type: clerk` in fymo.yml must fail construction outright,
+naming the exact `pip install` command, when pyjwt[crypto] isn't installed --
+the same "refuse to start" shape as `fymo serve --prod --server granian`
+when granian is missing (fymo/cli/commands/serve.py:_resolve_prod_server).
+Silently booting with auth half-wired (or worse, disabled) is explicitly the
+failure mode this guards against.
+"""
+from pathlib import Path
+
+import pytest
+
+from fymo.core.server import FymoApp
+
+
+def _write_fake_sidecar(tmp_path: Path) -> None:
+    """FymoApp always requires dist/sidecar.mjs (no dev-mode bypass). Same
+    minimal length-prefixed-JSON-IPC stub used by test_dotenv_loading.py /
+    test_logging.py -- only needed by the "boots successfully" test below,
+    which must get all the way through __init__; the "fails at boot" test
+    never reaches the dist/ check at all, since provider construction now
+    raises earlier in __init__ (inside _init_auth)."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "sidecar.mjs").write_text(
+        "let buf = Buffer.alloc(0);\n"
+        "process.stdin.on('data', (chunk) => {\n"
+        "  buf = Buffer.concat([buf, chunk]);\n"
+        "  while (buf.length >= 4) {\n"
+        "    const len = buf.readUInt32BE(0);\n"
+        "    if (buf.length < 4 + len) break;\n"
+        "    const msg = JSON.parse(buf.slice(4, 4 + len).toString('utf8'));\n"
+        "    buf = buf.slice(4 + len);\n"
+        "    const replyBody = Buffer.from(JSON.stringify({ ok: true, id: msg.id }), 'utf8');\n"
+        "    const header = Buffer.alloc(4);\n"
+        "    header.writeUInt32BE(replyBody.length, 0);\n"
+        "    process.stdout.write(Buffer.concat([header, replyBody]));\n"
+        "  }\n"
+        "});\n"
+    )
+
+
+def _write_clerk_fymo_yml(tmp_path: Path) -> None:
+    (tmp_path / "fymo.yml").write_text(
+        "name: ClerkBootTest\n"
+        "routes: {}\n"
+        "auth:\n"
+        "  enabled: true\n"
+        "  providers:\n"
+        "    - type: clerk\n"
+    )
+
+
+def test_fymo_app_refuses_to_start_when_clerk_configured_without_pyjwt(tmp_path, monkeypatch):
+    monkeypatch.setenv("FYMO_SECRET", "x" * 32)
+    monkeypatch.setenv("CLERK_ISSUER", "https://x.clerk.accounts.dev")
+    monkeypatch.setattr("fymo.auth.providers.clerk._pyjwt_available", lambda: False)
+    _write_clerk_fymo_yml(tmp_path)
+
+    with pytest.raises(RuntimeError, match=r"pip install 'fymo\[clerk\]'"):
+        FymoApp(project_root=tmp_path, dev=True)
+
+
+def test_fymo_app_boots_when_clerk_configured_and_pyjwt_available(tmp_path, monkeypatch):
+    """The extra's deps actually present (this dev environment has
+    pyjwt[crypto] as a real dev dependency) must restore today's behavior:
+    the app boots, auth is enabled, and a ClerkProvider is installed."""
+    pytest.importorskip("jwt")
+    pytest.importorskip("cryptography")
+    monkeypatch.setenv("FYMO_SECRET", "x" * 32)
+    monkeypatch.setenv("CLERK_ISSUER", "https://x.clerk.accounts.dev")
+    _write_clerk_fymo_yml(tmp_path)
+    _write_fake_sidecar(tmp_path)
+
+    app = FymoApp(project_root=tmp_path, dev=True)
+    try:
+        assert app.auth_enabled is True
+        from fymo.auth.providers.clerk import ClerkProvider
+        assert any(isinstance(p, ClerkProvider) for p in app.auth_providers)
+    finally:
+        app.shutdown()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_fymo_app_boots_password_only_with_zero_auth_extras(tmp_path, monkeypatch):
+    """Acceptance criterion: a fresh install plus the password provider must
+    still boot and enable auth with zero optional extras installed. Doesn't
+    uninstall anything from the shared venv (that would be fragile and leak
+    across the rest of the suite) -- it proves the same thing by asserting
+    jwt/cryptography are never imported to get here, mirroring how the
+    clerk-missing test above simulates absence via monkeypatch instead of
+    physically removing a package."""
+    import sys
+    for name in ("jwt", "cryptography"):
+        sys.modules.pop(name, None)
+
+    monkeypatch.setenv("FYMO_SECRET", "x" * 32)
+    (tmp_path / "fymo.yml").write_text(
+        "name: PasswordBootTest\n"
+        "routes: {}\n"
+        "auth:\n"
+        "  enabled: true\n"
+    )
+    _write_fake_sidecar(tmp_path)
+
+    app = FymoApp(project_root=tmp_path, dev=True)
+    try:
+        assert app.auth_enabled is True
+        from fymo.auth.providers.password import PasswordProvider
+        assert len(app.auth_providers) == 1
+        assert isinstance(app.auth_providers[0], PasswordProvider)
+    finally:
+        app.shutdown()
+
+    assert "jwt" not in sys.modules
+    assert "cryptography" not in sys.modules

--- a/tests/core/test_pyproject_extras.py
+++ b/tests/core/test_pyproject_extras.py
@@ -1,0 +1,43 @@
+"""Named extras exist in pyproject.toml (issue #59): Clerk/OIDC/OAuth are
+opt-in installs, never pulled in by a bare `pip install fymo`. Reads the
+real pyproject.toml at the repo root rather than re-deriving the expected
+values, so a future edit to the extras themselves doesn't have to also
+touch this test to stay honest about intent -- it only pins the shape:
+the three names must exist, and clerk must actually carry pyjwt.
+"""
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - repo requires-python >=3.11
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_pyproject() -> dict:
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        return tomllib.load(f)
+
+
+def test_clerk_oidc_oauth_extras_are_all_defined():
+    extras = _load_pyproject()["project"]["optional-dependencies"]
+    for name in ("clerk", "oidc", "oauth"):
+        assert name in extras, f"fymo[{name}] extra is missing from pyproject.toml"
+
+
+def test_clerk_extra_pulls_in_pyjwt_with_crypto():
+    extras = _load_pyproject()["project"]["optional-dependencies"]
+    clerk_deps = " ".join(extras["clerk"])
+    assert "pyjwt" in clerk_deps.lower()
+    assert "crypto" in clerk_deps.lower()
+
+
+def test_base_dependencies_never_mention_pyjwt_or_cryptography():
+    """The core `dependencies` list (unlike optional-dependencies) is what a
+    bare `pip install fymo` actually pulls in -- pyjwt/cryptography must
+    never leak in there, or fymo[clerk] stops meaning anything."""
+    deps = " ".join(_load_pyproject()["project"]["dependencies"]).lower()
+    assert "pyjwt" not in deps
+    assert "cryptography" not in deps

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,104 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/67/85c89a59ba36a671e79638f44d466749f08179266a57e4f2ffdf92174072/cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc", size = 183845, upload-time = "2026-07-06T21:32:26.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dd/e3b0baa2d3d6a857ac72b7efbf18e32e487c9cdafcc13049ad765495b15e/cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7", size = 184186, upload-time = "2026-07-06T21:32:28.025Z" },
+    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793, upload-time = "2026-07-06T21:32:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d1/9a5b7169499e8e8d8e636de70b97ac7c9447104d2ff1a2cd94790cea5162/cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c", size = 205737, upload-time = "2026-07-06T21:32:32.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b0/e131a9c41f10607926278453d9596163594fe1c4ebc46efe3b5e5b34eb84/cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f", size = 204909, upload-time = "2026-07-06T21:32:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883, upload-time = "2026-07-06T21:32:35.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251, upload-time = "2026-07-06T21:32:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250, upload-time = "2026-07-06T21:32:37.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441, upload-time = "2026-07-06T21:32:39.146Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/da/5c4918a2d61d86fa927d716cb3d8e4626ef8dc8f605a599d32f33897f59a/cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479", size = 174496, upload-time = "2026-07-06T21:32:40.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c8/6c2de1d55cf35ef8b92885d5ef280790f0fb9634d87ea1cc315176aecd61/cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458", size = 185113, upload-time = "2026-07-06T21:32:41.761Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/e8d7cb5783f1841a3c8fb3a7735838d7484d08ec08c9f984b14cac1ac0e9/cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d", size = 179927, upload-time = "2026-07-06T21:32:42.961Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -63,8 +161,64 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
+]
+
+[[package]]
 name = "fymo"
-version = "0.11.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -73,6 +227,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+clerk = [
+    { name = "pyjwt", extra = ["crypto"] },
+]
 granian = [
     { name = "granian" },
 ]
@@ -88,6 +245,7 @@ pydantic = [
 dev = [
     { name = "granian" },
     { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -100,14 +258,16 @@ requires-dist = [
     { name = "procrastinate", marker = "extra == 'procrastinate'", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'procrastinate'", specifier = ">=3.1" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.5" },
+    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'clerk'", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
-provides-extras = ["pydantic", "procrastinate", "granian"]
+provides-extras = ["pydantic", "procrastinate", "granian", "clerk", "oidc", "oauth"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "granian", specifier = ">=2.0,<3" },
     { name = "pydantic", specifier = ">=2.5" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
 ]
@@ -333,6 +493,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -456,6 +625,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #59. Locks the auth packaging direction before more providers land: core keeps the mechanism (resolve_session protocol, provider registry, current_user(), @require_auth, CSRF, session cookies, the UserStore Protocol) plus the password provider (stdlib-only, hashlib.scrypt, zero external deps). Clerk, OIDC, and OAuth move behind named extras, `fymo[clerk]`, `fymo[oidc]`, `fymo[oauth]`, not separate PyPI packages.

Two concrete gaps closed:

- ClerkProvider's missing-dependency error used to name a raw transitive package (`pip install pyjwt[crypto]`); now names the actual fymo extra.
- The failure used to happen inside the JWKS verifier, meaning in production only at the first authenticated request. Now checked eagerly at provider construction, which FymoApp.__init__ reaches at boot, so a misconfigured deployment refuses to start instead of silently shipping broken auth until someone tries to log in.

Deliberately did not add a separate deprecation-warning phase for "pyjwt present but the extra was never declared", there is no reliable runtime signal distinguishing that from "installed correctly", both states behave identically today (works, nothing disabled). The actual fix, a loud failure for the state that matters, missing entirely, covers this regardless of how the dependency got there.

## Test plan

- [x] Unit tests for provider construction/registry behavior plus a real-crypto RSA/JWT round trip
- [x] Full FymoApp boot proofs for missing / present / password-only
- [x] Test pinning the extras' actual shape in pyproject.toml
- [x] Verified end to end with a real built wheel: installed into a genuinely clean venv, `type: clerk` refused to boot naming the exact install command, then `pip install 'fymo[clerk]'` into that same venv and confirmed clean construction
- [x] Full suite green