### PR TITLE
fymo.testing: session and provider bootstrapping for app test suites

### DIFF
--- a/examples/blog_app/tests/conftest.py
+++ b/examples/blog_app/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Test setup for blog_app.
+
+Auth and request-scope bootstrapping comes from fymo.testing (signed_in /
+acting_as), so the only fixture the app owns is its own database: an
+isolated SQLite file per test instead of app/data/blog.db.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    from app.data import db as db_module
+
+    test_db = db_module.DB(tmp_path / "blog.db")
+    monkeypatch.setattr(db_module, "_db", test_db)
+    return test_db

--- a/examples/blog_app/tests/test_comments.py
+++ b/examples/blog_app/tests/test_comments.py
@@ -1,0 +1,40 @@
+"""Comment authorship comes from the authenticated session, never from
+client input. fymo.testing simulates the sessions: signed_in() for the
+first caller, acting_as() to switch to a second user mid-test."""
+from fymo.testing import acting_as, make_user, signed_in
+
+
+def _seed_post(db, slug="hello-world"):
+    db.execute(
+        "INSERT INTO posts (slug, title, summary, content_html, tags, published_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [slug, "Hello World", "intro post", "<p>hi</p>", "intro", "2026-01-01T00:00:00Z"],
+    )
+    return slug
+
+
+def test_authenticated_comment_is_attributed_to_the_session_user(db):
+    from app.remote.posts import NewComment, create_comment
+
+    slug = _seed_post(db)
+    alice = make_user(email="alice@example.com")
+    with signed_in(alice):
+        comment = create_comment(slug, input=NewComment(body="first!"))
+    assert comment["name"] == "alice"
+
+
+def test_second_user_cannot_comment_as_the_first(db):
+    from app.remote.posts import NewComment, create_comment, get_comments
+
+    slug = _seed_post(db)
+    alice = make_user(email="alice@example.com")
+    bob = make_user(email="bob@example.com")
+
+    with signed_in(alice):
+        create_comment(slug, input=NewComment(body="alice's take"))
+        with acting_as(bob):
+            bobs_comment = create_comment(slug, input=NewComment(body="bob's reply"))
+        assert bobs_comment["name"] == "bob"
+
+        comments = get_comments(slug)
+    assert {c["name"] for c in comments} == {"alice", "bob"}

--- a/examples/blog_app/tests/test_comments.py
+++ b/examples/blog_app/tests/test_comments.py
@@ -38,3 +38,22 @@ def test_second_user_cannot_comment_as_the_first(db):
 
         comments = get_comments(slug)
     assert {c["name"] for c in comments} == {"alice", "bob"}
+
+    rows = db.fetchall("SELECT name, uid FROM comments ORDER BY name")
+    uids = {row["name"]: row["uid"] for row in rows}
+    assert uids["alice"] != uids["bob"]
+
+
+def test_users_have_isolated_reactions(db):
+    from app.remote.posts import toggle_reaction
+
+    slug = _seed_post(db)
+    alice = make_user(email="alice@example.com")
+    bob = make_user(email="bob@example.com")
+
+    with signed_in(alice):
+        counts = toggle_reaction(slug, "clap")
+        assert counts["clap"] == 1
+        with acting_as(bob):
+            counts = toggle_reaction(slug, "clap")
+        assert counts["clap"] == 2

--- a/fymo/testing.py
+++ b/fymo/testing.py
@@ -44,6 +44,12 @@ fymo.remote.context); the resolver it registers reads the acting user from
 a contextvar, which is what lets `acting_as` swap identities mid-block and
 restore on exit, however deeply nested.
 
+The uid rule: the anonymous-identity uid (current_uid()) always follows
+the acting user, derived as "u_test{user.id}", so different users never
+share uid-keyed data (reactions, anonymous attribution) any more than two
+real browsers would. Both signed_in and acting_as take uid= when a test
+needs an exact value.
+
 Importable without pytest. When pytest is installed, the `signed_in_user`
 fixture at the bottom is also available; re-export it from a conftest.py to
 use it:
@@ -104,6 +110,10 @@ _acting_user: ContextVar[Optional[User]] = ContextVar(
 )
 
 
+def _uid_for(user: User) -> str:
+    return f"u_test{user.id}"
+
+
 def _testing_resolver(event: dict) -> Optional[User]:
     return _acting_user.get()
 
@@ -112,7 +122,7 @@ def _testing_resolver(event: dict) -> Optional[User]:
 def signed_in(
     user: Optional[User] = None,
     *,
-    uid: str = "u_testing",
+    uid: Optional[str] = None,
     environ: Optional[dict] = None,
 ) -> Iterator[User]:
     """Simulate an authenticated caller for the duration of the block.
@@ -123,9 +133,12 @@ def signed_in(
     current_uid(), and request_event() all work. Yields the user; pass one
     from make_user() to customize it, or omit it for a default.
 
-    `uid` and `environ` feed the request scope: `uid` is what current_uid()
-    returns, `environ` is a WSGI-shaped dict for tests that need specific
-    headers or cookies visible to resolvers.
+    The uid rule: identity is user plus uid, and the uid follows the user.
+    It defaults to "u_test{user.id}" so two different users never share a
+    uid (uid-keyed app data, like reaction rows, stays isolated per user
+    the way it would be for real browsers); pass `uid` explicitly when a
+    test cares about the exact value. `environ` is a WSGI-shaped dict for
+    tests that need specific headers or cookies visible to resolvers.
 
     On exit the resolver is removed and the scope closed, leaving the
     resolver registry exactly as it was found.
@@ -135,6 +148,8 @@ def signed_in(
 
     if user is None:
         user = make_user()
+    if uid is None:
+        uid = _uid_for(user)
     auth_context.register_session_resolver(_testing_resolver)
     token = _acting_user.set(user)
     try:
@@ -149,22 +164,35 @@ def signed_in(
 
 
 @contextmanager
-def acting_as(user: User) -> Iterator[User]:
+def acting_as(user: User, *, uid: Optional[str] = None) -> Iterator[User]:
     """Swap the resolved identity to `user` for the duration of the block.
 
+    Swaps the FULL identity: current_user() resolves to `user`, and the
+    request scope's uid (what current_uid() returns) follows the same rule
+    as signed_in, defaulting to "u_test{user.id}" unless `uid` is given.
+    Swapping only the user would let uid-keyed app data leak between the
+    two identities, a false pass for exactly the authorization tests this
+    API exists for.
+
     Must be entered inside a signed_in() block; the previously signed-in
-    user is restored on exit, even when the block raises. Nests freely:
-    each exit restores the identity of the enclosing block.
+    user and uid are restored on exit, even when the block raises. Nests
+    freely: each exit restores the identity of the enclosing block.
     """
+    from fymo.remote.context import _current_event
+
     if _acting_user.get() is None:
         raise RuntimeError(
             "acting_as() requires an enclosing signed_in() block; "
             "wrap the test body in `with signed_in(...):` first"
         )
+    event = _current_event.get()
+    prior_uid = event["uid"]
     token = _acting_user.set(user)
+    event["uid"] = uid if uid is not None else _uid_for(user)
     try:
         yield user
     finally:
+        event["uid"] = prior_uid
         _acting_user.reset(token)
 
 

--- a/fymo/testing.py
+++ b/fymo/testing.py
@@ -1,0 +1,252 @@
+"""Test bootstrapping for apps built on fymo.
+
+A test suite never constructs a FymoApp, so the process-wide seams FymoApp
+wires up at startup (the auth session-resolver chain, the storage / jobs /
+broadcasts provider singletons) are all missing in a bare test process.
+This module stands them up for the duration of a block and restores every
+registry exactly as it found it, so tests never leak state into each other.
+
+Simulate a signed-in caller for a remote function called directly
+(bypassing the WSGI layer):
+
+    from fymo.testing import signed_in
+    from app.remote.posts import create_comment
+
+    def test_comment_is_attributed():
+        with signed_in() as user:
+            comment = create_comment("hello-world", input=NewComment(body="hi"))
+            assert comment["name"] == user.email.split("@")[0]
+
+Prove one user cannot see or touch another user's data:
+
+    from fymo.testing import acting_as, make_user, signed_in
+
+    def test_other_users_drafts_are_hidden():
+        alice = make_user(email="alice@example.com")
+        bob = make_user(email="bob@example.com")
+        with signed_in(alice):
+            draft = create_draft(title="secret")
+            with acting_as(bob):
+                assert draft["id"] not in [d["id"] for d in get_my_drafts()]
+
+Get get_storage_provider() (plus jobs and broadcasts) working in a test
+process, reading the project's own fymo.yml the way FymoApp.__init__ does:
+
+    from fymo.testing import init_providers
+
+    def test_upload(tmp_path):
+        with init_providers(project_root):
+            get_storage_provider().write("avatars/1.png", data)
+
+`signed_in` wraps the same register_session_resolver + request_scope
+mechanism fymo's router uses for real requests (see fymo.auth.context and
+fymo.remote.context); the resolver it registers reads the acting user from
+a contextvar, which is what lets `acting_as` swap identities mid-block and
+restore on exit, however deeply nested.
+
+Importable without pytest. When pytest is installed, the `signed_in_user`
+fixture at the bottom is also available; re-export it from a conftest.py to
+use it:
+
+    from fymo.testing import signed_in_user  # noqa: F401
+"""
+from __future__ import annotations
+
+import itertools
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator, Optional
+
+from fymo.auth.store import User
+
+__all__ = [
+    "make_user",
+    "signed_in",
+    "acting_as",
+    "init_providers",
+]
+
+
+# --------------- fake users ---------------
+
+_next_user_id = itertools.count(1)
+
+
+def make_user(email: str = "test@example.com", **overrides) -> User:
+    """Build a real fymo User with sensible test defaults.
+
+    Every field of fymo.auth.store.User can be overridden by keyword; ids
+    auto-increment per process so two default users never collide.
+    """
+    fields = {
+        "id": next(_next_user_id),
+        "email": email,
+        "password_hash": None,
+        "email_verified": True,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "fymo_uid": None,
+        "session_epoch": 1,
+    }
+    fields.update(overrides)
+    return User(**fields)
+
+
+# --------------- signed-in sessions ---------------
+
+# The user current_user() should resolve to right now. None means no
+# signed_in block is active. A contextvar (not a plain global) so the
+# swap-and-restore semantics of acting_as hold under threads and nesting.
+_acting_user: ContextVar[Optional[User]] = ContextVar(
+    "fymo_testing_acting_user", default=None
+)
+
+
+def _testing_resolver(event: dict) -> Optional[User]:
+    return _acting_user.get()
+
+
+@contextmanager
+def signed_in(
+    user: Optional[User] = None,
+    *,
+    uid: str = "u_testing",
+    environ: Optional[dict] = None,
+) -> Iterator[User]:
+    """Simulate an authenticated caller for the duration of the block.
+
+    Registers a session resolver (the exact mechanism providers use, see
+    fymo.auth.context.register_session_resolver) that resolves to `user`,
+    and opens a remote-function request scope so current_user(),
+    current_uid(), and request_event() all work. Yields the user; pass one
+    from make_user() to customize it, or omit it for a default.
+
+    `uid` and `environ` feed the request scope: `uid` is what current_uid()
+    returns, `environ` is a WSGI-shaped dict for tests that need specific
+    headers or cookies visible to resolvers.
+
+    On exit the resolver is removed and the scope closed, leaving the
+    resolver registry exactly as it was found.
+    """
+    from fymo.auth import context as auth_context
+    from fymo.remote.context import request_scope
+
+    if user is None:
+        user = make_user()
+    auth_context.register_session_resolver(_testing_resolver)
+    token = _acting_user.set(user)
+    try:
+        with request_scope(uid=uid, environ=dict(environ or {})):
+            yield user
+    finally:
+        _acting_user.reset(token)
+        try:
+            auth_context._session_resolvers.remove(_testing_resolver)
+        except ValueError:
+            pass  # reset_session_resolvers() already dropped it mid-block
+
+
+@contextmanager
+def acting_as(user: User) -> Iterator[User]:
+    """Swap the resolved identity to `user` for the duration of the block.
+
+    Must be entered inside a signed_in() block; the previously signed-in
+    user is restored on exit, even when the block raises. Nests freely:
+    each exit restores the identity of the enclosing block.
+    """
+    if _acting_user.get() is None:
+        raise RuntimeError(
+            "acting_as() requires an enclosing signed_in() block; "
+            "wrap the test body in `with signed_in(...):` first"
+        )
+    token = _acting_user.set(user)
+    try:
+        yield user
+    finally:
+        _acting_user.reset(token)
+
+
+# --------------- provider bootstrap ---------------
+
+
+@contextmanager
+def init_providers(project_root: Path) -> Iterator[SimpleNamespace]:
+    """Initialize storage, jobs, and broadcasts providers from the
+    project's fymo.yml, mirroring what FymoApp.__init__ does at startup.
+
+    Storage is initialized only when fymo.yml has a `storage:` section
+    (there is no default provider, matching FymoApp); jobs and broadcasts
+    are always initialized, with the same defaults FymoApp uses. Yields a
+    namespace with the built providers (`.storage` is None when storage is
+    unconfigured); app code reaches them the normal way, via
+    get_storage_provider() / get_job_provider() / publish().
+
+    On exit every provider singleton is restored to exactly what it was
+    before the block, installed or not, so back-to-back tests can't leak
+    providers into each other.
+
+    Raises FileNotFoundError when project_root has no fymo.yml: a test
+    pointing at the wrong directory should fail loudly, not run against an
+    empty config.
+    """
+    import fymo.broadcast as broadcast_mod
+    import fymo.jobs as jobs_mod
+    import fymo.storage as storage_mod
+    from fymo.core.config import ConfigManager
+
+    project_root = Path(project_root)
+    if not (project_root / "fymo.yml").is_file():
+        raise FileNotFoundError(
+            f"no fymo.yml found in {project_root}; init_providers() takes "
+            "the project root directory, the same one FymoApp would run from"
+        )
+
+    config_manager = ConfigManager(project_root)
+
+    prior_storage = storage_mod._provider
+    prior_jobs = jobs_mod._job_provider
+    prior_broadcast_provider = broadcast_mod._provider
+    prior_broadcast_channels = broadcast_mod._channels
+
+    try:
+        storage_config = config_manager.get_storage_config()
+        storage = None
+        if storage_config is not None:
+            storage = storage_mod.init_storage_provider(project_root, storage_config)
+        jobs = jobs_mod.init_job_provider(
+            project_root, config_manager.get_jobs_config().get("provider")
+        )
+        broadcasts = broadcast_mod.init_broadcasts(
+            project_root, config_manager.get_broadcasts_config().get("provider")
+        )
+        yield SimpleNamespace(storage=storage, jobs=jobs, broadcasts=broadcasts)
+    finally:
+        storage_mod.set_storage_provider(prior_storage)
+        jobs_mod.set_job_provider(prior_jobs)
+        with broadcast_mod._lock:
+            broadcast_mod._provider = prior_broadcast_provider
+            broadcast_mod._channels = prior_broadcast_channels
+
+
+# --------------- optional pytest fixtures ---------------
+#
+# fymo does not depend on pytest at runtime, so the fixtures only exist
+# when pytest is importable. Everything above stays plain context managers
+# usable from any test runner.
+
+try:
+    import pytest as _pytest
+except ImportError:  # pragma: no cover
+    _pytest = None
+
+if _pytest is not None:
+    __all__.append("signed_in_user")
+
+    @_pytest.fixture
+    def signed_in_user() -> Iterator[User]:
+        """A default signed-in user for the whole test. Re-export from your
+        conftest.py: `from fymo.testing import signed_in_user  # noqa: F401`"""
+        with signed_in() as user:
+            yield user

--- a/journal/journal_024.md
+++ b/journal/journal_024.md
@@ -71,9 +71,35 @@ module under a blocked pytest import, not by trusting my reading of it.
 blog_app got the consumer-side proof: its first tests, and the only
 fixture the app itself owns is its database. Alice comments, bob comments
 through acting_as, and the assertion is that authorship follows the
-session, never the client. Full suite green, 929 tests up from 907, and the
-ten skips among them are the same Postgres-gated provider tests that skip
-everywhere without TEST_DATABASE_URL.
+session, never the client. Full suite green, and the only skips are the
+same Postgres-gated provider tests that skip everywhere without
+TEST_DATABASE_URL. (Final counts are in the postscript below; the tally I
+first wrote here went stale within a day.)
+
+## Postscript: The uid That Rode Along
+
+Caught before merge, and I'm glad it was: acting_as swapped the user and
+nothing else. current_user() flipped to bob, but the uid in the request
+scope, set once by signed_in, rode along unchanged, so both identities
+were the same anonymous caller the whole time. blog_app's own reactions
+table is what made the miss concrete instead of theoretical. Reactions
+are keyed purely by uid, so signed_in(alice) plus acting_as(bob) plus
+toggle_reaction had bob toggling alice's clap OFF. The cruel part is the
+shape of the failure: an isolation test written in good faith over that
+API would go green for exactly the wrong reason, and a green isolation
+test that lies is worse than no test at all.
+
+The fix was settling a rule rather than patching the symptom: identity
+is user plus uid, and the uid follows the user, derived as
+u_test{user.id} for both signed_in and acting_as, with an explicit uid=
+escape hatch when a test cares about the exact value. acting_as
+snapshots the event's uid and restores it in a finally, so nesting and
+exception exits unwind level by level, and signed_in stopped handing
+every block the same shared constant while I was at it. The regression
+tests live where the miss lived: blog_app now asserts alice's and bob's
+comment rows carry different uids, and a reactions test insists bob's
+clap takes the count to two instead of erasing alice's. Full suite now
+stands at 938 tests, 928 passing, same ten Postgres-gated skips.
 
 ---
 

--- a/journal/journal_024.md
+++ b/journal/journal_024.md
@@ -1,0 +1,80 @@
+# Journal Entry 024: The Conftest Everyone Kept Rewriting
+
+**Date**: July 16, 2026
+**Focus**: fymo.testing, so apps stop spelunking in fymo's own test suite
+**Status**: Shipped
+
+## The Complaint
+
+Issue #48 said it plainly: every app built on fymo with real auth and real
+storage ends up re-deriving the same handful of conftest lines, and the
+only place to learn the correct pattern is fymo's internal tests, which
+were never meant to be documentation. Simulating a signed-in caller,
+simulating a second different caller to prove user B can't touch user A's
+data, and getting get_storage_provider() to work at all in a process that
+never constructs a FymoApp. Three things, none hard, all undiscoverable.
+
+## The Assumption I Walked In With
+
+I started by rereading tests/auth/test_resolvers.py, expecting to package
+up everything its fixture does: install a secret, build a SqliteUserStore,
+mint a session token, hand it in as a cookie. That was the wrong shape,
+and the resolver chain itself is what told me so. current_user() walks the
+built-in cookie resolver first, and with no fymo_session cookie present
+that resolver returns None before it ever touches the user store. So a
+fake session needs no store, no secret, no token at all. Register one
+resolver that returns your User, open a request scope, done. The utility
+became a thin wrapper around register_session_resolver plus request_scope,
+the exact mechanism real providers use, rather than a parallel
+implementation that could drift from it.
+
+That collapse made the second utility nearly free. The resolver doesn't
+close over a user, it reads one from a contextvar. signed_in() sets it,
+acting_as() swaps it and restores it on exit through the contextvar token,
+and nesting to any depth falls out of that without any bookkeeping I had
+to write. Proving B can't act as A is now two lines in the middle of a
+test instead of a second hand-rolled fixture.
+
+## Cleanup Is the Product
+
+The part I went back and forth on was teardown. The tempting version of
+signed_in's exit path is reset_session_resolvers(), one call, registry
+empty. But a test may have registered its own provider resolver before
+entering the block, and nuking the whole chain would eat it. So the block
+removes exactly the one resolver it registered and nothing else, and
+there's a test pinning that: pre-register a sentinel, run a signed_in
+block, assert the registry holds exactly the sentinel afterward.
+
+Same posture for init_providers. It mirrors FymoApp.__init__'s order,
+storage only when fymo.yml configures it, jobs and broadcasts always with
+the same defaults, but on exit it restores the previous provider
+singletons rather than resetting them to None. A test that had already
+installed something deserves to get that something back, not a blank
+slate. The back-to-back test takes a full snapshot of every registry,
+runs two utility blocks in sequence, and asserts the snapshot is
+byte-identical after. Journal 021's leak is why that test exists.
+
+One deliberate difference from FymoApp: a missing fymo.yml raises
+FileNotFoundError instead of quietly proceeding with an empty config the
+way ConfigManager tolerates. A test pointed at the wrong directory should
+fail at the with statement, not three asserts later with a confusing
+"storage is not initialized".
+
+## Keeping pytest Optional
+
+fymo doesn't depend on pytest at runtime, and the testing module had to
+respect that. Everything is a plain context manager, importable anywhere;
+the one pytest fixture sits behind a try-import at the bottom of the file
+and simply doesn't exist when pytest doesn't. Verified by importing the
+module under a blocked pytest import, not by trusting my reading of it.
+
+blog_app got the consumer-side proof: its first tests, and the only
+fixture the app itself owns is its database. Alice comments, bob comments
+through acting_as, and the assertion is that authorship follows the
+session, never the client. Full suite green, 929 tests up from 907, and the
+ten skips among them are the same Postgres-gated provider tests that skip
+everywhere without TEST_DATABASE_URL.
+
+---
+
+*End of Journal Entry 024*

--- a/tests/testing/test_cleanup.py
+++ b/tests/testing/test_cleanup.py
@@ -1,0 +1,57 @@
+"""The utilities' whole point is cleanup: global registries must be exactly
+as found after any combination of fymo.testing blocks."""
+from pathlib import Path
+
+import pytest
+
+import fymo.broadcast as broadcast_mod
+import fymo.jobs as jobs_mod
+import fymo.storage as storage_mod
+from fymo.auth import context as auth_context
+from fymo.auth.context import current_user
+from fymo.remote.context import _current_event
+from fymo.testing import acting_as, init_providers, make_user, signed_in
+
+
+def _snapshot():
+    return {
+        "resolvers": list(auth_context._session_resolvers),
+        "storage": storage_mod._provider,
+        "jobs": jobs_mod._job_provider,
+        "broadcast_provider": broadcast_mod._provider,
+        "broadcast_channels": broadcast_mod._channels,
+        "event": _current_event.get(),
+    }
+
+
+def test_two_utilities_back_to_back_leave_registries_as_found(tmp_path: Path):
+    (tmp_path / "fymo.yml").write_text("name: t\nstorage: {provider: local}\n")
+    before = _snapshot()
+
+    with signed_in(make_user(email="one@example.com")) as one:
+        assert current_user() is one
+
+    with init_providers(tmp_path):
+        storage_mod.get_storage_provider()
+
+    assert _snapshot() == before
+
+
+def test_combined_usage_then_clean(tmp_path: Path):
+    (tmp_path / "fymo.yml").write_text("name: t\nstorage: {provider: local}\n")
+    before = _snapshot()
+
+    alice = make_user(email="alice@example.com")
+    bob = make_user(email="bob@example.com")
+    with init_providers(tmp_path):
+        with signed_in(alice):
+            with acting_as(bob):
+                assert current_user() is bob
+                storage_mod.get_storage_provider().write("k.txt", b"v")
+            assert current_user() is alice
+
+    assert _snapshot() == before
+    with pytest.raises(RuntimeError):
+        storage_mod.get_storage_provider()
+    with pytest.raises(RuntimeError):
+        current_user()

--- a/tests/testing/test_init_providers.py
+++ b/tests/testing/test_init_providers.py
@@ -78,6 +78,39 @@ def test_restores_prior_providers_exactly(project: Path):
         storage_mod.reset_storage_provider()
 
 
+def test_cleanup_when_body_raises(project: Path):
+    prior_storage = storage_mod._provider
+    prior_jobs = jobs_mod._job_provider
+    prior_bc = broadcast_mod._provider
+    prior_channels = broadcast_mod._channels
+    with pytest.raises(ValueError):
+        with init_providers(project):
+            raise ValueError("boom")
+    assert storage_mod._provider is prior_storage
+    assert jobs_mod._job_provider is prior_jobs
+    assert broadcast_mod._provider is prior_bc
+    assert broadcast_mod._channels is prior_channels
+
+
+def test_partial_init_failure_restores_prior_storage(tmp_path: Path):
+    from fymo.jobs.providers.registry import JobProviderConfigError
+
+    (tmp_path / "fymo.yml").write_text(
+        "name: broken\n"
+        "storage: {provider: local}\n"
+        "jobs: {provider: nosuchprovider}\n"
+    )
+    sentinel = object()
+    storage_mod.set_storage_provider(sentinel)
+    try:
+        with pytest.raises(JobProviderConfigError):
+            with init_providers(tmp_path):
+                pass
+        assert storage_mod._provider is sentinel
+    finally:
+        storage_mod.reset_storage_provider()
+
+
 def test_missing_fymo_yml_raises(tmp_path: Path):
     with pytest.raises(FileNotFoundError):
         with init_providers(tmp_path / "nowhere"):

--- a/tests/testing/test_init_providers.py
+++ b/tests/testing/test_init_providers.py
@@ -1,0 +1,84 @@
+"""fymo.testing.init_providers: fymo.yml-driven provider bootstrap for bare test processes."""
+from pathlib import Path
+
+import pytest
+
+import fymo.broadcast as broadcast_mod
+import fymo.jobs as jobs_mod
+import fymo.storage as storage_mod
+from fymo.storage import get_storage_provider
+from fymo.storage.providers.local import LocalStorageProvider
+from fymo.testing import init_providers
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "fymo.yml").write_text(
+        "name: scaffold\n"
+        "storage:\n"
+        "  provider: local\n"
+        "  root: app/data/files\n"
+    )
+    return tmp_path
+
+
+def test_storage_provider_works_inside_block(project: Path):
+    with init_providers(project):
+        provider = get_storage_provider()
+        assert isinstance(provider, LocalStorageProvider)
+        provider.write("hello.txt", b"hi")
+        assert (project / "app" / "data" / "files" / "hello.txt").read_bytes() == b"hi"
+
+
+def test_storage_raises_after_block(project: Path):
+    with init_providers(project):
+        get_storage_provider()
+    with pytest.raises(RuntimeError):
+        get_storage_provider()
+
+
+def test_jobs_and_broadcasts_initialized(project: Path):
+    from fymo.jobs import get_job_provider
+    from fymo.jobs.providers.threaded import ThreadedJobProvider
+
+    with init_providers(project):
+        assert isinstance(get_job_provider(), ThreadedJobProvider)
+        assert broadcast_mod.get_channels() == {}
+
+
+def test_yields_the_built_providers(project: Path):
+    with init_providers(project) as providers:
+        assert providers.storage is get_storage_provider()
+        assert providers.jobs is jobs_mod.get_job_provider()
+        assert providers.broadcasts is broadcast_mod.get_broadcast_provider()
+
+
+def test_no_storage_section_skips_storage(tmp_path: Path):
+    (tmp_path / "fymo.yml").write_text("name: bare\n")
+    with init_providers(tmp_path) as providers:
+        assert providers.storage is None
+        with pytest.raises(RuntimeError):
+            get_storage_provider()
+
+
+def test_restores_prior_providers_exactly(project: Path):
+    sentinel = object()
+    storage_mod.set_storage_provider(sentinel)
+    prior_jobs = jobs_mod._job_provider
+    prior_bc = broadcast_mod._provider
+    prior_channels = broadcast_mod._channels
+    try:
+        with init_providers(project):
+            assert get_storage_provider() is not sentinel
+        assert get_storage_provider() is sentinel
+        assert jobs_mod._job_provider is prior_jobs
+        assert broadcast_mod._provider is prior_bc
+        assert broadcast_mod._channels is prior_channels
+    finally:
+        storage_mod.reset_storage_provider()
+
+
+def test_missing_fymo_yml_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        with init_providers(tmp_path / "nowhere"):
+            pass

--- a/tests/testing/test_signed_in.py
+++ b/tests/testing/test_signed_in.py
@@ -1,0 +1,114 @@
+"""fymo.testing.signed_in / acting_as: fake authenticated sessions for tests."""
+import pytest
+
+from fymo.auth import context as auth_context
+from fymo.auth.context import current_user, register_session_resolver, reset_session_resolvers
+from fymo.remote.identity import current_uid
+from fymo.testing import acting_as, make_user, signed_in
+
+
+def test_signed_in_default_user_resolves_via_current_user():
+    with signed_in() as user:
+        assert current_user() == user
+        assert current_user().email == user.email
+
+
+def test_signed_in_custom_user():
+    alice = make_user(email="alice@example.com")
+    with signed_in(alice):
+        resolved = current_user()
+        assert resolved is alice
+        assert resolved.email == "alice@example.com"
+
+
+def test_make_user_assigns_unique_ids():
+    a = make_user()
+    b = make_user()
+    assert a.id != b.id
+
+
+def test_make_user_accepts_overrides():
+    u = make_user(email="x@example.com", id=42, email_verified=False)
+    assert u.id == 42
+    assert u.email == "x@example.com"
+    assert u.email_verified is False
+
+
+def test_signed_in_provides_request_scope_uid():
+    with signed_in(uid="u_custom"):
+        assert current_uid() == "u_custom"
+
+
+def test_current_user_raises_outside_block():
+    with signed_in():
+        pass
+    with pytest.raises(RuntimeError):
+        current_user()
+
+
+def test_acting_as_swaps_and_restores():
+    alice = make_user(email="alice@example.com")
+    bob = make_user(email="bob@example.com")
+    with signed_in(alice):
+        assert current_user() is alice
+        with acting_as(bob):
+            assert current_user() is bob
+        assert current_user() is alice
+
+
+def test_acting_as_yields_the_user():
+    bob = make_user(email="bob@example.com")
+    with signed_in():
+        with acting_as(bob) as inner:
+            assert inner is bob
+
+
+def test_acting_as_nests():
+    a = make_user(email="a@example.com")
+    b = make_user(email="b@example.com")
+    c = make_user(email="c@example.com")
+    with signed_in(a):
+        with acting_as(b):
+            with acting_as(c):
+                assert current_user() is c
+            assert current_user() is b
+        assert current_user() is a
+
+
+def test_acting_as_outside_signed_in_raises():
+    bob = make_user(email="bob@example.com")
+    with pytest.raises(RuntimeError):
+        with acting_as(bob):
+            pass
+
+
+def test_acting_as_restores_on_exception():
+    alice = make_user(email="alice@example.com")
+    bob = make_user(email="bob@example.com")
+    with signed_in(alice):
+        with pytest.raises(ValueError):
+            with acting_as(bob):
+                raise ValueError("boom")
+        assert current_user() is alice
+
+
+def test_signed_in_leaves_resolver_registry_as_found():
+    sentinel = lambda event: None
+    register_session_resolver(sentinel)
+    try:
+        assert auth_context._session_resolvers == [sentinel]
+        with signed_in():
+            pass
+        assert auth_context._session_resolvers == [sentinel]
+    finally:
+        reset_session_resolvers()
+
+
+def test_signed_in_blocks_nest():
+    alice = make_user(email="alice@example.com")
+    bob = make_user(email="bob@example.com")
+    with signed_in(alice):
+        with signed_in(bob):
+            assert current_user() is bob
+        assert current_user() is alice
+    assert auth_context._session_resolvers == []

--- a/tests/testing/test_signed_in.py
+++ b/tests/testing/test_signed_in.py
@@ -39,6 +39,20 @@ def test_signed_in_provides_request_scope_uid():
         assert current_uid() == "u_custom"
 
 
+def test_signed_in_default_uid_derives_from_user():
+    user = make_user(id=7)
+    with signed_in(user):
+        assert current_uid() == "u_test7"
+
+
+def test_sequential_signed_in_users_get_distinct_uids():
+    with signed_in(make_user(email="one@example.com")):
+        uid_one = current_uid()
+    with signed_in(make_user(email="two@example.com")):
+        uid_two = current_uid()
+    assert uid_one != uid_two
+
+
 def test_current_user_raises_outside_block():
     with signed_in():
         pass
@@ -54,6 +68,46 @@ def test_acting_as_swaps_and_restores():
         with acting_as(bob):
             assert current_user() is bob
         assert current_user() is alice
+
+
+def test_acting_as_swaps_uid_with_the_user():
+    alice = make_user(id=11)
+    bob = make_user(id=22)
+    with signed_in(alice):
+        assert current_uid() == "u_test11"
+        with acting_as(bob):
+            assert current_uid() == "u_test22"
+        assert current_uid() == "u_test11"
+
+
+def test_acting_as_accepts_uid_override():
+    bob = make_user(email="bob@example.com")
+    with signed_in(uid="u_outer"):
+        with acting_as(bob, uid="u_inner"):
+            assert current_uid() == "u_inner"
+        assert current_uid() == "u_outer"
+
+
+def test_acting_as_nested_uids_restore_level_by_level():
+    a = make_user(id=101)
+    b = make_user(id=102)
+    c = make_user(id=103)
+    with signed_in(a):
+        with acting_as(b):
+            with acting_as(c):
+                assert current_uid() == "u_test103"
+            assert current_uid() == "u_test102"
+        assert current_uid() == "u_test101"
+
+
+def test_acting_as_restores_uid_on_exception():
+    alice = make_user(id=31)
+    bob = make_user(id=32)
+    with signed_in(alice):
+        with pytest.raises(ValueError):
+            with acting_as(bob):
+                raise ValueError("boom")
+        assert current_uid() == "u_test31"
 
 
 def test_acting_as_yields_the_user():
@@ -102,6 +156,20 @@ def test_signed_in_leaves_resolver_registry_as_found():
         assert auth_context._session_resolvers == [sentinel]
     finally:
         reset_session_resolvers()
+
+
+def test_signed_in_cleans_up_when_body_raises():
+    from fymo.remote.context import _current_event
+
+    resolvers_before = list(auth_context._session_resolvers)
+    event_before = _current_event.get()
+    with pytest.raises(ValueError):
+        with signed_in():
+            raise ValueError("boom")
+    assert auth_context._session_resolvers == resolvers_before
+    assert _current_event.get() == event_before
+    with pytest.raises(RuntimeError):
+        current_user()
 
 
 def test_signed_in_blocks_nest():


### PR DESCRIPTION
## Summary

Closes #48. Ships the test utilities every fymo app was re-deriving from fymo's own internal test suite.

- `signed_in(user)`: fake signed-in session for the duration of a block, real User object, wraps the existing register_session_resolver + request_scope mechanism.
- `acting_as(other_user)`: switch identity mid-test, the primitive authorization tests need. Swaps the full identity including the request-scope uid (identity is user plus uid; uid derives as u_test{id} so two users never silently share uid-keyed data).
- `init_providers(project_root)`: one line to get storage/jobs/broadcasts working in a bare test process, mirroring FymoApp.__init__.
- `signed_in_user` pytest fixture behind a try-import guard; the module imports fine without pytest.
- Everything restores global state exactly on exit, including exception paths and partial init failure.

## Test plan

- 24 tests under tests/testing/: cleanup exactness (registry snapshot, back-to-back runs), uid semantics (6 tests), exception-path restore for all three utilities, nesting.
- blog_app gets its first tests, using only the shipped utilities: comment attribution across two users, and reaction isolation (bob's clap must not toggle alice's off).
- Full suite: 928 passed, 10 skipped (pre-existing DB-gated).