### PR TITLE
Request-scoped identity extras for app-defined authorization data

### DIFF
--- a/fymo/auth/__init__.py
+++ b/fymo/auth/__init__.py
@@ -13,7 +13,13 @@ Public API:
 The fymo.yml `auth:` section enables it and points at custom stores when
 needed. See `fymo.auth.store.UserStore` Protocol for the seam.
 """
-from fymo.auth.context import current_user, require_auth, AuthRequired
+from fymo.auth.context import (
+    current_user,
+    require_auth,
+    AuthRequired,
+    identity_extras,
+    register_identity_extras_hook,
+)
 from fymo.auth.passwords import hash_password, verify_password
 from fymo.auth.store import User, UserStore, SqliteUserStore, EmailAlreadyExists
 
@@ -21,6 +27,8 @@ __all__ = [
     "current_user",
     "require_auth",
     "AuthRequired",
+    "identity_extras",
+    "register_identity_extras_hook",
     "hash_password",
     "verify_password",
     "User",

--- a/fymo/auth/context.py
+++ b/fymo/auth/context.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import contextvars
 import functools
-from typing import Callable, List, Optional, TypeVar
+from types import MappingProxyType
+from typing import Callable, List, Mapping, Optional, TypeVar
 
 from fymo.auth.email import EmailSender, LoggingEmailSender
 from fymo.auth.session import build_set_cookie, build_clear_cookie, verify_session_token
@@ -149,6 +150,77 @@ def _fymo_session_resolver(event: dict) -> Optional[User]:
     return user
 
 
+# --------------- identity extras (app-defined data next to the identity) ---
+#
+# fymo answers "who is this"; apps also need "what may this user do", and
+# that data (org, roles, scopes, tenant) has to live somewhere reachable
+# wherever current_user() is. Hooks registered here run once per request
+# scope, right after a resolver returns a user, and their merged result is
+# stored on the mutable per-request event dict that _current_event holds.
+# fymo stores the value and never inspects it.
+#
+# A hook (rather than an imperative setter) is the population point because
+# the built-in fymo-session resolver wins the chain before any registered
+# resolver runs: apps on fymo's own sessions would otherwise have no code
+# that executes at resolution time. The hook fires for every resolver in the
+# chain equally, built-in or provider.
+#
+# Coverage matches current_user() exactly: remote functions, SSR
+# controllers/layouts and the soft-nav data endpoint (both open the same
+# request scope when auth is enabled, see fymo.core.ssr_controller), and
+# broadcast guards. Note SSR opens one scope per controller invocation, so
+# "once per request" there means once per getContext/getDoc call.
+
+IdentityExtrasHook = Callable[[User], Mapping[str, object]]
+
+_identity_extras_hooks: List[IdentityExtrasHook] = []
+
+_EXTRAS_KEY = "identity_extras"
+_EMPTY_EXTRAS: Mapping[str, object] = MappingProxyType({})
+
+
+def register_identity_extras_hook(hook: IdentityExtrasHook) -> None:
+    """Add a hook called once per request scope with the resolved User.
+
+    Hooks run in registration order the first time current_user() resolves
+    someone; their returned mappings are merged (later wins on key
+    collision) and frozen for the rest of the scope. Never called for
+    anonymous requests."""
+    _identity_extras_hooks.append(hook)
+
+
+def reset_identity_extras_hooks() -> None:
+    """Drop all registered hooks (re-init / tests)."""
+    _identity_extras_hooks.clear()
+
+
+def identity_extras() -> Mapping[str, object]:
+    """Return the app-defined data attached to the resolved identity.
+
+    Empty until current_user() first resolves a user in this scope (or when
+    no hooks are registered); never an error inside a scope. Raises the same
+    RuntimeError as request_event() outside one."""
+    from fymo.remote.context import _current_event
+    event = _current_event.get()
+    if event is None:
+        raise RuntimeError(
+            "identity_extras() called outside of a remote-function request scope"
+        )
+    extras = event.get(_EXTRAS_KEY)
+    if extras is None:
+        return _EMPTY_EXTRAS
+    return extras
+
+
+def _populate_identity_extras(event: dict, user: User) -> None:
+    if _EXTRAS_KEY in event or not _identity_extras_hooks:
+        return
+    merged: dict = {}
+    for hook in _identity_extras_hooks:
+        merged.update(hook(user))
+    event[_EXTRAS_KEY] = MappingProxyType(merged)
+
+
 def current_user() -> Optional[User]:
     """Return the authenticated user, or None when no provider recognizes the
     request. Walks the fymo-session cookie first, then provider resolvers."""
@@ -161,6 +233,7 @@ def current_user() -> Optional[User]:
     for resolve in (_fymo_session_resolver, *_session_resolvers):
         user = resolve(event)
         if user is not None:
+            _populate_identity_extras(event, user)
             return user
     return None
 

--- a/fymo/auth/context.py
+++ b/fymo/auth/context.py
@@ -168,8 +168,7 @@ def _fymo_session_resolver(event: dict) -> Optional[User]:
 # Coverage matches current_user() exactly: remote functions, SSR
 # controllers/layouts and the soft-nav data endpoint (both open the same
 # request scope when auth is enabled, see fymo.core.ssr_controller), and
-# broadcast guards. Note SSR opens one scope per controller invocation, so
-# "once per request" there means once per getContext/getDoc call.
+# broadcast guards.
 
 IdentityExtrasHook = Callable[[User], Mapping[str, object]]
 
@@ -179,13 +178,45 @@ _EXTRAS_KEY = "identity_extras"
 _EMPTY_EXTRAS: Mapping[str, object] = MappingProxyType({})
 
 
+def _hook_registration_key(hook: IdentityExtrasHook):
+    """Identity of a hook's definition site, stable across importlib.reload.
+
+    The dev process re-executes app module bodies several times per reload
+    (hygiene check, guarded-sites scan, discovery), and each reload creates
+    a new function object, so object identity cannot dedup a top-level
+    registration. The (module, qualname, file, line) of the definition
+    survives reloads; two distinct lambdas in one scope still differ by
+    line. Callables without __code__ fall back to object identity."""
+    code = getattr(hook, "__code__", None)
+    if code is None:
+        return hook
+    return (
+        getattr(hook, "__module__", None),
+        getattr(hook, "__qualname__", None),
+        code.co_filename,
+        code.co_firstlineno,
+    )
+
+
 def register_identity_extras_hook(hook: IdentityExtrasHook) -> None:
     """Add a hook called once per request scope with the resolved User.
 
     Hooks run in registration order the first time current_user() resolves
     someone; their returned mappings are merged (later wins on key
     collision) and frozen for the rest of the scope. Never called for
-    anonymous requests."""
+    anonymous requests. During SSR a request scope is opened per controller
+    invocation, so a hook runs once per getContext/getDoc call there, not
+    once per HTTP request.
+
+    Registering a hook whose definition site is already registered replaces
+    the stale entry in place (keeping order) instead of appending, so the
+    natural registration point, the top level of an app module, stays
+    idempotent under the dev server's module reloads."""
+    key = _hook_registration_key(hook)
+    for i, existing in enumerate(_identity_extras_hooks):
+        if _hook_registration_key(existing) == key:
+            _identity_extras_hooks[i] = hook
+            return
     _identity_extras_hooks.append(hook)
 
 

--- a/journal/journal_023.md
+++ b/journal/journal_023.md
@@ -51,18 +51,51 @@ one query per request, not one per check.
 ## The Memo I Didn't Add
 
 While in there it was tempting to memoize the resolved user too, since the
-sentinel machinery was right at hand. I left it alone. The SSE broadcast
-path holds a single request scope open for the lifetime of a connection,
-and a memoized user there would freeze identity for hours and make epoch
-revocation invisible mid-stream. Extras get exactly that freezing behavior
-on purpose, they're per-request by contract. Identity resolution keeps its
-re-walk semantics because something observable actually depends on them.
+sentinel machinery was right at hand. I left it alone, and my first reason
+for leaving it alone turned out to be wrong. I had convinced myself the
+SSE broadcast path holds a request scope open for the lifetime of a
+connection, where a memoized user would freeze identity for hours.
+Re-reading sse.py instead of trusting my memory of it: the scope wraps the
+authorization guard call only and closes before the stream ever starts.
+The hours-long scope I was defending against does not exist.
+
+The decision still stands, on real ground this time. current_user()
+re-walking the chain on every call is observable behavior the resolver
+tests exercise directly, resolvers get registered and swapped and the walk
+is expected to see the change. A silent memo would rewrite those semantics
+as a side effect of an unrelated feature. Extras get frozen per scope on
+purpose, that is their contract. Identity resolution keeps its re-walk
+because nothing about this issue asked me to change it.
 
 One thing I did verify rather than assume: SSR controllers run inside the
 same request scope remote functions get, when auth is enabled, so extras
 set by a hook are readable from getContext and layouts too. The honest
 footnote is that SSR opens one scope per controller invocation, so "once
-per request" there means once per getContext call. It's in the docstring.
+per request" there means once per getContext call. The hook's docstring
+carries that caveat now.
+
+## The Hook That Registered Itself Three Times
+
+After the first cut I went back over where an app would actually call
+register_identity_extras_hook from. The natural place is the top level of
+an app module, and in a dev process that module body runs up to three
+times: the hygiene check, the guarded-sites scan, and discovery each
+reload it through importlib. Every pass appended another copy of the hook,
+so the one-query-per-request promise quietly became three queries in dev,
+and no value-based assertion could catch it, the merged result was
+byte-identical.
+
+The obvious fix, deduplicating by function identity, does not work: every
+reload creates a brand new function object. What survives a reload is the
+definition site, module, qualname, file, line, so registration now
+replaces the stale entry whose site matches instead of appending. Two
+different lambdas in one scope still differ by line, which the merge test
+proves, and a new test builds a scratch module, reloads it twice, and
+asserts exactly one hook fires exactly once per scope. The resolver chain
+solved this same problem by resetting before re-registering, but hooks
+can't borrow that trick, nothing between the three reload passes ever
+re-runs the reset point. With the dedup and a test pinning the returned
+mapping as read-only, the suite stands at 920 for 920.
 
 ## Ten Skips That Weren't Free
 

--- a/journal/journal_023.md
+++ b/journal/journal_023.md
@@ -1,0 +1,81 @@
+# Journal Entry 023: A Place to Put What the User May Do
+
+**Date**: July 16, 2026
+**Focus**: Identity extras, the request-scoped slot issue #57 asked for
+**Status**: Shipped
+
+## The Missing Slot
+
+fymo answers "who is this" completely. Custom resolvers, the session
+cookie, token providers, all of it works. The moment an app asks "what is
+this user allowed to do", it needs data sitting next to the identity, an
+org id, roles, scopes, and fymo gave that data nowhere to live. I know
+because a real app built on fymo re-fetched permission rows inside every
+remote function that needed them, then hand-rolled a module-level cache
+keyed by user id to make that bearable. Both worse than the framework just
+providing the slot.
+
+Going looking for the slot confirmed there wasn't one. User is a frozen
+dataclass, nothing can be added. RequestEvent is also frozen, and it gets
+rebuilt from the raw event dict on every request_event() call, so there's
+no stable object to hang anything on. current_user() re-walks the whole
+resolver chain on every single call, no per-request memo to piggyback on.
+The one mutable per-request thing in the entire system is the plain dict
+the request-scope contextvar holds. That dict is where extras now live.
+
+## The Setter That Would Never Run
+
+My first shape was the obvious one: set_identity_extras(mapping), called
+from inside your session resolver, read back with identity_extras(). Write
+the API, register a resolver in the test, done by lunch.
+
+Then I traced who actually gets to run during session resolution. The
+chain is the built-in fymo-session resolver first, then registered ones,
+first non-None wins. Which means for every app using fymo's own sessions,
+the majority case and the exact case the permission-cache app was in, the
+built-in resolver resolves the user and returns before any app code
+executes. A setter "called during session resolution" has nowhere to be
+called from. The shape only worked for apps that had already replaced
+fymo's auth with their own resolver, the people who needed it least.
+
+So the population point is a hook instead. register_identity_extras_hook
+takes a function of the resolved User, and current_user() fires the hooks
+once per request scope, right after whichever resolver in the chain
+resolved, built-in or provider, then freezes the merged result into the
+event dict. fymo never looks inside it. Absent means an empty mapping,
+never an error, and outside a request scope the accessor raises the same
+RuntimeError request_event() does. The hook running once per scope also
+quietly kills the hand-rolled cache: a hook that hits the database runs
+one query per request, not one per check.
+
+## The Memo I Didn't Add
+
+While in there it was tempting to memoize the resolved user too, since the
+sentinel machinery was right at hand. I left it alone. The SSE broadcast
+path holds a single request scope open for the lifetime of a connection,
+and a memoized user there would freeze identity for hours and make epoch
+revocation invisible mid-stream. Extras get exactly that freezing behavior
+on purpose, they're per-request by contract. Identity resolution keeps its
+re-walk semantics because something observable actually depends on them.
+
+One thing I did verify rather than assume: SSR controllers run inside the
+same request scope remote functions get, when auth is enabled, so extras
+set by a hook are readable from getContext and layouts too. The honest
+footnote is that SSR opens one scope per controller invocation, so "once
+per request" there means once per getContext call. It's in the docstring.
+
+## Ten Skips That Weren't Free
+
+The full suite came back green with ten skips, all Postgres-gated tests
+wanting a TEST_DATABASE_URL. Easy to wave off as environmental. Instead I
+checked what was actually running on this machine and found the Postgres
+container from the issue-50 work still up. First attempt failed on a
+guessed password, the container wanted fymo, not postgres, and the job
+tests needed the procrastinate extra installed. With both fixed, all ten
+formerly-skipped tests passed against the real database, and the suite
+finished 917 for 917, zero skips. A skip you haven't explained is just a
+failure you haven't met yet.
+
+---
+
+*End of Journal Entry 023*

--- a/tests/auth/test_identity_extras.py
+++ b/tests/auth/test_identity_extras.py
@@ -125,6 +125,69 @@ def test_hook_runs_for_provider_resolved_identities(store):
         assert identity_extras()["id"] == user.id
 
 
+def test_extras_mapping_is_read_only(store):
+    """The returned mapping is frozen: extras are populated once per scope,
+    and nothing downstream may mutate them in place."""
+    user = store.create("ro@example.com", "hash")
+    register_identity_extras_hook(lambda u: {"org": "acme"})
+
+    with _scope_with_session(user):
+        empty = identity_extras()
+        with pytest.raises(TypeError):
+            empty["sneak"] = 1  # type: ignore[index]
+        current_user()
+        extras = identity_extras()
+        with pytest.raises(TypeError):
+            extras["org"] = "evil"  # type: ignore[index]
+
+
+def test_registering_same_hook_twice_replaces_not_duplicates(store):
+    def attach(user):
+        return {"org": "acme"}
+
+    register_identity_extras_hook(attach)
+    register_identity_extras_hook(attach)
+    assert len(auth_context._identity_extras_hooks) == 1
+
+
+def test_hook_registration_survives_module_reload_without_duplicates(store, tmp_path, monkeypatch):
+    """The dev process re-executes app module bodies several times per
+    reload (hygiene check, guarded-sites scan, discovery, each via
+    importlib.reload), and reload creates a new function object every pass.
+    A top-level register_identity_extras_hook call must replace its stale
+    predecessor, not accumulate one copy per pass."""
+    import importlib
+
+    mod_name = "fymo_issue57_hookmod"
+    (tmp_path / f"{mod_name}.py").write_text(
+        "from fymo.auth import register_identity_extras_hook\n"
+        "\n"
+        "CALLS = []\n"
+        "\n"
+        "def attach(user):\n"
+        "    CALLS.append(user.id)\n"
+        "    return {'org': 'acme'}\n"
+        "\n"
+        "register_identity_extras_hook(attach)\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    mod = importlib.import_module(mod_name)
+    try:
+        mod = importlib.reload(mod)
+        mod = importlib.reload(mod)
+
+        assert len(auth_context._identity_extras_hooks) == 1
+        assert auth_context._identity_extras_hooks[0] is mod.attach
+
+        user = store.create("reload@example.com", "hash")
+        with _scope_with_session(user):
+            current_user()
+            assert dict(identity_extras()) == {"org": "acme"}
+        assert mod.CALLS == [user.id]
+    finally:
+        sys.modules.pop(mod_name, None)
+
+
 # --------------- concurrency: no leakage across scopes ---------------
 
 

--- a/tests/auth/test_identity_extras.py
+++ b/tests/auth/test_identity_extras.py
@@ -1,0 +1,264 @@
+"""Request-scoped identity extras (issue #57).
+
+Apps attach their own authorization-adjacent data (org, roles, scopes,
+tenant) next to the resolved identity via register_identity_extras_hook(),
+and read it back anywhere current_user() is readable via identity_extras().
+fymo stores the value and never inspects it; absent means empty, never an
+error.
+"""
+import base64
+import io
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from fymo.auth import identity_extras, register_identity_extras_hook
+from fymo.auth import context as auth_context
+from fymo.auth.context import (
+    current_user,
+    register_session_resolver,
+    require_auth,
+    reset_identity_extras_hooks,
+    reset_session_resolvers,
+)
+from fymo.auth.session import make_session_token
+from fymo.auth.store import SqliteUserStore
+from fymo.remote import devalue, router as router_mod
+from fymo.remote.context import request_scope
+from fymo.remote.identity import set_secret
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    set_secret(b"x" * 32)
+    s = SqliteUserStore(project_root=tmp_path)
+    auth_context.set_user_store(s)
+    yield s
+    reset_session_resolvers()
+    reset_identity_extras_hooks()
+
+
+def _scope_with_session(user):
+    token = make_session_token(user.id, user.session_epoch)
+    return request_scope(uid="u_x", environ={"HTTP_COOKIE": f"fymo_session={token}"})
+
+
+# --------------- unit: hook population + accessor ---------------
+
+
+def test_hook_extras_readable_alongside_current_user(store):
+    user = store.create("alice@example.com", "hash")
+    register_identity_extras_hook(lambda u: {"org": "acme", "email": u.email})
+
+    with _scope_with_session(user):
+        assert current_user() is not None
+        extras = identity_extras()
+        assert extras["org"] == "acme"
+        assert extras["email"] == "alice@example.com"
+
+
+def test_hook_runs_once_per_request_scope(store):
+    user = store.create("bob@example.com", "hash")
+    calls = []
+    register_identity_extras_hook(lambda u: calls.append(u.id) or {"n": len(calls)})
+
+    with _scope_with_session(user):
+        current_user()
+        current_user()
+        current_user()
+        assert identity_extras()["n"] == 1
+    assert calls == [user.id]
+
+
+def test_absent_extras_returns_empty_mapping_inside_scope(store):
+    user = store.create("carol@example.com", "hash")
+    with _scope_with_session(user):
+        # Before any resolution, and after resolution with no hooks
+        # registered, extras read as empty.
+        assert dict(identity_extras()) == {}
+        assert current_user() is not None
+        assert dict(identity_extras()) == {}
+
+
+def test_anonymous_request_leaves_extras_empty(store):
+    register_identity_extras_hook(lambda u: {"should": "never run"})
+    with request_scope(uid="u_x", environ={}):
+        assert current_user() is None
+        assert dict(identity_extras()) == {}
+
+
+def test_accessor_raises_outside_request_scope(store):
+    with pytest.raises(RuntimeError, match="outside of a remote-function request scope"):
+        identity_extras()
+
+
+def test_hooks_merge_in_registration_order(store):
+    user = store.create("dave@example.com", "hash")
+    register_identity_extras_hook(lambda u: {"role": "viewer", "org": "acme"})
+    register_identity_extras_hook(lambda u: {"role": "admin"})
+
+    with _scope_with_session(user):
+        current_user()
+        extras = identity_extras()
+        assert extras["role"] == "admin"
+        assert extras["org"] == "acme"
+
+
+def test_hook_runs_for_provider_resolved_identities(store):
+    """The hook fires no matter which resolver in the chain resolved the
+    user, so token/JWT provider identities get extras exactly like
+    fymo-session ones."""
+    user = store.create("token@example.com", "hash")
+    register_session_resolver(
+        lambda event: user
+        if event.get("headers", {}).get("x-provider-token") == "ok"
+        else None
+    )
+    register_identity_extras_hook(lambda u: {"via": "provider", "id": u.id})
+
+    with request_scope(uid="u_x", environ={"HTTP_X_PROVIDER_TOKEN": "ok"}):
+        assert current_user() is not None
+        assert identity_extras()["via"] == "provider"
+        assert identity_extras()["id"] == user.id
+
+
+# --------------- concurrency: no leakage across scopes ---------------
+
+
+def test_concurrent_scopes_do_not_leak_extras(store):
+    alice = store.create("a@example.com", "hash")
+    bob = store.create("b@example.com", "hash")
+    register_identity_extras_hook(lambda u: {"email": u.email})
+
+    barrier = threading.Barrier(2, timeout=10)
+    results: dict[str, object] = {}
+    errors: list[BaseException] = []
+
+    def worker(name: str, user):
+        try:
+            with _scope_with_session(user):
+                barrier.wait()  # both scopes open before either resolves
+                current_user()
+                barrier.wait()  # both populated before either reads
+                results[name] = dict(identity_extras())
+        except BaseException as e:  # noqa: BLE001 - surface thread failures
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=worker, args=("alice", alice)),
+        threading.Thread(target=worker, args=("bob", bob)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, errors
+    assert results["alice"] == {"email": "a@example.com"}
+    assert results["bob"] == {"email": "b@example.com"}
+
+
+# --------------- acceptance: full remote-router round trip ---------------
+
+
+@pytest.fixture(autouse=True)
+def _wire_secret():
+    set_secret(b"x" * 32)
+
+
+@pytest.fixture
+def app_env(tmp_path: Path, monkeypatch):
+    """Same wiring as tests/auth/test_remote_e2e.py: password provider's
+    remote functions dispatched through the real router, plus an app-authored
+    function that reads identity_extras()."""
+    from fymo.auth.providers.password import PasswordProvider
+    from fymo.auth.providers.registry import system_remote_modules
+    from fymo.remote.discovery import _functions_hash
+
+    store = SqliteUserStore(project_root=tmp_path)
+    auth_context.set_user_store(store)
+
+    @require_auth
+    def my_extras() -> dict:
+        return dict(identity_extras())
+
+    modules = system_remote_modules([PasswordProvider()])
+    modules["auth"]["my_extras"] = my_extras
+    router_mod.set_system_modules(modules)
+    auth_hash = _functions_hash(modules["auth"])
+
+    monkeypatch.setattr(
+        router_mod,
+        "_resolve_module_for_hash",
+        lambda h: "auth" if h == auth_hash else None,
+    )
+    yield store, auth_hash
+    router_mod.set_system_modules({})
+    reset_session_resolvers()
+    reset_identity_extras_hooks()
+
+
+def _b64url(s: str) -> str:
+    return base64.urlsafe_b64encode(s.encode("utf-8")).rstrip(b"=").decode("ascii")
+
+
+def _call(hash_: str, fn: str, args: list, cookies: str = ""):
+    body = json.dumps({"payload": _b64url(devalue.stringify(args))}).encode()
+    env = {
+        "REQUEST_METHOD": "POST",
+        "PATH_INFO": f"/_fymo/remote/{hash_}/{fn}",
+        "CONTENT_LENGTH": str(len(body)),
+        "CONTENT_TYPE": "application/json",
+        "HTTP_COOKIE": cookies,
+        "HTTP_HOST": "x",
+        "HTTP_ORIGIN": "http://x",
+        "wsgi.url_scheme": "http",
+        "REMOTE_ADDR": "127.0.0.1",
+        "wsgi.input": io.BytesIO(body),
+        "wsgi.errors": sys.stderr,
+    }
+    responses = []
+    def sr(status, headers): responses.append((status, headers))
+    out = b"".join(router_mod.handle_remote(env, sr))
+    return responses[0], json.loads(out)
+
+
+def _extract_cookie(headers, name) -> str | None:
+    for k, v in headers:
+        if k.lower() == "set-cookie" and v.startswith(f"{name}="):
+            return v.split(";", 1)[0]
+    return None
+
+
+def test_extras_attached_at_resolution_read_back_in_remote_function(app_env):
+    """Acceptance (issue #57): an app attaches a dict of its own data when
+    the session resolves and reads it back from inside a remote function via
+    the public accessor, without touching fymo's User shape."""
+    _, h = app_env
+    register_identity_extras_hook(
+        lambda user: {"org": "acme", "roles": ["admin"], "owner_of": [user.id]}
+    )
+
+    (_, headers), env = _call(h, "signup", ["alice@example.com", "longpassword"])
+    session_cookie = _extract_cookie(headers, "fymo_session")
+    user = devalue.parse(env["result"])
+
+    (_, _), env = _call(h, "my_extras", [], cookies=session_cookie)
+    assert env["type"] == "result", env
+    extras = devalue.parse(env["result"])
+    assert extras == {"org": "acme", "roles": ["admin"], "owner_of": [user["id"]]}
+
+
+def test_remote_function_sees_empty_extras_when_nothing_attached(app_env):
+    """Absent means empty, never an error: no hook registered, the accessor
+    still answers with an empty mapping through the full router path."""
+    _, h = app_env
+    (_, headers), _ = _call(h, "signup", ["bob@example.com", "longpassword"])
+    session_cookie = _extract_cookie(headers, "fymo_session")
+
+    (_, _), env = _call(h, "my_extras", [], cookies=session_cookie)
+    assert env["type"] == "result", env
+    assert devalue.parse(env["result"]) == {}


### PR DESCRIPTION
## Summary

Closes #57. Apps can now attach their own data (roles, scopes, org/tenant, ownership handles) to the resolved identity and read it back anywhere current_user() works.

- `register_identity_extras_hook(fn)`: hook receives the resolved User, returns a mapping; fires once per request scope for whichever resolver wins (built-in or provider), merged in registration order, never fired for anonymous requests.
- `identity_extras()`: read-only mapping, empty when nothing registered, same RuntimeError style as request_event() outside a scope.
- fymo stores the value and never inspects it. Zero behavior change when no hooks are registered.
- Registration is reload-safe: hooks dedup by definition site, so the dev server's triple module execution (hygiene, guard scan, discovery) registers one copy, not three.
- Verified SSR getContext/getDoc and broadcast guards run inside a request scope, so extras are readable there too.

## Test plan

- 13 tests in tests/auth/test_identity_extras.py: once-per-scope, merge order, anonymous, outside-scope, thread isolation (barrier-synced), remote-router round trip, reload idempotency (importlib.reload twice, exactly one registration), read-only mapping.
- Full suite: 920 passed, 0 failed (Postgres-gated tests included against a live container).