### PR TITLE
Cursor pagination convention for remote functions

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -129,8 +129,11 @@ The pieces, all from `fymo.remote`:
   opaque cursor is just base64url-encoded JSON of the last-seen sort-key
   value(s). `decode_cursor` raises a `RemoteError` that the router turns
   into a 400 `bad_cursor` envelope on any garbage input (bad base64,
-  non-JSON, wrong arity, nested values), so a tampered cursor can never
-  become a 500.
+  non-JSON, wrong arity, nested values, ints beyond the JS safe-integer
+  range), so a tampered cursor can never become a 500. One thing it
+  cannot detect: a *well-formed* cursor pasted from a different paginated
+  function with the same arity decodes fine and just yields a wrong or
+  empty page — cursors are opaque, not authenticated.
 - **The fetch-one-extra idiom** — query `LIMIT limit + 1`. Getting
   `limit + 1` rows back proves there's a next page without a second
   `COUNT(*)` query; `paginate(rows, limit, key=...)` drops the extra row

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -81,3 +81,102 @@ updated by the soft-nav router, not by the SSR render pass: reads inside
 read in top-level template markup during the very first render may
 briefly differ from what the server rendered, the same as any other value
 that legitimately differs between server and client.
+
+## Paginated remote functions
+
+Nothing stops a remote function from returning every row, and at demo row
+counts that works, which is exactly the problem: `list_x()` returning the
+whole table is the path of least resistance and gives no signal in dev that
+it stops working later. The convention for anything list-shaped that can
+grow is cursor pagination:
+
+```python
+from typing import TypedDict
+from fymo.remote import remote, decode_cursor, paginate
+
+
+class PostsPage(TypedDict):
+    items: list[PostSummary]
+    next_cursor: str | None    # opaque; null means "no more pages"
+
+
+@remote
+def list_posts(cursor: str | None = None, limit: int = 20) -> PostsPage:
+    limit = max(1, min(limit, 50))
+    fields = "slug, title, summary, tags, published_at"
+    if cursor:
+        published_at, slug = decode_cursor(cursor, expect=2)
+        rows = get_db().fetchall(
+            f"SELECT {fields} FROM posts WHERE (published_at, slug) < (?, ?) "
+            "ORDER BY published_at DESC, slug DESC LIMIT ?",
+            [published_at, slug, limit + 1],
+        )
+    else:
+        rows = get_db().fetchall(
+            f"SELECT {fields} FROM posts ORDER BY published_at DESC, slug DESC LIMIT ?",
+            [limit + 1],
+        )
+    return paginate(rows, limit, key=lambda p: (p["published_at"], p["slug"]))
+```
+
+This is copied from `examples/blog_app/app/remote/posts.py`, which
+demonstrates it end to end (the home page SSRs the first page and a "More
+posts" button fetches the rest through the `$remote` client).
+
+The pieces, all from `fymo.remote`:
+
+- **`encode_cursor(*values)` / `decode_cursor(cursor, expect=n)`** — an
+  opaque cursor is just base64url-encoded JSON of the last-seen sort-key
+  value(s). `decode_cursor` raises a `RemoteError` that the router turns
+  into a 400 `bad_cursor` envelope on any garbage input (bad base64,
+  non-JSON, wrong arity, nested values), so a tampered cursor can never
+  become a 500.
+- **The fetch-one-extra idiom** — query `LIMIT limit + 1`. Getting
+  `limit + 1` rows back proves there's a next page without a second
+  `COUNT(*)` query; `paginate(rows, limit, key=...)` drops the extra row
+  and encodes the last *kept* row's sort key(s) as `next_cursor`, or `None`
+  when the extra row didn't come back.
+- **A unique sort key** — the cursor must identify an exact position, so
+  sort by something unique. A timestamp alone usually isn't; the example
+  uses `(published_at, slug)` with SQLite's row-value comparison. A single
+  auto-increment `id` works too: `WHERE id < ? ORDER BY id DESC`, with
+  `key=lambda r: r["id"]`.
+
+Why cursor instead of `offset`? `OFFSET n` scans and discards `n` rows on
+every page, and a row inserted between two requests shifts every subsequent
+page (items repeat or vanish). A cursor is a WHERE clause on an indexed
+column: constant cost per page, stable under concurrent writes, and it
+devalue-round-trips as a plain string.
+
+Declare the page shape as a plain per-module TypedDict (`PostsPage`), not a
+generic `Page[T]`. Codegen (`fymo/remote/typemap.py`) maps a subscripted
+generic TypedDict to `unknown` — a plain TypedDict comes out as a real
+interface:
+
+```ts
+export interface PostsPage {
+  items: PostSummary[];
+  next_cursor: string | null;
+}
+export function list_posts(cursor?: string | null, limit?: number): Promise<PostsPage>;
+```
+
+On the client, page one is a call with no cursor; every next page feeds the
+previous `next_cursor` back in until it comes back `null`:
+
+```svelte
+<script lang="ts">
+  let feed = $state<PostSummary[]>([]);
+  let cursor: string | null = $state(null);
+
+  async function loadMore() {
+    const page = await list_posts(cursor, 10);
+    feed = [...feed, ...page.items];
+    cursor = page.next_cursor;   // null => hide the button
+  }
+</script>
+```
+
+Omitted arguments use the Python-side defaults: the generated client sends
+`undefined` for a skipped trailing argument and the dispatcher substitutes
+the parameter default, so `list_posts()` means `cursor=None, limit=20`.

--- a/examples/blog_app/app/controllers/index.py
+++ b/examples/blog_app/app/controllers/index.py
@@ -1,12 +1,17 @@
 """Home page controller."""
-from app.remote.posts import get_posts
+from app.remote.posts import list_posts
 
 
 def getContext():
-    posts = get_posts()
+    # First page only; hero takes one slot. The template loads the rest
+    # through the list_posts remote callable threaded as a prop.
+    page = list_posts(limit=11)
+    posts = page["items"]
     return {
         "hero": posts[0] if posts else None,
         "posts": posts[1:] if len(posts) > 1 else [],
+        "next_cursor": page["next_cursor"],
+        "list_posts": list_posts,  # remote callable threaded as prop
     }
 
 

--- a/examples/blog_app/app/remote/posts.py
+++ b/examples/blog_app/app/remote/posts.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import TypedDict, Literal
 from pydantic import BaseModel, Field
 
-from fymo.remote import current_uid, NotFound, remote
+from fymo.remote import current_uid, NotFound, remote, decode_cursor, paginate
 from fymo.auth import require_auth, current_user
 from app.data.db import get_db
 
@@ -45,6 +45,11 @@ class ReactionCounts(TypedDict):
     mind: int
 
 
+class PostsPage(TypedDict):
+    items: list[PostSummary]
+    next_cursor: str | None
+
+
 class NewComment(BaseModel):
     body: str = Field(min_length=1, max_length=1000)
 
@@ -54,6 +59,28 @@ def get_posts() -> list[PostSummary]:
     return get_db().fetchall(
         "SELECT slug, title, summary, tags, published_at FROM posts ORDER BY published_at DESC"
     )
+
+
+@remote
+def list_posts(cursor: str | None = None, limit: int = 20) -> PostsPage:
+    # Cursor pagination over (published_at, slug): published_at alone isn't
+    # unique, so slug breaks ties. Fetch one row past `limit`; paginate()
+    # turns that extra row into next_cursor (null on the last page).
+    limit = max(1, min(limit, 50))
+    fields = "slug, title, summary, tags, published_at"
+    if cursor:
+        published_at, slug = decode_cursor(cursor, expect=2)
+        rows = get_db().fetchall(
+            f"SELECT {fields} FROM posts WHERE (published_at, slug) < (?, ?) "
+            "ORDER BY published_at DESC, slug DESC LIMIT ?",
+            [published_at, slug, limit + 1],
+        )
+    else:
+        rows = get_db().fetchall(
+            f"SELECT {fields} FROM posts ORDER BY published_at DESC, slug DESC LIMIT ?",
+            [limit + 1],
+        )
+    return paginate(rows, limit, key=lambda p: (p["published_at"], p["slug"]))
 
 
 @remote

--- a/examples/blog_app/app/templates/index/index.svelte
+++ b/examples/blog_app/app/templates/index/index.svelte
@@ -1,7 +1,33 @@
 <script lang="ts">
-  import type { PostSummary } from '$remote/posts';
+  import type { PostSummary, PostsPage } from '$remote/posts';
 
-  let { hero, posts }: { hero: PostSummary | null; posts: PostSummary[] } = $props();
+  let {
+    hero,
+    posts,
+    next_cursor,
+    list_posts,
+  }: {
+    hero: PostSummary | null;
+    posts: PostSummary[];
+    next_cursor: string | null;
+    list_posts: (cursor?: string | null, limit?: number) => Promise<PostsPage>;
+  } = $props();
+
+  let feed = $state([...posts]);
+  let cursor = $state(next_cursor);
+  let loading = $state(false);
+
+  async function loadMore() {
+    if (loading || !cursor) return;
+    loading = true;
+    try {
+      const page = await list_posts(cursor, 10);
+      feed = [...feed, ...page.items];
+      cursor = page.next_cursor;
+    } finally {
+      loading = false;
+    }
+  }
 
   const fmt = (d: string) =>
     new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
@@ -32,7 +58,7 @@
 <section class="feed">
   <p class="kicker section-label">Latest writing</p>
   <ul>
-    {#each posts as p}
+    {#each feed as p}
       <li>
         <a href="/posts/{p.slug}">
           <time>{fmt(p.published_at)}</time>
@@ -45,6 +71,11 @@
       </li>
     {/each}
   </ul>
+  {#if cursor}
+    <button class="load-more" onclick={loadMore} disabled={loading}>
+      {loading ? 'Loading…' : 'More posts'}
+    </button>
+  {/if}
 </section>
 
 <style>
@@ -101,6 +132,18 @@
   .feed .summary { color: var(--muted); font-size: 0.92rem; line-height: 1.5; }
   .feed .arrow { color: var(--muted); transition: transform 0.15s ease, color 0.15s ease; }
   .feed a:hover .arrow { color: var(--accent); transform: translateX(4px); }
+
+  .load-more {
+    display: block; width: 100%; margin-top: 1.4rem;
+    padding: 0.8rem; cursor: pointer;
+    font-family: var(--font-mono); font-size: 0.78rem;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--muted); background: var(--surface);
+    border: 1px solid var(--rule); border-radius: 10px;
+    transition: border-color 0.2s ease, color 0.2s ease;
+  }
+  .load-more:hover:enabled { border-color: color-mix(in srgb, var(--accent) 55%, var(--rule)); color: var(--accent); }
+  .load-more:disabled { cursor: default; opacity: 0.6; }
 
   @media (max-width: 34rem) {
     .feed a { grid-template-columns: 1fr auto; }

--- a/fymo/remote/__init__.py
+++ b/fymo/remote/__init__.py
@@ -3,8 +3,10 @@ from fymo.remote.errors import RemoteError, NotFound, Unauthorized, Forbidden, C
 from fymo.remote.identity import current_uid
 from fymo.remote.context import request_event
 from fymo.remote.decorators import remote
+from fymo.remote.pagination import encode_cursor, decode_cursor, paginate
 
 __all__ = [
     "RemoteError", "NotFound", "Unauthorized", "Forbidden", "Conflict",
     "current_uid", "request_event", "remote",
+    "encode_cursor", "decode_cursor", "paginate",
 ]

--- a/fymo/remote/adapters.py
+++ b/fymo/remote/adapters.py
@@ -238,12 +238,29 @@ def _coerce_value(value: Any, hint: Any):
 
 
 def validate_args(args: list, sig: inspect.Signature, hints: dict) -> list:
-    """Validate and coerce positional args against the function signature."""
+    """Validate and coerce positional args against the function signature.
+
+    An omitted argument uses the parameter's default. The generated JS
+    client always sends every positional slot, so a skipped trailing
+    argument arrives as devalue UNDEFINED rather than being absent; both
+    forms (UNDEFINED and a short args list) mean "not provided" here, which
+    matches what `undefined` means at the JS call site.
+    """
+    from fymo.remote.devalue import UNDEFINED
+
     params = list(sig.parameters.values())
-    if len(args) != len(params):
+    if len(args) > len(params):
         raise TypeError(f"expected {len(params)} args, got {len(args)}")
     out = []
-    for arg, param in zip(args, params):
+    for i, param in enumerate(params):
+        arg = args[i] if i < len(args) else UNDEFINED
+        if arg is UNDEFINED:
+            if param.default is inspect.Parameter.empty:
+                if i >= len(args):
+                    raise TypeError(f"expected {len(params)} args, got {len(args)}")
+                raise TypeError(f"missing required argument {param.name!r}")
+            out.append(param.default)
+            continue
         hint = hints.get(param.name, Any)
         out.append(_coerce_value(arg, hint))
     return out

--- a/fymo/remote/adapters.py
+++ b/fymo/remote/adapters.py
@@ -161,10 +161,38 @@ def _coerce_dict_key(key: Any, key_hint: Any):
     return _coerce_value(key, key_hint)
 
 
+def _reject_undefined(value: Any) -> None:
+    """devalue's UNDEFINED sentinel means "argument omitted" at a top-level
+    slot (validate_args handles that before coercion) and nothing anywhere
+    else. A JS call like fn([undefined]) parses to the raw sentinel nested
+    in a container; letting it through guarantees a downstream 500 (no user
+    code or DB driver can handle it), so every pass-through path scans for
+    it before returning the value unvalidated."""
+    from fymo.remote.devalue import UNDEFINED
+    if value is UNDEFINED:
+        raise TypeError("undefined is only valid as a whole omitted argument")
+    if isinstance(value, list):
+        for v in value:
+            _reject_undefined(v)
+    elif isinstance(value, dict):
+        for v in value.values():
+            _reject_undefined(v)
+
+
 def _coerce_value(value: Any, hint: Any):
     """Validate `value` against `hint`. Raises TypeError or ValidationError on mismatch."""
-    if hint is Any or hint is type(None):
+    from fymo.remote.devalue import UNDEFINED
+    if value is UNDEFINED:
+        raise TypeError("undefined is only valid as a whole omitted argument")
+    if hint is Any:
+        _reject_undefined(value)
         return value
+    if hint is type(None):
+        # The NoneType branch of a union must actually check for None;
+        # returning the value unchecked made `str | None` accept anything.
+        if value is not None:
+            raise TypeError(f"expected None, got {type(value).__name__}")
+        return None
     origin = get_origin(hint)
 
     if _is_pydantic_model(hint):
@@ -192,6 +220,7 @@ def _coerce_value(value: Any, hint: Any):
             raise TypeError(f"expected list, got {type(value).__name__}")
         args = get_args(hint)
         if not args:
+            _reject_undefined(value)
             return value
         # Fixed-length tuple: tuple[int, str] validates each position against
         # its own type. tuple[int, ...] (and list/set/frozenset) validate
@@ -208,6 +237,7 @@ def _coerce_value(value: Any, hint: Any):
             raise TypeError(f"expected dict, got {type(value).__name__}")
         args = get_args(hint)
         if not args:
+            _reject_undefined(value)
             return value
         key_hint, val_hint = args
         return {
@@ -234,6 +264,7 @@ def _coerce_value(value: Any, hint: Any):
         return _validate_structured(value, hint)
 
     # Unknown/unhandled annotation — no validator available, pass through.
+    _reject_undefined(value)
     return value
 
 

--- a/fymo/remote/pagination.py
+++ b/fymo/remote/pagination.py
@@ -1,0 +1,70 @@
+"""Cursor pagination helpers for remote functions that return lists.
+
+The convention: a paginated function takes `(cursor: str | None = None,
+limit: int = 20)` and returns `{"items": [...], "next_cursor": str | None}`.
+The cursor is opaque to the client: base64url-encoded JSON of the last-seen
+sort-key value(s). Fetch `limit + 1` rows ("WHERE sort_key < :last ORDER BY
+sort_key DESC LIMIT :limit + 1") and let `paginate` split off the extra row
+into `next_cursor`. These helpers know nothing about any database; the query
+stays in app code.
+"""
+import base64
+import json
+from typing import Any, Callable
+
+from fymo.remote.errors import RemoteError
+
+_CURSOR_MAX = 1024
+
+
+def _bad_cursor() -> RemoteError:
+    return RemoteError("invalid pagination cursor", status=400, code="bad_cursor")
+
+
+def encode_cursor(*values: Any) -> str:
+    """Encode one or more sort-key values into an opaque cursor string."""
+    raw = json.dumps(list(values), separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def decode_cursor(cursor: str, *, expect: "int | None" = None) -> list:
+    """Decode a cursor back into its sort-key values.
+
+    Any malformed input (wrong type, bad base64, non-JSON, not a non-empty
+    list, wrong arity when `expect` is given) raises a RemoteError that the
+    router turns into a 400 "bad_cursor" envelope instead of a 500.
+    """
+    if not isinstance(cursor, str) or not cursor or len(cursor) > _CURSOR_MAX:
+        raise _bad_cursor()
+    try:
+        pad = "=" * (-len(cursor) % 4)
+        values = json.loads(base64.urlsafe_b64decode(cursor + pad).decode("utf-8"))
+    except Exception:
+        raise _bad_cursor()
+    if not isinstance(values, list) or not values:
+        raise _bad_cursor()
+    if expect is not None and len(values) != expect:
+        raise _bad_cursor()
+    # Sort-key values are scalars; nested JSON in a cursor is garbage and
+    # must not leak through to whatever query binds the values.
+    if not all(v is None or isinstance(v, (str, int, float, bool)) for v in values):
+        raise _bad_cursor()
+    return values
+
+
+def paginate(rows: list, limit: int, *, key: Callable[[Any], Any]) -> dict:
+    """Split a fetch-one-extra row list into the page dict.
+
+    `rows` holds up to `limit + 1` rows. If the extra row is present there
+    is a next page: keep `limit` rows and encode the last kept row's sort
+    key(s) as `next_cursor`. `key` maps a row to its sort-key value, or a
+    tuple of values for composite sort keys.
+    """
+    items = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and items:
+        values = key(items[-1])
+        if not isinstance(values, tuple):
+            values = (values,)
+        next_cursor = encode_cursor(*values)
+    return {"items": items, "next_cursor": next_cursor}

--- a/fymo/remote/pagination.py
+++ b/fymo/remote/pagination.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 from fymo.remote.errors import RemoteError
 
 _CURSOR_MAX = 1024
+_JS_SAFE_INT = 2**53  # Number.MAX_SAFE_INTEGER + 1's magnitude boundary
 
 
 def _bad_cursor() -> RemoteError:
@@ -49,6 +50,13 @@ def decode_cursor(cursor: str, *, expect: "int | None" = None) -> list:
     # must not leak through to whatever query binds the values.
     if not all(v is None or isinstance(v, (str, int, float, bool)) for v in values):
         raise _bad_cursor()
+    # JSON ints are unbounded but every legitimate cursor value came from
+    # JS, so anything beyond Number.MAX_SAFE_INTEGER is tampering. Without
+    # this bound an oversized int passes here and 500s at the database
+    # bind instead (sqlite3 raises OverflowError past 64 bits).
+    if any(isinstance(v, int) and not isinstance(v, bool) and abs(v) > _JS_SAFE_INT
+           for v in values):
+        raise _bad_cursor()
     return values
 
 
@@ -59,7 +67,13 @@ def paginate(rows: list, limit: int, *, key: Callable[[Any], Any]) -> dict:
     is a next page: keep `limit` rows and encode the last kept row's sort
     key(s) as `next_cursor`. `key` maps a row to its sort-key value, or a
     tuple of values for composite sort keys.
+
+    `limit` must be positive: 0 silently ends pagination with rows left,
+    and a negative slice would emit a next_cursor pointing at the wrong
+    row, so both fail loudly as caller bugs.
     """
+    if limit < 1:
+        raise ValueError(f"paginate limit must be >= 1, got {limit}")
     items = rows[:limit]
     next_cursor = None
     if len(rows) > limit and items:

--- a/journal/journal_025.md
+++ b/journal/journal_025.md
@@ -1,0 +1,121 @@
+# Journal Entry 025: The List That Works Until It Doesn't
+
+**Date**: July 16, 2026
+**Focus**: A cursor pagination convention for remote functions, and the dispatch gap hiding under it
+**Status**: Shipped
+
+## The Path of Least Resistance
+
+Issue #53 is one of those problems that isn't a bug so much as a shape the
+framework quietly encourages. Nothing about the remote-function layer says
+anything about pagination, neither example app demonstrates it, and so the
+obvious way to write any listing function is what the blog's own
+`get_posts()` did: `SELECT everything ORDER BY published_at DESC`, return
+the lot. It works at ten rows, it works at a hundred, and there is no
+signal anywhere in dev that it stops working later. The fix isn't to police
+it. It's to make the paginated version copyable enough that it becomes the
+new path of least resistance.
+
+## Page[T] Doesn't Make It Out Alive
+
+The shape I wanted was the obvious one: a generic `Page[T]` TypedDict in
+the framework, `def list_posts(...) -> Page[PostSummary]`, one type to rule
+them all. So before writing anything I ran `Page[PostSummary]` through the
+codegen typemap to see what the client would get.
+
+`unknown`. Not an error, not a warning, just `unknown` and no interface
+emitted. A subscripted generic TypedDict isn't a `type`, so it falls past
+the TypedDict branch, past the dataclass branch, past everything, and lands
+in the fallback. Meanwhile a plain per-module TypedDict comes out as a real
+interface with every field intact. I could have taught the typemap about
+`Generic` aliases, but that's a rabbit hole with pydantic, forward refs and
+the stdlib fallback all wanting opinions, and the convention needs to be
+copyable today. So the convention is the boring version, and the docs say
+so out loud: declare `PostsPage` yourself, three lines, done. The framework
+ships the helpers, not the type.
+
+## The Blocker Nobody Ordered
+
+The signature I wanted was `list_posts(cursor: str | None = None,
+limit: int = 20)`. Call it with no arguments, get page one. Except when I
+traced what actually happens when the browser calls `list_posts()`: the
+generated client always sends every positional slot, so an omitted argument
+goes over the wire as devalue `undefined`, and the server's `validate_args`
+demanded an exact argument count and then choked on `UNDEFINED` where an
+`int` should be. A 422 for calling a function exactly as its signature
+invites you to.
+
+There was a second, sneakier version of the same problem: for
+`cursor: str | None`, the union validator tried the `None` branch, and the
+`None` branch passes anything through untouched. So `UNDEFINED` didn't fail
+validation there, it *arrived in the function* as a sentinel object that
+`cursor is None` doesn't catch. Nothing in the codebase had ever hit either
+case, because no existing remote function had a default parameter. The
+convention was going to be the first, so the convention had to come with
+the fix: an omitted or `undefined` argument now means "use the parameter's
+default," which is exactly what `undefined` means at the JS call site, and
+an `undefined` for a parameter with no default is a clean validation error.
+
+## Opaque Cursors, One Extra Row
+
+The helpers themselves (`fymo/remote/pagination.py`) stayed small on
+purpose. `encode_cursor(*values)` is base64url of a JSON list of the
+last-seen sort-key values. `decode_cursor` reverses it and treats anything
+malformed as a 400 `bad_cursor` through the existing `RemoteError`
+machinery: bad base64, non-JSON, an empty list, the wrong arity, and also
+nested JSON values, because a cursor that decodes to `[["a"],{}]` isn't a
+sort key and shouldn't get anywhere near a query binding where it would
+blow up as a driver error and surface as a 500. Cursors are client input.
+They will be tampered with, and tampering should cost the tamperer a 400,
+not me a stack trace.
+
+The query side is the fetch-one-extra idiom: ask for `limit + 1` rows, and
+if the extra one comes back you know there's a next page without a second
+`COUNT(*)` round trip. `paginate(rows, limit, key=...)` drops the extra
+row and encodes the last kept row's keys as `next_cursor`, or `None` when
+the extra row didn't show. The helpers never see a database. The SQL stays
+in app code where it belongs.
+
+One thing the blog example forced me to get right: `published_at` alone is
+not a cursor. Two posts can share a timestamp, and a cursor that can't
+name an exact position either skips a row or repeats one. So the example
+sorts by `(published_at, slug)` and uses SQLite's row-value comparison,
+`WHERE (published_at, slug) < (?, ?)`, and the integration test seeds two
+posts on the same date specifically to catch anyone (me, later) simplifying
+the tiebreak away.
+
+## Wiring It Into the Blog
+
+`get_posts()` stays, untouched, because tests depend on it and because the
+contrast is sort of the point. Next to it now lives `list_posts(cursor,
+limit) -> PostsPage`, and the home page uses it end to end: the controller
+SSRs the first page and threads `list_posts` itself into the template as a
+prop, the same marker-object trick the comments form already used, and the
+template grows a "More posts" button that feeds `next_cursor` back in until
+it comes back null and the button disappears.
+
+The e2e check was the satisfying part. Real build, real wsgiref socket,
+curl for the transport: three pages of posts including the tied-date pair
+in the right order, seven slugs total with no duplicates and no gaps, the
+final page answering `next_cursor: null`, an argless call landing on the
+defaults, and a garbage cursor bouncing off as a 400 `bad_cursor` instead
+of a 500. Then ten more rows straight into the SQLite file and a re-curl of
+`/` to watch the button actually render once the table outgrew the first
+page.
+
+## What I'd Watch For
+
+The defaults fix is the piece with reach beyond pagination. Every remote
+function can now have optional trailing parameters and be called the way
+its Python signature reads, which is strictly better, but it also means a
+hand-written client that sends *fewer* args than the signature has is no
+longer an automatic error when the missing ones have defaults. That's the
+correct trade, it mirrors how Python itself treats the call, but it's a
+behavior change in the dispatch path and it's the first thing I'd look at
+if some future optional-parameter function misbehaves.
+
+The other loose end is `Page[T]`. The typemap could learn generics someday,
+and if it does, the convention can graduate without breaking anyone,
+because a generic that emits the same `{ items, next_cursor }` interface is
+wire-identical to the hand-rolled TypedDict. Until then the docs promise
+nothing the codegen can't deliver.

--- a/tests/integration/test_blog_pagination.py
+++ b/tests/integration/test_blog_pagination.py
@@ -1,0 +1,116 @@
+"""End-to-end: the paginated list_posts remote function through real dispatch."""
+import base64
+import io
+import json
+import sys
+from pathlib import Path
+import pytest
+
+from fymo.remote import devalue
+
+
+def _b64url(s: str) -> str:
+    return base64.urlsafe_b64encode(s.encode("utf-8")).rstrip(b"=").decode("ascii")
+
+
+def _remote_call(app, hash_, fn_name, args):
+    body_payload = json.dumps({"payload": _b64url(devalue.stringify(args))}).encode()
+    responses = []
+    def sr(s, h): responses.append((s, h))
+    out = b"".join(app({
+        "REQUEST_METHOD": "POST",
+        "PATH_INFO": f"/_fymo/remote/{hash_}/{fn_name}",
+        "CONTENT_LENGTH": str(len(body_payload)),
+        "CONTENT_TYPE": "application/json",
+        "QUERY_STRING": "",
+        "HTTP_HOST": "x",
+        "HTTP_ORIGIN": "http://x",
+        "wsgi.url_scheme": "http",
+        "SERVER_NAME": "x", "SERVER_PORT": "0", "SERVER_PROTOCOL": "HTTP/1.1",
+        "REMOTE_ADDR": "127.0.0.1",
+        "wsgi.input": io.BytesIO(body_payload), "wsgi.errors": sys.stderr,
+    }, sr))
+    return responses[0], json.loads(out)
+
+
+@pytest.mark.usefixtures("node_available")
+def test_list_posts_pages_through_to_the_end(blog_app: Path):
+    for _k in list(sys.modules):
+        if _k == "app" or _k.startswith("app."):
+            del sys.modules[_k]
+
+    from fymo.build.pipeline import BuildPipeline
+    from tests.integration._seed_helpers import seed_test_post
+
+    # Five posts: three distinct dates plus two sharing one, so the
+    # (published_at, slug) tiebreak actually gets exercised.
+    seed_test_post("post-e", published_at="2026-01-05T00:00:00Z")
+    seed_test_post("post-d", published_at="2026-01-04T00:00:00Z")
+    seed_test_post("post-c2", published_at="2026-01-03T00:00:00Z")
+    seed_test_post("post-c1", published_at="2026-01-03T00:00:00Z")
+    seed_test_post("post-a", published_at="2026-01-01T00:00:00Z")
+
+    BuildPipeline(project_root=blog_app).build(dev=False)
+    manifest = json.loads((blog_app / "dist" / "manifest.json").read_text())
+    hash_ = manifest["remote_modules"]["posts"]["hash"]
+
+    from fymo import create_app
+    app = create_app(blog_app)
+    try:
+        # Page 1: no cursor.
+        (status, _), env = _remote_call(app, hash_, "list_posts", [None, 2])
+        assert status.startswith("200")
+        assert env["type"] == "result"
+        page1 = devalue.parse(env["result"])
+        assert [p["slug"] for p in page1["items"]] == ["post-e", "post-d"]
+        assert page1["next_cursor"]
+
+        # Page 2: same-date posts ordered by slug DESC.
+        (_, _), env = _remote_call(app, hash_, "list_posts", [page1["next_cursor"], 2])
+        page2 = devalue.parse(env["result"])
+        assert [p["slug"] for p in page2["items"]] == ["post-c2", "post-c1"]
+        assert page2["next_cursor"]
+
+        # Page 3: last row, next_cursor null.
+        (_, _), env = _remote_call(app, hash_, "list_posts", [page2["next_cursor"], 2])
+        page3 = devalue.parse(env["result"])
+        assert [p["slug"] for p in page3["items"]] == ["post-a"]
+        assert page3["next_cursor"] is None
+
+        # The generated client sends every positional slot; an argless call
+        # arrives as [undefined, undefined] and must use the defaults.
+        (_, _), env = _remote_call(
+            app, hash_, "list_posts", [devalue.UNDEFINED, devalue.UNDEFINED]
+        )
+        assert env["type"] == "result"
+        page = devalue.parse(env["result"])
+        assert len(page["items"]) == 5
+        assert page["next_cursor"] is None
+
+        # Garbage cursor fails cleanly, not with a 500.
+        (_, _), env = _remote_call(app, hash_, "list_posts", ["not a cursor", 2])
+        assert env["type"] == "error"
+        assert env["status"] == 400
+        assert env["error"] == "bad_cursor"
+    finally:
+        if app.sidecar:
+            app.sidecar.stop()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_list_posts_types_survive_codegen(blog_app: Path):
+    for _k in list(sys.modules):
+        if _k == "app" or _k.startswith("app."):
+            del sys.modules[_k]
+
+    from fymo.build.pipeline import BuildPipeline
+    BuildPipeline(project_root=blog_app).build(dev=False)
+
+    dts = (blog_app / "dist" / "client" / "_remote" / "posts.d.ts").read_text()
+    assert "export interface PostsPage {" in dts
+    assert "items: PostSummary[];" in dts
+    assert "next_cursor: string | null;" in dts
+    assert (
+        "export function list_posts(cursor?: string | null, limit?: number): "
+        "Promise<PostsPage>;" in dts
+    )

--- a/tests/remote/test_adapters.py
+++ b/tests/remote/test_adapters.py
@@ -119,3 +119,57 @@ def test_undefined_arg_without_default_rejected():
 
     with pytest.raises(TypeError, match="x"):
         validate_args([UNDEFINED], sig, hints)
+
+
+def test_none_hint_rejects_non_none_values():
+    """The NoneType branch of a union must actually check for None. It used
+    to return the value unchecked, so `str | None` accepted absolutely
+    anything (an int, a dict) via its None branch."""
+    def fn(cursor: str | None = None) -> str | None: return cursor
+    sig = inspect.signature(fn)
+    hints = _hints_for(fn)
+
+    with pytest.raises(TypeError):
+        validate_args([42], sig, hints)
+    with pytest.raises(TypeError):
+        validate_args([{"a": 1}], sig, hints)
+    assert validate_args([None], sig, hints) == [None]
+    assert validate_args(["abc"], sig, hints) == ["abc"]
+
+
+def test_nested_undefined_is_rejected_not_leaked():
+    """devalue UNDEFINED means "argument omitted" at a top-level slot and
+    nothing anywhere else. A JS call like fn([undefined]) used to deliver
+    the raw sentinel into user code, where the first DB bind 500s."""
+    from fymo.remote.devalue import UNDEFINED
+
+    def fn(xs: list[str | None]) -> int: return len(xs)
+    sig = inspect.signature(fn)
+    hints = _hints_for(fn)
+    with pytest.raises(TypeError):
+        validate_args([[UNDEFINED]], sig, hints)
+
+    def fn2(d: dict[str, str | None]) -> int: return len(d)
+    sig2 = inspect.signature(fn2)
+    hints2 = _hints_for(fn2)
+    with pytest.raises(TypeError):
+        validate_args([{"k": UNDEFINED}], sig2, hints2)
+
+
+def test_nested_undefined_rejected_in_unparameterized_hints():
+    """Bare `list`/`dict` and Any hints pass values through without element
+    validation, which must still not include the UNDEFINED sentinel."""
+    from fymo.remote.devalue import UNDEFINED
+    from typing import Any
+
+    def fn(xs: list) -> int: return len(xs)
+    sig = inspect.signature(fn)
+    hints = _hints_for(fn)
+    with pytest.raises(TypeError):
+        validate_args([[UNDEFINED]], sig, hints)
+
+    def fn2(x: Any) -> int: return 0
+    sig2 = inspect.signature(fn2)
+    hints2 = _hints_for(fn2)
+    with pytest.raises(TypeError):
+        validate_args([[{"deep": [UNDEFINED]}]], sig2, hints2)

--- a/tests/remote/test_adapters.py
+++ b/tests/remote/test_adapters.py
@@ -86,3 +86,36 @@ def test_arg_count_mismatch():
 
     with pytest.raises(TypeError, match="expected 2"):
         validate_args([1], sig, hints)
+
+
+def test_undefined_args_fill_param_defaults():
+    from fymo.remote.devalue import UNDEFINED
+
+    def fn(cursor: str | None = None, limit: int = 20) -> int: return limit
+    sig = inspect.signature(fn)
+    hints = _hints_for(fn)
+
+    # The generated JS client always sends every positional slot, so a call
+    # like list_posts() arrives as [undefined, undefined].
+    assert validate_args([UNDEFINED, UNDEFINED], sig, hints) == [None, 20]
+    assert validate_args(["abc", UNDEFINED], sig, hints) == ["abc", 20]
+
+
+def test_missing_trailing_args_fill_param_defaults():
+    def fn(cursor: str | None = None, limit: int = 20) -> int: return limit
+    sig = inspect.signature(fn)
+    hints = _hints_for(fn)
+
+    assert validate_args([], sig, hints) == [None, 20]
+    assert validate_args(["abc"], sig, hints) == ["abc", 20]
+
+
+def test_undefined_arg_without_default_rejected():
+    from fymo.remote.devalue import UNDEFINED
+
+    def fn(x: int) -> int: return x
+    sig = inspect.signature(fn)
+    hints = _hints_for(fn)
+
+    with pytest.raises(TypeError, match="x"):
+        validate_args([UNDEFINED], sig, hints)

--- a/tests/remote/test_pagination.py
+++ b/tests/remote/test_pagination.py
@@ -1,0 +1,88 @@
+"""Cursor pagination helpers: opaque cursor round-trip + fetch-one-extra split."""
+import pytest
+from fymo.remote.errors import RemoteError
+from fymo.remote.pagination import encode_cursor, decode_cursor, paginate
+
+
+def test_cursor_round_trip_single_value():
+    cur = encode_cursor("2026-01-01T00:00:00Z")
+    assert decode_cursor(cur) == ["2026-01-01T00:00:00Z"]
+
+
+def test_cursor_round_trip_multiple_values():
+    cur = encode_cursor("2026-01-01T00:00:00Z", "welcome-to-fymo")
+    assert decode_cursor(cur) == ["2026-01-01T00:00:00Z", "welcome-to-fymo"]
+
+
+def test_cursor_round_trip_numeric_value():
+    assert decode_cursor(encode_cursor(42)) == [42]
+
+
+def test_cursor_is_urlsafe_and_unpadded():
+    cur = encode_cursor("value with spaces & specials?/+~")
+    assert "=" not in cur and "+" not in cur and "/" not in cur
+
+
+def test_cursor_expect_arity():
+    cur = encode_cursor("a", "b")
+    assert decode_cursor(cur, expect=2) == ["a", "b"]
+    with pytest.raises(RemoteError) as exc:
+        decode_cursor(cur, expect=1)
+    assert exc.value.status == 400
+    assert exc.value.code == "bad_cursor"
+
+
+@pytest.mark.parametrize("garbage", [
+    "",
+    "not base64 at all!!!",
+    "aGVsbG8",        # base64 of "hello", not JSON
+    "e30",            # base64 of "{}", JSON but not a list
+    "W10",            # base64 of "[]", empty list
+    "W1siYSJdLHt9XQ", # base64 of '[["a"],{}]', nested values are not sort keys
+    12345,            # not even a string
+    None,
+])
+def test_garbage_cursor_raises_remote_error(garbage):
+    with pytest.raises(RemoteError) as exc:
+        decode_cursor(garbage)
+    assert exc.value.status == 400
+    assert exc.value.code == "bad_cursor"
+
+
+def _rows(n):
+    return [{"id": i, "ts": f"2026-01-{i:02d}"} for i in range(n, 0, -1)]
+
+
+def test_paginate_full_page_with_extra_row():
+    rows = _rows(4)  # fetched with limit 3 + 1
+    page = paginate(rows, 3, key=lambda r: r["ts"])
+    assert page["items"] == rows[:3]
+    assert page["next_cursor"] == encode_cursor(rows[2]["ts"])
+
+
+def test_paginate_last_page_exact():
+    rows = _rows(3)  # limit 3, no extra row came back
+    page = paginate(rows, 3, key=lambda r: r["ts"])
+    assert page["items"] == rows
+    assert page["next_cursor"] is None
+
+
+def test_paginate_short_page():
+    rows = _rows(2)
+    page = paginate(rows, 3, key=lambda r: r["ts"])
+    assert page["items"] == rows
+    assert page["next_cursor"] is None
+
+
+def test_paginate_empty():
+    page = paginate([], 3, key=lambda r: r["ts"])
+    assert page["items"] == []
+    assert page["next_cursor"] is None
+
+
+def test_paginate_composite_key():
+    rows = _rows(4)
+    page = paginate(rows, 3, key=lambda r: (r["ts"], r["id"]))
+    last = rows[2]
+    assert page["next_cursor"] == encode_cursor(last["ts"], last["id"])
+    assert decode_cursor(page["next_cursor"], expect=2) == [last["ts"], last["id"]]

--- a/tests/remote/test_pagination.py
+++ b/tests/remote/test_pagination.py
@@ -86,3 +86,31 @@ def test_paginate_composite_key():
     last = rows[2]
     assert page["next_cursor"] == encode_cursor(last["ts"], last["id"])
     assert decode_cursor(page["next_cursor"], expect=2) == [last["ts"], last["id"]]
+
+
+def test_cursor_int_outside_js_safe_range_is_bad_cursor():
+    """A tampered cursor holding an oversized int must be a clean 400, not
+    an OverflowError 500 at the database bind (sqlite3 rejects ints beyond
+    64 bits; JSON ints are unbounded). Legitimate cursors only ever hold
+    values that came from JS, so the JS safe-integer range is the bound."""
+    for huge in (10**300, -(10**300), 2**53 + 1, -(2**53) - 1):
+        with pytest.raises(RemoteError) as e:
+            decode_cursor(encode_cursor(huge, "x"))
+        assert e.value.code == "bad_cursor"
+
+
+def test_cursor_int_at_js_safe_boundary_round_trips():
+    assert decode_cursor(encode_cursor(2**53, "x")) == [2**53, "x"]
+    assert decode_cursor(encode_cursor(-(2**53), "x")) == [-(2**53), "x"]
+
+
+def test_paginate_rejects_nonpositive_limit():
+    """limit=0 silently ends pagination and a negative limit produces a
+    bogus next_cursor pointing at the wrong row; both are caller bugs that
+    must fail loudly (blog_app clamps before calling, but the helper is
+    public API)."""
+    rows = [1, 2, 3]
+    with pytest.raises(ValueError):
+        paginate(rows, 0, key=lambda r: r)
+    with pytest.raises(ValueError):
+        paginate(rows, -1, key=lambda r: r)

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.11.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Nothing nudged remote functions toward pagination and no example demonstrated it, so the path of least resistance was unbounded list_x(). This adds the documented, copyable pattern end to end.

- `fymo/remote/pagination.py` (exported from fymo.remote): `encode_cursor`/`decode_cursor` (opaque base64url cursors; any garbage, bad base64, non-JSON, wrong arity, nested values, ints beyond the JS safe range, raises a clean 400 bad_cursor envelope, never a 500) and `paginate(rows, limit, key=...)` for the fetch-one-extra idiom
- Convention shape: `list_x(cursor: str | None = None, limit: int = 20)` returning `{"items": [...], "next_cursor": str | None}` as a plain per-module TypedDict (verified empirically that a generic Page[T] does not survive codegen; the docs say so)
- Enabling fix in `fymo/remote/adapters.py`: the generated client sends every positional slot, so omitted args arrive as devalue UNDEFINED, which previously either 422ed or leaked the raw sentinel into user code through Optional params. Omitted/UNDEFINED trailing args now fill from parameter defaults; nested UNDEFINED (fn([undefined])) is rejected on every path; the NoneType union branch now actually validates (it used to accept anything)
- blog_app demonstrates it end to end: `list_posts` with a composite (published_at, slug) cursor, SSR of page one, a "More posts" button feeding next_cursor back until null; existing get_posts untouched
- docs/conventions.md: full section (signature, wire shape, cursor-vs-offset, fetch-one-extra, unique-sort-key warning, copy-paste example)

Closes #53

## Test plan

- [x] TDD: 29 new tests (cursor round-trip/garbage/bounds, paginate edges incl. limit < 1, adapter default-filling and UNDEFINED rejection, codegen .d.ts assertion against real build output, two integration tests through real build + dispatch)
- [x] Full suite 926 passed / 10 skipped
- [x] Independent review with hostile-input repros; all three findings (nested UNDEFINED leak, unchecked NoneType branch, oversized-int cursor 500) fixed with failing tests first
- [x] Live: real server, curled through 3 pages including a tied-timestamp pair, no dupes/gaps, null cursor at the end; garbage cursor 400s; oversized-int cursor 400s; crafted nested-undefined payload 422s