### PR TITLE
PostgresUserStore: identity in the same database as the app's data

### DIFF
--- a/fymo/auth/postgres_store.py
+++ b/fymo/auth/postgres_store.py
@@ -1,0 +1,323 @@
+"""PostgresUserStore: the UserStore Protocol on the app's own Postgres.
+
+Enable it in `fymo.yml`:
+
+    auth:
+      user_store: fymo.auth.postgres_store.PostgresUserStore
+
+The connection string comes from the DATABASE_URL environment variable, the
+same one the procrastinate job provider and the postgres broadcast provider
+already read, so identity lands in the database the rest of the app uses.
+A missing DATABASE_URL fails at construction, i.e. at boot, never as a lazy
+first-request error. The driver is optional; install it with
+`pip install 'fymo[postgres]'`.
+
+POSTGRES OBJECTS OWNED BY THIS STORE:
+Everything fymo creates is prefixed `fymo_` because it shares the app's
+database. The full list (see `schema_postgres.sql`):
+
+    fymo_users                          table
+    fymo_users_pkey                     index (implicit, primary key)
+    fymo_users_id_seq                   sequence (implicit, owned by fymo_users.id)
+    fymo_users_email_lower_idx          unique index on lower(email)
+    fymo_user_oauth_identities          table
+    fymo_user_oauth_identities_pkey     index (implicit, primary key)
+
+Semantics mirror SqliteUserStore exactly: case-insensitive email uniqueness
+(EmailAlreadyExists on collision), session_epoch bumping, idempotent
+identity linking, and consume-once verify/reset tokens. Thread safety comes
+from a small psycopg_pool ConnectionPool instead of SqliteUserStore's
+single-connection lock; each method borrows a pooled connection for exactly
+one transaction.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from fymo.auth.store import EmailAlreadyExists, User
+from fymo.auth.verify_token import hash_token, verify_reset_token, verify_verify_token
+
+_SCHEMA_PATH = Path(__file__).parent / "schema_postgres.sql"
+_ENV_VAR = "DATABASE_URL"
+
+# Advisory-lock key serializing schema bootstrap, so several workers booting
+# at once don't race the CREATEs. Arbitrary but stable: 'fymo' in ASCII.
+_BOOTSTRAP_LOCK_KEY = 0x66796D6F
+
+
+def _import_psycopg():
+    """Import the optional driver with an actionable error, mirroring the
+    procrastinate provider: a missing extra must say how to fix itself, not
+    dump a ModuleNotFoundError."""
+    try:
+        import psycopg
+        import psycopg_pool
+        from psycopg.rows import dict_row
+    except ImportError as e:
+        raise RuntimeError(
+            "PostgresUserStore needs the psycopg package with pool support "
+            "(install it with: pip install 'fymo[postgres]')"
+        ) from e
+    return psycopg, psycopg_pool, dict_row
+
+
+class PostgresUserStore:
+    """UserStore over the app's Postgres. Schema bootstrapped on first connect.
+
+    Same constructor contract as SqliteUserStore: one positional project
+    root. It is unused here (the connection comes from $DATABASE_URL) but
+    keeps the `auth.user_store` loader working unchanged for every store.
+    """
+
+    def __init__(self, project_root: Path):
+        self.project_root = Path(project_root)
+        url = os.environ.get(_ENV_VAR)
+        if not url:
+            raise RuntimeError(
+                f"PostgresUserStore needs ${_ENV_VAR} set to a Postgres "
+                "connection string. It is checked here, at boot, so a "
+                "missing URL never surfaces as a first-request failure."
+            )
+        self._url = url
+        self._psycopg, self._psycopg_pool, self._dict_row = _import_psycopg()
+        self._lock = threading.Lock()
+        self._pool = None
+
+    def _get_pool(self):
+        """Open the pool and bootstrap the schema on first use, the pooled
+        analogue of SqliteUserStore._connect. Deliberately small with no
+        tuning surface: auth traffic is one short transaction per call."""
+        if self._pool is None:
+            with self._lock:
+                if self._pool is None:
+                    pool = self._psycopg_pool.ConnectionPool(
+                        self._url,
+                        min_size=1,
+                        max_size=4,
+                        open=True,
+                        kwargs={"row_factory": self._dict_row},
+                    )
+                    with pool.connection() as conn:
+                        conn.execute(
+                            "SELECT pg_advisory_xact_lock(%s)",
+                            (_BOOTSTRAP_LOCK_KEY,),
+                        )
+                        conn.execute(_SCHEMA_PATH.read_text())
+                        self._migrate(conn)
+                    self._pool = pool
+        return self._pool
+
+    @staticmethod
+    def _migrate(conn) -> None:
+        """Additive migrations for databases created before a column existed.
+
+        `CREATE TABLE IF NOT EXISTS` never alters an existing table, so a
+        column added to schema_postgres.sql after a database was created
+        would be missing. Add it here idempotently; same hook pattern as
+        SqliteUserStore._migrate, covering the same columns.
+        """
+        conn.execute(
+            "ALTER TABLE fymo_users "
+            "ADD COLUMN IF NOT EXISTS session_epoch INTEGER NOT NULL DEFAULT 1"
+        )
+        conn.execute(
+            "ALTER TABLE fymo_users ADD COLUMN IF NOT EXISTS email_verify_token TEXT"
+        )
+        conn.execute(
+            "ALTER TABLE fymo_users ADD COLUMN IF NOT EXISTS email_verify_sent_at TEXT"
+        )
+        conn.execute(
+            "ALTER TABLE fymo_users ADD COLUMN IF NOT EXISTS password_reset_token TEXT"
+        )
+
+    def close(self) -> None:
+        """Release pooled connections. Not part of the UserStore Protocol;
+        process teardown normally handles it, tests call it explicitly."""
+        if self._pool is not None:
+            self._pool.close()
+            self._pool = None
+
+    @staticmethod
+    def _row_to_user(row) -> Optional[User]:
+        if row is None:
+            return None
+        return User(
+            id=row["id"],
+            email=row["email"],
+            password_hash=row["password_hash"],
+            email_verified=bool(row["email_verified"]),
+            created_at=row["created_at"],
+            fymo_uid=row["fymo_uid"],
+            session_epoch=row["session_epoch"],
+        )
+
+    _COLUMNS = "id, email, password_hash, email_verified, created_at, fymo_uid, session_epoch"
+
+    def get_by_id(self, user_id: int) -> Optional[User]:
+        with self._get_pool().connection() as conn:
+            row = conn.execute(
+                f"SELECT {self._COLUMNS} FROM fymo_users WHERE id = %s",
+                (user_id,),
+            ).fetchone()
+        return self._row_to_user(row)
+
+    def get_by_email(self, email: str) -> Optional[User]:
+        with self._get_pool().connection() as conn:
+            row = conn.execute(
+                f"SELECT {self._COLUMNS} FROM fymo_users "
+                "WHERE lower(email) = lower(%s)",
+                (email,),
+            ).fetchone()
+        return self._row_to_user(row)
+
+    def create(self, email: str, password_hash: Optional[str]) -> User:
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        try:
+            with self._get_pool().connection() as conn:
+                row = conn.execute(
+                    "INSERT INTO fymo_users (email, password_hash, created_at) "
+                    "VALUES (%s, %s, %s) RETURNING id",
+                    (email, password_hash, now),
+                ).fetchone()
+        except self._psycopg.errors.UniqueViolation as e:
+            raise EmailAlreadyExists(email) from e
+        return User(
+            id=row["id"], email=email, password_hash=password_hash,
+            email_verified=False, created_at=now, fymo_uid=None,
+        )
+
+    def set_password_hash(self, user_id: int, password_hash: str) -> None:
+        # Bump the epoch in the same statement so a password change atomically
+        # revokes every session issued under the old password.
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users "
+                "SET password_hash = %s, session_epoch = session_epoch + 1 "
+                "WHERE id = %s",
+                (password_hash, user_id),
+            )
+
+    def bump_session_epoch(self, user_id: int) -> None:
+        """Invalidate all outstanding sessions for a user (logout, forced sign-out)."""
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users SET session_epoch = session_epoch + 1 "
+                "WHERE id = %s",
+                (user_id,),
+            )
+
+    def get_by_identity(self, provider: str, provider_user_id: str) -> Optional[User]:
+        """Return the user linked to an external identity, or None."""
+        with self._get_pool().connection() as conn:
+            row = conn.execute(
+                f"SELECT {self._COLUMNS} FROM fymo_users WHERE id = ("
+                "  SELECT user_id FROM fymo_user_oauth_identities"
+                "  WHERE provider = %s AND provider_user_id = %s"
+                ")",
+                (provider, provider_user_id),
+            ).fetchone()
+        return self._row_to_user(row)
+
+    def link_identity(
+        self, user_id: int, provider: str, provider_user_id: str, email: Optional[str]
+    ) -> None:
+        """Attach an external identity to a user. Idempotent on (provider, sub)."""
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "INSERT INTO fymo_user_oauth_identities "
+                "(user_id, provider, provider_user_id, email, linked_at) "
+                "VALUES (%s, %s, %s, %s, %s) "
+                "ON CONFLICT (provider, provider_user_id) DO NOTHING",
+                (user_id, provider, provider_user_id, email, now),
+            )
+
+    def claim_fymo_uid(self, user_id: int, fymo_uid: str) -> None:
+        """Idempotent: only sets fymo_uid if currently NULL."""
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users SET fymo_uid = %s "
+                "WHERE id = %s AND fymo_uid IS NULL",
+                (fymo_uid, user_id),
+            )
+
+    def set_verify_token(self, user_id: int, token: str) -> None:
+        """Record a newly-issued verification token for `user_id`.
+
+        Only the token's hash is persisted (see `fymo.auth.verify_token`),
+        and setting a new token implicitly invalidates any previous
+        outstanding one for this user, since the old token's hash no longer
+        matches the row, so `consume_verify_token` will reject it even if
+        it hasn't expired.
+        """
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users "
+                "SET email_verify_token = %s, email_verify_sent_at = %s "
+                "WHERE id = %s",
+                (hash_token(token), now, user_id),
+            )
+
+    def consume_verify_token(self, token: str) -> Optional[int]:
+        """Validate `token` (signature + expiry) and, if it matches the
+        outstanding token hash on record, atomically mark the user verified
+        and clear the stored hash so the token can't be replayed. Returns the
+        verified user's id, or None if the token is forged, expired, already
+        consumed, or superseded by a later `set_verify_token` call."""
+        verified = verify_verify_token(token)
+        if verified is None:
+            return None
+        user_id, _issued_at = verified
+        with self._get_pool().connection() as conn:
+            cur = conn.execute(
+                "UPDATE fymo_users "
+                "SET email_verified = TRUE, email_verify_token = NULL "
+                "WHERE id = %s AND email_verify_token = %s",
+                (user_id, hash_token(token)),
+            )
+            if cur.rowcount == 0:
+                return None
+        return user_id
+
+    def set_reset_token(self, user_id: int, token: str) -> None:
+        """Record a newly-issued password-reset token for `user_id`.
+
+        Only the token's hash is persisted (see `fymo.auth.verify_token`),
+        and setting a new token implicitly invalidates any previous
+        outstanding one for this user, since the old token's hash no longer
+        matches the row, so `consume_reset_token` will reject it even if it
+        hasn't expired.
+        """
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users SET password_reset_token = %s WHERE id = %s",
+                (hash_token(token), user_id),
+            )
+
+    def consume_reset_token(self, token: str) -> Optional[int]:
+        """Validate `token` (signature + expiry) and, if it matches the
+        outstanding token hash on record, atomically clear the stored hash so
+        the token can't be replayed. Returns the user's id, or None if the
+        token is forged, expired, already consumed, or superseded by a later
+        `set_reset_token` call. Does NOT change the password itself; the
+        caller (`fymo.auth.remote.reset_password`) does that via
+        `set_password_hash`, which also bumps `session_epoch` to revoke every
+        outstanding session."""
+        verified = verify_reset_token(token)
+        if verified is None:
+            return None
+        user_id, _issued_at = verified
+        with self._get_pool().connection() as conn:
+            cur = conn.execute(
+                "UPDATE fymo_users SET password_reset_token = NULL "
+                "WHERE id = %s AND password_reset_token = %s",
+                (user_id, hash_token(token)),
+            )
+            if cur.rowcount == 0:
+                return None
+        return user_id

--- a/fymo/auth/postgres_store.py
+++ b/fymo/auth/postgres_store.py
@@ -112,13 +112,21 @@ class PostgresUserStore:
                         open=True,
                         kwargs={"row_factory": self._dict_row},
                     )
-                    with pool.connection() as conn:
-                        conn.execute(
-                            "SELECT pg_advisory_xact_lock(%s)",
-                            (_BOOTSTRAP_LOCK_KEY,),
-                        )
-                        conn.execute(_SCHEMA_PATH.read_text())
-                        self._migrate(conn)
+                    # If bootstrap fails (transient outage on first call),
+                    # close the pool instead of leaking it: its background
+                    # workers would keep reconnecting until process exit,
+                    # and the next call would build another pool on top.
+                    try:
+                        with pool.connection() as conn:
+                            conn.execute(
+                                "SELECT pg_advisory_xact_lock(%s)",
+                                (_BOOTSTRAP_LOCK_KEY,),
+                            )
+                            conn.execute(_SCHEMA_PATH.read_text())
+                            self._migrate(conn)
+                    except BaseException:
+                        pool.close()
+                        raise
                     self._pool = pool
         return self._pool
 

--- a/fymo/auth/postgres_store.py
+++ b/fymo/auth/postgres_store.py
@@ -23,12 +23,23 @@ database. The full list (see `schema_postgres.sql`):
     fymo_user_oauth_identities          table
     fymo_user_oauth_identities_pkey     index (implicit, primary key)
 
-Semantics mirror SqliteUserStore exactly: case-insensitive email uniqueness
-(EmailAlreadyExists on collision), session_epoch bumping, idempotent
-identity linking, and consume-once verify/reset tokens. Thread safety comes
-from a small psycopg_pool ConnectionPool instead of SqliteUserStore's
-single-connection lock; each method borrows a pooled connection for exactly
-one transaction.
+Semantics match SqliteUserStore for every Protocol method: case-insensitive
+email uniqueness (EmailAlreadyExists on collision), session_epoch bumping,
+idempotent identity linking, and consume-once verify/reset tokens. Two
+known divergences, both in Postgres's favor:
+
+  * Case folding is locale-aware here, ASCII-only in SQLite (NOCASE).
+    "É@x.com" and "é@x.com" are two distinct users in a SQLite auth.db but
+    collide here, so a SQLite database already holding both spellings
+    cannot be imported into this store. Pinned by a test in
+    tests/auth/test_postgres_store.py.
+  * fymo_user_oauth_identities.user_id is an enforced foreign key here;
+    SQLite declares it but never enables PRAGMA foreign_keys. Unreachable
+    through normal Protocol flows, which always link existing users.
+
+Thread safety comes from a small psycopg_pool ConnectionPool instead of
+SqliteUserStore's single-connection lock; each method borrows a pooled
+connection for exactly one transaction.
 """
 from __future__ import annotations
 

--- a/fymo/auth/schema_postgres.sql
+++ b/fymo/auth/schema_postgres.sql
@@ -1,0 +1,31 @@
+-- Postgres translation of schema.sql: same columns, same semantics. Every
+-- object is prefixed fymo_ because this schema lives inside the app's own
+-- database, next to app tables. Add columns via app-level migrations; fymo
+-- will not destructively touch these tables once created.
+
+CREATE TABLE IF NOT EXISTS fymo_users (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    email           TEXT NOT NULL,
+    password_hash   TEXT,         -- NULL for OAuth-only users
+    email_verified  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TEXT NOT NULL,
+    fymo_uid        TEXT,         -- anonymous uid this user claimed on first login
+    session_epoch   INTEGER NOT NULL DEFAULT 1, -- bumped to revoke outstanding sessions
+    email_verify_token    TEXT,   -- hash of the outstanding verification token, NULL once consumed
+    email_verify_sent_at  TEXT,   -- when the last verification email was sent
+    password_reset_token  TEXT    -- hash of the outstanding password-reset token, NULL once consumed
+);
+
+-- Case-insensitive uniqueness: the Postgres spelling of SQLite's
+-- UNIQUE COLLATE NOCASE (get_by_email compares lower(email) too).
+CREATE UNIQUE INDEX IF NOT EXISTS fymo_users_email_lower_idx
+    ON fymo_users (lower(email));
+
+CREATE TABLE IF NOT EXISTS fymo_user_oauth_identities (
+    user_id           BIGINT NOT NULL REFERENCES fymo_users(id),
+    provider          TEXT NOT NULL,
+    provider_user_id  TEXT NOT NULL,
+    email             TEXT,
+    linked_at         TEXT NOT NULL,
+    PRIMARY KEY (provider, provider_user_id)
+);

--- a/fymo/auth/schema_postgres.sql
+++ b/fymo/auth/schema_postgres.sql
@@ -16,8 +16,11 @@ CREATE TABLE IF NOT EXISTS fymo_users (
     password_reset_token  TEXT    -- hash of the outstanding password-reset token, NULL once consumed
 );
 
--- Case-insensitive uniqueness: the Postgres spelling of SQLite's
--- UNIQUE COLLATE NOCASE (get_by_email compares lower(email) too).
+-- Case-insensitive uniqueness (get_by_email compares lower(email) too).
+-- Stricter than SQLite's UNIQUE COLLATE NOCASE: lower() folds per the
+-- database locale while NOCASE folds ASCII only, so non-ASCII spellings
+-- that coexist in a SQLite auth.db collide here (see the module docstring
+-- of postgres_store.py).
 CREATE UNIQUE INDEX IF NOT EXISTS fymo_users_email_lower_idx
     ON fymo_users (lower(email));
 

--- a/fymo/auth/store.py
+++ b/fymo/auth/store.py
@@ -1,9 +1,12 @@
 """UserStore Protocol + the default SQLite implementation.
 
-App authors swap the implementation via `fymo.yml`:
+App authors swap the implementation via `fymo.yml`. fymo ships two: this
+module's SqliteUserStore (the default) and
+`fymo.auth.postgres_store.PostgresUserStore`, which keeps identity in the
+same Postgres database the rest of the app uses:
 
     auth:
-      user_store: my_app.auth.PostgresUserStore
+      user_store: fymo.auth.postgres_store.PostgresUserStore
 
 The class is instantiated with a single positional argument: the project
 root path. Anything else (DB URL, schema name, etc.) should come from the

--- a/journal/journal_025.md
+++ b/journal/journal_025.md
@@ -1,0 +1,79 @@
+# Journal Entry 025: Proving the Second Data Point
+
+**Date**: July 16, 2026
+**Focus**: PostgresUserStore, and what "pluggable" actually costs to claim
+**Status**: Shipped
+
+## One Implementation Is Not an Interface
+
+The auth store has been a Protocol since day one, with a docstring
+promising you can swap it via one line of fymo.yml. Technically true. In
+practice, fymo shipped exactly one implementation, SQLite, so "swappable"
+meant writing twelve methods from scratch with no second example to copy
+from. Meanwhile most real fymo apps already run Postgres, jobs and
+broadcasts assume it outright, so the common deployment ended up with app
+data in Postgres and user identity in a lonely SQLite file nothing else
+knows exists. Two datastores, no foreign key between them, ownership rows
+keyed by email string because there's no shared id to point at.
+
+The fix was issue 50's option one: ship PostgresUserStore next to
+SqliteUserStore, same Protocol, same constructor shape, so the swap really
+is one config line. The store reads DATABASE_URL, the same variable the
+job queue and broadcast provider already use, which is the whole point.
+Identity lands in the database the rest of the app lives in.
+
+## The Battery Came First
+
+The real deliverable isn't the Postgres class, it's the conformance suite.
+Before writing a line of the new store, I pulled every behavior the SQLite
+store promises into one battery and parametrized it over store factories:
+duplicate email collision, case-insensitive lookup, epoch bumping on
+password change, consume-once tokens, superseded tokens, identity linking
+where the first link wins. Thirty-three tests, run identically against
+both backends. SQLite went green immediately, which proved the battery
+described reality rather than my hopes. Then the Postgres half failed with
+a missing module, which is exactly the failure you want to see before the
+module exists.
+
+Writing the battery also forced honesty about semantics I'd have otherwise
+glossed over. A failed INSERT in Postgres aborts the whole transaction,
+so there's a test that creates a duplicate, catches the error, and then
+keeps using the store, because a backend that forgets to roll back passes
+every test except the one that runs after a failure.
+
+## Dialect, Not Redesign
+
+The translation itself stayed deliberately boring. SQLite's UNIQUE COLLATE
+NOCASE became a unique index on lower(email). The single locked connection
+became a small psycopg_pool, four connections, no tuning knobs, each
+method borrowing one for exactly one transaction. Schema bootstrap happens
+on first connect like the SQLite store, wrapped in an advisory lock so
+eight workers booting at once don't race the CREATEs. Every object is
+prefixed fymo_ and listed at the top of the module, because these tables
+share a database with app tables and nobody should have to guess which
+rows are the framework's.
+
+Two failure modes got promoted to boot time on purpose. Missing
+DATABASE_URL raises in the constructor, naming the variable. Missing
+psycopg raises naming the exact install command, fymo[postgres]. A store
+that waits until the first login attempt to discover it can't connect is
+a store that fails in production at 2 a.m. instead of in the terminal at
+deploy.
+
+## Run It for Real
+
+Conformance against a mock proves nothing about a database, so the whole
+battery ran against an actual Postgres 16, thirty-three for thirty-three,
+plus a migration test that builds the table the old way and watches the
+store add the missing columns on connect. Then the loader path end to end:
+resolve the dotted config path, instantiate with a project root, create
+and fetch a user through a real pool. The full suite closed it out, 977
+tests, everything green, including the eight-threads-against-a-four-
+connection-pool case that makes the pool actually wait.
+
+The Protocol finally has its second data point. Turns out the way to prove
+an interface is pluggable is to plug something into it.
+
+---
+
+*End of Journal Entry 025*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pydantic>=2.5",
     "granian>=2.0,<3",
+    "psycopg[binary,pool]>=3.1",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 [project.optional-dependencies]
 pydantic = ["pydantic>=2.5"]
 procrastinate = ["procrastinate>=3.0", "psycopg[binary,pool]>=3.1"]
+postgres = ["psycopg[binary,pool]>=3.1"]
 granian = ["granian>=2.0,<3"]
 
 [project.scripts]

--- a/tests/auth/test_postgres_store.py
+++ b/tests/auth/test_postgres_store.py
@@ -1,0 +1,76 @@
+"""PostgresUserStore behavior outside the shared conformance battery.
+
+Boot-time failure modes need no database and always run: both must raise at
+construction with an actionable message, never on the first request. The
+migration test needs a real Postgres and is gated on TEST_DATABASE_URL like
+the conformance battery.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from fymo.auth.postgres_store import PostgresUserStore
+
+
+def test_missing_database_url_raises_at_construction(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        PostgresUserStore(tmp_path)
+
+
+def test_missing_psycopg_names_the_install_command(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/unused")
+    # A None entry in sys.modules makes `import psycopg` raise ImportError,
+    # simulating the extra not being installed.
+    monkeypatch.setitem(sys.modules, "psycopg", None)
+    with pytest.raises(RuntimeError, match=r"fymo\[postgres\]"):
+        PostgresUserStore(tmp_path)
+
+
+def test_construction_does_not_connect(monkeypatch, tmp_path: Path):
+    """The pool opens on first use, like SqliteUserStore's lazy connect;
+    an unreachable database must not block boot."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:1/nowhere")
+    store = PostgresUserStore(tmp_path)
+    assert store._pool is None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="needs TEST_DATABASE_URL pointing at a real Postgres instance",
+)
+def test_migrates_table_created_before_later_columns(monkeypatch, tmp_path: Path):
+    """A fymo_users table created before the session_epoch and token columns
+    existed must gain them on first connect, defaulting existing rows to
+    epoch 1 rather than erroring. Mirror of the SqliteUserStore migration
+    test in test_store.py."""
+    url = os.environ["TEST_DATABASE_URL"]
+    monkeypatch.setenv("DATABASE_URL", url)
+    import psycopg
+    with psycopg.connect(url, autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS fymo_user_oauth_identities, fymo_users")
+        conn.execute(
+            "CREATE TABLE fymo_users ("
+            " id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,"
+            " email TEXT NOT NULL,"
+            " password_hash TEXT,"
+            " email_verified BOOLEAN NOT NULL DEFAULT FALSE,"
+            " created_at TEXT NOT NULL,"
+            " fymo_uid TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO fymo_users (email, password_hash, created_at)"
+            " VALUES ('legacy@x.com', 'h', '2026-01-01T00:00:00+00:00')"
+        )
+
+    store = PostgresUserStore(tmp_path)
+    try:
+        user = store.get_by_email("legacy@x.com")
+        assert user is not None
+        assert user.session_epoch == 1
+        store.bump_session_epoch(user.id)
+        assert store.get_by_id(user.id).session_epoch == 2
+    finally:
+        store.close()

--- a/tests/auth/test_postgres_store.py
+++ b/tests/auth/test_postgres_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from fymo.auth.postgres_store import PostgresUserStore
+from fymo.auth.store import EmailAlreadyExists, SqliteUserStore
 
 
 def test_missing_database_url_raises_at_construction(monkeypatch, tmp_path: Path):
@@ -72,5 +73,33 @@ def test_migrates_table_created_before_later_columns(monkeypatch, tmp_path: Path
         assert user.session_epoch == 1
         store.bump_session_epoch(user.id)
         assert store.get_by_id(user.id).session_epoch == 2
+    finally:
+        store.close()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="needs TEST_DATABASE_URL pointing at a real Postgres instance",
+)
+def test_non_ascii_email_case_collision_diverges_from_sqlite(monkeypatch, tmp_path: Path):
+    """Known, documented divergence (see the module docstring): lower()
+    folds per the database locale while SQLite's NOCASE folds ASCII only,
+    so these two spellings coexist as distinct users in a SQLite auth.db
+    but collide here. Consequence: a SQLite database already holding both
+    cannot be imported into this store."""
+    sqlite_store = SqliteUserStore(tmp_path)
+    sqlite_store.create("É@example.com", "h")
+    sqlite_store.create("é@example.com", "h")
+
+    url = os.environ["TEST_DATABASE_URL"]
+    monkeypatch.setenv("DATABASE_URL", url)
+    import psycopg
+    with psycopg.connect(url, autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS fymo_user_oauth_identities, fymo_users")
+    store = PostgresUserStore(tmp_path)
+    try:
+        store.create("É@example.com", "h")
+        with pytest.raises(EmailAlreadyExists):
+            store.create("é@example.com", "h")
     finally:
         store.close()

--- a/tests/auth/test_postgres_store.py
+++ b/tests/auth/test_postgres_store.py
@@ -103,3 +103,35 @@ def test_non_ascii_email_case_collision_diverges_from_sqlite(monkeypatch, tmp_pa
             store.create("é@example.com", "h")
     finally:
         store.close()
+
+
+def test_bootstrap_failure_closes_the_pool(monkeypatch, tmp_path: Path):
+    """If schema bootstrap raises on the first call (transient outage), the
+    freshly built pool must be closed, not leaked with its background
+    workers reconnecting forever, and _pool must stay None so the next
+    call retries from scratch."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/unused")
+    store = PostgresUserStore(tmp_path)
+
+    created = []
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            self.closed = False
+            created.append(self)
+
+        def connection(self):
+            raise RuntimeError("bootstrap boom")
+
+        def close(self):
+            self.closed = True
+
+    class FakePoolModule:
+        ConnectionPool = FakePool
+
+    monkeypatch.setattr(store, "_psycopg_pool", FakePoolModule)
+    with pytest.raises(RuntimeError, match="bootstrap boom"):
+        store.get_by_id(1)
+    assert store._pool is None
+    assert len(created) == 1
+    assert created[0].closed is True

--- a/tests/auth/test_store_conformance.py
+++ b/tests/auth/test_store_conformance.py
@@ -1,0 +1,354 @@
+"""UserStore Protocol conformance battery, run identically against every
+shipped backend.
+
+SqliteUserStore always runs. PostgresUserStore runs only when
+TEST_DATABASE_URL points at a reachable Postgres instance (the same opt-in
+the procrastinate and postgres-broadcast tests use); otherwise its half of
+the matrix is skipped with that reason. The Postgres half drops and
+recreates the fymo_ auth tables per test, so point TEST_DATABASE_URL at a
+scratch database, never a real one.
+"""
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from fymo.auth.store import EmailAlreadyExists, SqliteUserStore, User, UserStore
+from fymo.auth.verify_token import make_reset_token, make_verify_token
+from fymo.remote import identity
+from fymo.remote.identity import set_secret
+
+
+@pytest.fixture(autouse=True)
+def _wire_secret():
+    previous = identity._secret
+    set_secret(b"x" * 32)
+    yield
+    identity._secret = previous
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def store_factory(request, tmp_path: Path, monkeypatch):
+    """Callable returning a fresh store instance over the same backend state.
+
+    Most tests use the derived `store` fixture; the persistence test calls
+    this twice to prove data survives an instance swap.
+    """
+    created = []
+    if request.param == "sqlite":
+        def make():
+            s = SqliteUserStore(tmp_path)
+            created.append(s)
+            return s
+        yield make
+    else:
+        url = os.environ.get("TEST_DATABASE_URL")
+        if not url:
+            pytest.skip("needs TEST_DATABASE_URL pointing at a real Postgres instance")
+        monkeypatch.setenv("DATABASE_URL", url)
+        import psycopg
+        with psycopg.connect(url, autocommit=True) as conn:
+            conn.execute(
+                "DROP TABLE IF EXISTS fymo_user_oauth_identities, fymo_users"
+            )
+        from fymo.auth.postgres_store import PostgresUserStore
+
+        def make():
+            s = PostgresUserStore(tmp_path)
+            created.append(s)
+            return s
+        yield make
+    for s in created:
+        close = getattr(s, "close", None)
+        if close is not None:
+            close()
+
+
+@pytest.fixture
+def store(store_factory):
+    return store_factory()
+
+
+# Protocol shape
+
+def test_satisfies_userstore_protocol(store):
+    assert isinstance(store, UserStore)
+
+
+# create / get_by_id / get_by_email
+
+def test_create_and_get_by_id(store):
+    u = store.create("alice@example.com", "scrypt$hash")
+    assert isinstance(u, User)
+    assert u.id > 0
+    assert u.email == "alice@example.com"
+    assert u.password_hash == "scrypt$hash"
+    assert u.email_verified is False
+    assert u.created_at
+    assert u.fymo_uid is None
+    assert u.session_epoch == 1
+
+    fetched = store.get_by_id(u.id)
+    assert fetched is not None
+    assert fetched.id == u.id
+    assert fetched.email == u.email
+    assert fetched.password_hash == u.password_hash
+    assert fetched.email_verified is False
+    assert fetched.created_at == u.created_at
+    assert fetched.session_epoch == 1
+
+
+def test_create_allows_null_password_hash(store):
+    u = store.create("oauth-only@example.com", None)
+    assert u.password_hash is None
+    assert store.get_by_id(u.id).password_hash is None
+
+
+def test_get_by_id_missing_returns_none(store):
+    assert store.get_by_id(999999) is None
+
+
+def test_get_by_email_missing_returns_none(store):
+    assert store.get_by_email("nobody@nowhere.com") is None
+
+
+def test_get_by_email_is_case_insensitive(store):
+    store.create("Bob@Example.com", None)
+    assert store.get_by_email("bob@example.com") is not None
+    assert store.get_by_email("BOB@EXAMPLE.COM") is not None
+
+
+def test_duplicate_email_raises(store):
+    store.create("dup@example.com", "h")
+    with pytest.raises(EmailAlreadyExists):
+        store.create("dup@example.com", "h")
+
+
+def test_duplicate_email_case_insensitive(store):
+    store.create("UPPER@example.com", "h")
+    with pytest.raises(EmailAlreadyExists):
+        store.create("upper@example.com", "h")
+
+
+def test_store_still_usable_after_duplicate_email(store):
+    """The failed INSERT must not poison later calls (a Postgres backend
+    that forgets to roll back would fail every statement after the first
+    unique violation)."""
+    store.create("first@example.com", "h")
+    with pytest.raises(EmailAlreadyExists):
+        store.create("first@example.com", "h")
+    u = store.create("second@example.com", "h")
+    assert store.get_by_id(u.id) is not None
+    assert store.get_by_email("first@example.com") is not None
+
+
+def test_persists_across_store_instances(store_factory):
+    first = store_factory()
+    u = first.create("persist@me.com", "h")
+    second = store_factory()
+    again = second.get_by_id(u.id)
+    assert again is not None
+    assert again.email == "persist@me.com"
+
+
+# password / session epoch
+
+def test_set_password_hash_updates_hash(store):
+    u = store.create("p@p.com", None)
+    store.set_password_hash(u.id, "scrypt$new")
+    assert store.get_by_id(u.id).password_hash == "scrypt$new"
+
+
+def test_set_password_hash_bumps_epoch(store):
+    u = store.create("pw@x.com", "h")
+    assert u.session_epoch == 1
+    store.set_password_hash(u.id, "scrypt$new")
+    assert store.get_by_id(u.id).session_epoch == 2
+
+
+def test_bump_session_epoch_increments(store):
+    u = store.create("bump@x.com", "h")
+    store.bump_session_epoch(u.id)
+    assert store.get_by_id(u.id).session_epoch == 2
+    store.bump_session_epoch(u.id)
+    assert store.get_by_id(u.id).session_epoch == 3
+
+
+# fymo_uid claim
+
+def test_claim_fymo_uid_sets_once(store):
+    u = store.create("c@c.com", "h")
+    assert u.fymo_uid is None
+    store.claim_fymo_uid(u.id, "u_first")
+    assert store.get_by_id(u.id).fymo_uid == "u_first"
+
+
+def test_claim_fymo_uid_is_idempotent(store):
+    u = store.create("c2@c.com", "h")
+    store.claim_fymo_uid(u.id, "u_first")
+    store.claim_fymo_uid(u.id, "u_second")
+    assert store.get_by_id(u.id).fymo_uid == "u_first"
+
+
+# external identities
+
+def test_link_identity_and_get_by_identity_roundtrip(store):
+    u = store.create("id@x.com", None)
+    store.link_identity(u.id, "google", "sub-123", "id@x.com")
+    found = store.get_by_identity("google", "sub-123")
+    assert found is not None
+    assert found.id == u.id
+
+
+def test_get_by_identity_unknown_returns_none(store):
+    assert store.get_by_identity("google", "no-such-sub") is None
+
+
+def test_link_identity_first_link_wins(store):
+    """Relinking the same (provider, sub) to another user is a no-op."""
+    a = store.create("a@x.com", None)
+    b = store.create("b@x.com", None)
+    store.link_identity(a.id, "github", "sub-1", "a@x.com")
+    store.link_identity(b.id, "github", "sub-1", "b@x.com")
+    assert store.get_by_identity("github", "sub-1").id == a.id
+
+
+def test_link_identity_distinct_subs_map_to_distinct_users(store):
+    a = store.create("a2@x.com", None)
+    b = store.create("b2@x.com", None)
+    store.link_identity(a.id, "github", "sub-a", None)
+    store.link_identity(b.id, "github", "sub-b", None)
+    assert store.get_by_identity("github", "sub-a").id == a.id
+    assert store.get_by_identity("github", "sub-b").id == b.id
+
+
+def test_one_user_can_hold_identities_from_multiple_providers(store):
+    u = store.create("multi@x.com", None)
+    store.link_identity(u.id, "google", "g-sub", None)
+    store.link_identity(u.id, "github", "h-sub", None)
+    assert store.get_by_identity("google", "g-sub").id == u.id
+    assert store.get_by_identity("github", "h-sub").id == u.id
+
+
+# email verification tokens
+
+def test_consume_verify_token_marks_verified(store):
+    u = store.create("v@x.com", "h")
+    token = make_verify_token(u.id)
+    store.set_verify_token(u.id, token)
+    assert store.consume_verify_token(token) == u.id
+    assert store.get_by_id(u.id).email_verified is True
+
+
+def test_consume_verify_token_is_single_use(store):
+    u = store.create("v2@x.com", "h")
+    token = make_verify_token(u.id)
+    store.set_verify_token(u.id, token)
+    assert store.consume_verify_token(token) == u.id
+    assert store.consume_verify_token(token) is None
+
+
+def test_consume_verify_token_garbage_returns_none(store):
+    assert store.consume_verify_token("not.a.token") is None
+
+
+def test_consume_verify_token_never_issued_returns_none(store):
+    """Signature-valid token for a user that never had one recorded."""
+    u = store.create("v3@x.com", "h")
+    assert store.consume_verify_token(make_verify_token(u.id)) is None
+    assert store.get_by_id(u.id).email_verified is False
+
+
+def test_consume_verify_token_unknown_user_returns_none(store):
+    assert store.consume_verify_token(make_verify_token(999999)) is None
+
+
+def test_consume_verify_token_superseded_returns_none(store):
+    """A newer set_verify_token invalidates the earlier token."""
+    u = store.create("v4@x.com", "h")
+    now = int(time.time())
+    old = make_verify_token(u.id, issued_at=now - 10)
+    new = make_verify_token(u.id, issued_at=now)
+    store.set_verify_token(u.id, old)
+    store.set_verify_token(u.id, new)
+    assert store.consume_verify_token(old) is None
+    assert store.consume_verify_token(new) == u.id
+
+
+# password reset tokens
+
+def test_consume_reset_token_returns_user_id(store):
+    u = store.create("r@x.com", "h")
+    token = make_reset_token(u.id)
+    store.set_reset_token(u.id, token)
+    assert store.consume_reset_token(token) == u.id
+
+
+def test_consume_reset_token_does_not_verify_email(store):
+    u = store.create("r2@x.com", "h")
+    token = make_reset_token(u.id)
+    store.set_reset_token(u.id, token)
+    store.consume_reset_token(token)
+    assert store.get_by_id(u.id).email_verified is False
+
+
+def test_consume_reset_token_is_single_use(store):
+    u = store.create("r3@x.com", "h")
+    token = make_reset_token(u.id)
+    store.set_reset_token(u.id, token)
+    assert store.consume_reset_token(token) == u.id
+    assert store.consume_reset_token(token) is None
+
+
+def test_consume_reset_token_never_issued_returns_none(store):
+    u = store.create("r4@x.com", "h")
+    assert store.consume_reset_token(make_reset_token(u.id)) is None
+
+
+def test_consume_reset_token_superseded_returns_none(store):
+    u = store.create("r5@x.com", "h")
+    now = int(time.time())
+    old = make_reset_token(u.id, issued_at=now - 10)
+    new = make_reset_token(u.id, issued_at=now)
+    store.set_reset_token(u.id, old)
+    store.set_reset_token(u.id, new)
+    assert store.consume_reset_token(old) is None
+    assert store.consume_reset_token(new) == u.id
+
+
+def test_concurrent_creates_from_many_threads(store):
+    """Both backends must survive parallel writers: SqliteUserStore via its
+    connection lock, PostgresUserStore via the connection pool (more threads
+    here than the pool's max_size, so waiting is exercised too)."""
+    import threading
+    errors = []
+
+    def work(i: int) -> None:
+        try:
+            u = store.create(f"thread{i}@x.com", "h")
+            assert store.get_by_id(u.id).email == f"thread{i}@x.com"
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=work, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert errors == []
+    assert all(not t.is_alive() for t in threads)
+
+
+def test_tokens_are_purpose_bound(store):
+    """A verify token can never be consumed as a reset token or vice versa,
+    even for the same user with both outstanding."""
+    u = store.create("cross@x.com", "h")
+    verify = make_verify_token(u.id)
+    reset = make_reset_token(u.id)
+    store.set_verify_token(u.id, verify)
+    store.set_reset_token(u.id, reset)
+    assert store.consume_reset_token(verify) is None
+    assert store.consume_verify_token(reset) is None
+    assert store.consume_verify_token(verify) == u.id
+    assert store.consume_reset_token(reset) == u.id

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.11.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -75,6 +75,9 @@ dependencies = [
 [package.optional-dependencies]
 granian = [
     { name = "granian" },
+]
+postgres = [
+    { name = "psycopg", extra = ["binary", "pool"] },
 ]
 procrastinate = [
     { name = "procrastinate" },
@@ -98,11 +101,12 @@ requires-dist = [
     { name = "granian", marker = "extra == 'granian'", specifier = ">=2.0,<3" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "procrastinate", marker = "extra == 'procrastinate'", specifier = ">=3.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'procrastinate'", specifier = ">=3.1" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.5" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
-provides-extras = ["pydantic", "procrastinate", "granian"]
+provides-extras = ["pydantic", "procrastinate", "postgres", "granian"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,7 @@ pydantic = [
 [package.dev-dependencies]
 dev = [
     { name = "granian" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -111,6 +112,7 @@ provides-extras = ["pydantic", "procrastinate", "postgres", "granian"]
 [package.metadata.requires-dev]
 dev = [
     { name = "granian", specifier = ">=2.0,<3" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },


### PR DESCRIPTION
## Summary

Closes #50. Ships a second UserStore implementation so "swappable" is proven, and identity can live in the same Postgres the app already uses.

- fymo/auth/postgres_store.py: PostgresUserStore, same constructor shape as SqliteUserStore, plugs into the existing auth.user_store config with zero loader changes.
- DATABASE_URL checked at construction (boot-loud), psycopg imported lazily with an error naming pip install 'fymo[postgres]', new postgres extra in pyproject.
- psycopg_pool connection pool, schema bootstrap on first connect under an advisory lock, safe across concurrent processes; pool closed and retried clean if bootstrap fails.
- Tables are fymo_-prefixed (6 objects, listed in the module docstring) since they share a database with app tables.
- Two known, documented divergences from SQLite: locale-aware email case folding (Postgres is stricter for non-ASCII, pinned by test) and enforced FK on identity links.

## Test plan

- 33-test conformance battery parametrized over BOTH stores: every Protocol method, duplicate email (incl. case-insensitive and connection-usable-after-failure), token consume-once, epoch revocation, identity first-link-wins, 8-thread concurrency through the pool.
- Postgres side gated on TEST_DATABASE_URL; verified 979 passed, 0 skipped against a real postgres:16 container, including a 6-process bootstrap race and an 8-thread single-token race (exactly one winner).
- Without a database: 934 passed, 45 skipped, all skips clearly reasoned.