### PR TITLE
Per-function rate limiting for remote functions

### DIFF
--- a/fymo/core/middleware.py
+++ b/fymo/core/middleware.py
@@ -37,12 +37,21 @@ Both are skipped in dev (`dev=True`).
 """
 from __future__ import annotations
 
-import threading
-import time
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from fymo.core.config import parse_bool
+
+# Bucket mechanics live in fymo.core.ratelimit, shared with the remote
+# router's per-function limiter. Re-exported here (`_TokenBucket`,
+# `_SWEEP_INTERVAL_SECONDS`) because this module was their original home.
+from fymo.core.ratelimit import (  # noqa: F401
+    _SWEEP_INTERVAL_SECONDS,
+    BucketRegistry,
+    _TokenBucket,
+    resolve_client_ip,
+    retry_after_seconds,
+)
 
 
 # ---------------- Rate limiter ----------------
@@ -59,77 +68,21 @@ class RateLimitConfig:
     trust_proxy: bool = False
 
 
-class _TokenBucket:
-    __slots__ = ("tokens", "last_refill", "capacity", "rate")
-
-    def __init__(self, capacity: int, rate: float):
-        self.tokens: float = float(capacity)
-        self.last_refill = time.monotonic()
-        self.capacity = capacity
-        self.rate = rate  # tokens per second
-
-    def take(self) -> bool:
-        now = time.monotonic()
-        self.tokens = min(self.capacity, self.tokens + (now - self.last_refill) * self.rate)
-        self.last_refill = now
-        if self.tokens >= 1.0:
-            self.tokens -= 1.0
-            return True
-        return False
-
-
-#: How often (in seconds) `RateLimiter.check` opportunistically sweeps idle
-#: buckets. A dedicated background thread isn't worth it for this -- request
-#: traffic itself drives the sweep, and a 60s cadence bounds the sweep's own
-#: overhead to well under the cost of the token-bucket check it rides along
-#: with.
-_SWEEP_INTERVAL_SECONDS = 60.0
-
-
-class RateLimiter:
+class RateLimiter(BucketRegistry):
     """Per-(IP, rule) token bucket rate limiter, in-process.
 
-    `_buckets` is otherwise unbounded: every distinct (client_ip, rule)
-    pair seen gets its own entry that nothing ever removes, so a
-    long-running process fielding traffic from many distinct IPs (the
-    normal case for anything public-facing) leaks memory for as long as it
-    runs. `check` opportunistically sweeps idle buckets to bound this.
+    The bucket registry, locking, and idle-bucket sweep come from
+    `BucketRegistry` (fymo.core.ratelimit); this class adds the WSGI-facing
+    policy: which bucket a request maps to (client IP + longest matching
+    path-prefix rule) and how big that bucket is.
     """
 
     def __init__(self, config: RateLimitConfig):
+        super().__init__()
         self.config = config
-        self._buckets: Dict[Tuple[str, str], _TokenBucket] = {}
-        self._lock = threading.Lock()
-        self._last_sweep = time.monotonic()
-
-    def _sweep_idle_buckets(self, now: float) -> None:
-        """Drop buckets that have fully refilled since their last request.
-
-        A fully-refilled bucket carries no state a brand-new one wouldn't
-        also have (both start at `capacity` tokens), so evicting it doesn't
-        change any client-visible behavior -- the next request for that key
-        just lazily recreates an identical bucket. Buckets with partial
-        state (a client currently being throttled, or one that hasn't been
-        idle long enough to fully refill) are left alone, since dropping
-        those WOULD reset their limit early. Must be called with `_lock`
-        held.
-        """
-        stale = [
-            key
-            for key, bucket in self._buckets.items()
-            if bucket.tokens + (now - bucket.last_refill) * bucket.rate >= bucket.capacity
-        ]
-        for key in stale:
-            del self._buckets[key]
 
     def client_ip(self, environ: dict) -> str:
-        if self.config.trust_proxy:
-            xff = environ.get("HTTP_X_FORWARDED_FOR", "")
-            if xff:
-                first = xff.split(",", 1)[0].strip()
-                if first:
-                    return first
-        return environ.get("REMOTE_ADDR", "unknown")
+        return resolve_client_ip(environ, self.config.trust_proxy)
 
     def _rule_for_path(self, path: str) -> Tuple[int, str]:
         """Return (rpm, rule_key). Longest matching prefix wins."""
@@ -154,26 +107,12 @@ class RateLimiter:
         path = environ.get("PATH_INFO", "/")
         ip = self.client_ip(environ)
         rpm, rule_key = self._rule_for_path(path)
-        scope_key = (ip, rule_key)
 
-        with self._lock:
-            now = time.monotonic()
-            if now - self._last_sweep >= _SWEEP_INTERVAL_SECONDS:
-                self._sweep_idle_buckets(now)
-                self._last_sweep = now
-
-            bucket = self._buckets.get(scope_key)
-            if bucket is None or bucket.capacity != rpm:
-                bucket = _TokenBucket(capacity=rpm, rate=rpm / 60.0)
-                self._buckets[scope_key] = bucket
-            allowed = bucket.take()
-            remaining = max(0, int(bucket.tokens))
+        allowed, remaining = self.check_key((ip, rule_key), rpm, rpm / 60.0)
 
         info = {"limit": rpm, "remaining": remaining, "retry_after": 0}
         if not allowed:
-            # Seconds until 1 token regenerates; ceil to at least 1.
-            seconds_per_token = 60.0 / rpm if rpm > 0 else 60.0
-            info["retry_after"] = max(1, int(seconds_per_token + 0.999))
+            info["retry_after"] = retry_after_seconds(rpm)
         return allowed, info
 
 

--- a/fymo/core/ratelimit.py
+++ b/fymo/core/ratelimit.py
@@ -1,0 +1,125 @@
+"""Shared in-process token-bucket core.
+
+Two limiters use this: the WSGI middleware's path-prefix limiter
+(fymo.core.middleware.RateLimiter) and the remote router's per-function
+limiter (fymo.remote.rate_limit). They differ only in how they derive a
+bucket key and a capacity for a given request; the bucket mechanics,
+locking, and idle-bucket eviction are identical and live here so the two
+cannot drift apart.
+
+Same deployment story as the middleware: single-process only. Distributed
+(Redis-backed) rate limiting is intentionally not in v1.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Hashable, Tuple
+
+
+class _TokenBucket:
+    __slots__ = ("tokens", "last_refill", "capacity", "rate")
+
+    def __init__(self, capacity: int, rate: float):
+        self.tokens: float = float(capacity)
+        self.last_refill = time.monotonic()
+        self.capacity = capacity
+        self.rate = rate  # tokens per second
+
+    def take(self) -> bool:
+        now = time.monotonic()
+        self.tokens = min(self.capacity, self.tokens + (now - self.last_refill) * self.rate)
+        self.last_refill = now
+        if self.tokens >= 1.0:
+            self.tokens -= 1.0
+            return True
+        return False
+
+
+#: How often (in seconds) `BucketRegistry.check_key` opportunistically sweeps
+#: idle buckets. A dedicated background thread isn't worth it for this,
+#: request traffic itself drives the sweep, and a 60s cadence bounds the
+#: sweep's own overhead to well under the cost of the token-bucket check it
+#: rides along with.
+_SWEEP_INTERVAL_SECONDS = 60.0
+
+
+class BucketRegistry:
+    """A keyed collection of token buckets with bounded memory.
+
+    `_buckets` is otherwise unbounded: every distinct key seen gets its own
+    entry that nothing ever removes, so a long-running process fielding
+    traffic from many distinct clients (the normal case for anything
+    public-facing) leaks memory for as long as it runs. `check_key`
+    opportunistically sweeps idle buckets to bound this.
+    """
+
+    def __init__(self):
+        self._buckets: Dict[Hashable, _TokenBucket] = {}
+        self._lock = threading.Lock()
+        self._last_sweep = time.monotonic()
+
+    def _sweep_idle_buckets(self, now: float) -> None:
+        """Drop buckets that have fully refilled since their last request.
+
+        A fully-refilled bucket carries no state a brand-new one wouldn't
+        also have (both start at `capacity` tokens), so evicting it doesn't
+        change any client-visible behavior, the next request for that key
+        just lazily recreates an identical bucket. Buckets with partial
+        state (a client currently being throttled, or one that hasn't been
+        idle long enough to fully refill) are left alone, since dropping
+        those WOULD reset their limit early. Must be called with `_lock`
+        held.
+        """
+        stale = [
+            key
+            for key, bucket in self._buckets.items()
+            if bucket.tokens + (now - bucket.last_refill) * bucket.rate >= bucket.capacity
+        ]
+        for key in stale:
+            del self._buckets[key]
+
+    def check_key(self, key: Hashable, capacity: int, rate: float) -> Tuple[bool, int]:
+        """Take one token from the bucket for `key`; return (allowed, remaining).
+
+        Lazily creates the bucket on first sight of a key, and replaces it
+        when the configured capacity changed (a config edit shouldn't keep
+        serving out of a stale-sized bucket).
+        """
+        with self._lock:
+            now = time.monotonic()
+            if now - self._last_sweep >= _SWEEP_INTERVAL_SECONDS:
+                self._sweep_idle_buckets(now)
+                self._last_sweep = now
+
+            bucket = self._buckets.get(key)
+            if bucket is None or bucket.capacity != capacity:
+                bucket = _TokenBucket(capacity=capacity, rate=rate)
+                self._buckets[key] = bucket
+            allowed = bucket.take()
+            remaining = max(0, int(bucket.tokens))
+        return allowed, remaining
+
+
+def resolve_client_ip(environ: dict, trust_proxy: bool) -> str:
+    """Return the client IP for rate-limit keying.
+
+    When `trust_proxy` is on, the first hop in X-Forwarded-For is treated as
+    the client IP. Only safe behind a trusted reverse proxy that overwrites
+    the header (the same trust boundary as `resolve_scheme` /
+    X-Forwarded-Proto).
+    """
+    if trust_proxy:
+        xff = environ.get("HTTP_X_FORWARDED_FOR", "")
+        if xff:
+            first = xff.split(",", 1)[0].strip()
+            if first:
+                return first
+    return environ.get("REMOTE_ADDR", "unknown")
+
+
+def retry_after_seconds(rpm: int) -> int:
+    """Seconds until one token regenerates at `rpm` tokens/minute; ceil to at
+    least 1 to be useful as a Retry-After value."""
+    seconds_per_token = 60.0 / rpm if rpm > 0 else 60.0
+    return max(1, int(seconds_per_token + 0.999))

--- a/fymo/remote/__init__.py
+++ b/fymo/remote/__init__.py
@@ -1,10 +1,11 @@
 """Fymo remote functions: server-only Python callable from Svelte components."""
-from fymo.remote.errors import RemoteError, NotFound, Unauthorized, Forbidden, Conflict
+from fymo.remote.errors import RemoteError, NotFound, Unauthorized, Forbidden, Conflict, RateLimited
 from fymo.remote.identity import current_uid
 from fymo.remote.context import request_event
 from fymo.remote.decorators import remote
+from fymo.remote.rate_limit import rate_limit
 
 __all__ = [
-    "RemoteError", "NotFound", "Unauthorized", "Forbidden", "Conflict",
-    "current_uid", "request_event", "remote",
+    "RemoteError", "NotFound", "Unauthorized", "Forbidden", "Conflict", "RateLimited",
+    "current_uid", "request_event", "remote", "rate_limit",
 ]

--- a/fymo/remote/errors.py
+++ b/fymo/remote/errors.py
@@ -32,3 +32,15 @@ class Forbidden(RemoteError):
 class Conflict(RemoteError):
     status = 409
     code = "conflict"
+
+
+class RateLimited(RemoteError):
+    """Too many requests for a @rate_limit-decorated function (or raised
+    manually by app code). `retry_after` is seconds until the caller may
+    try again; the router surfaces it in the error envelope."""
+    status = 429
+    code = "rate_limited"
+
+    def __init__(self, message: str = "rate limit exceeded", *, retry_after: int = 1):
+        super().__init__(message)
+        self.retry_after = retry_after

--- a/fymo/remote/rate_limit.py
+++ b/fymo/remote/rate_limit.py
@@ -1,0 +1,173 @@
+"""Per-function rate limiting for remote functions.
+
+The middleware limiter (fymo.core.middleware.RateLimiter) is keyed by
+(IP, path-prefix rule), so every function behind /_fymo/remote/ shares one
+budget. That's the wrong granularity when one function is expensive or
+costs real money per call (an LLM call, a paid third-party API) while its
+module neighbors are cheap reads. @rate_limit gives that one function its
+own budget, enforced by the router at dispatch time (after the function
+is resolved, before its arguments are even parsed).
+
+Same marker-attribute pattern as @remote's __fymo_remote__ and
+@require_auth's __fymo_require_auth__: the decorator stamps configuration
+on the function object and returns it unchanged, so the marker survives
+functools.wraps stacking in any decorator order.
+
+Buckets are per (function, scope-key), in-process, sharing the middleware
+limiter's token-bucket core and idle-bucket sweep (fymo.core.ratelimit) so
+memory stays bounded. Both limiters stack: the middleware's path-prefix
+budget still applies at the WSGI edge.
+
+No fymo.yml surface: configuration is per-function and lives next to the
+code it protects.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http.cookies import SimpleCookie
+from typing import Callable, Optional, TypeVar
+
+from fymo.core.ratelimit import BucketRegistry, resolve_client_ip, retry_after_seconds
+from fymo.remote.errors import RateLimited
+from fymo.remote.identity import _UID_COOKIE, _read_cookie, _verify
+
+F = TypeVar("F", bound=Callable)
+
+_VALID_SCOPES = ("ip", "user", "uid")
+
+
+@dataclass(frozen=True)
+class RateLimitRule:
+    per_minute: int
+    scope: str
+
+
+def rate_limit(per_minute: int, scope: str = "ip") -> Callable[[F], F]:
+    """Give this remote function its own token-bucket budget.
+
+    `per_minute` is the bucket capacity (and refill rate, in tokens per
+    minute). `scope` picks what a "caller" is:
+
+    - "ip":   the client IP, resolved with the same trust_proxy awareness
+              as the middleware limiter (first X-Forwarded-For hop only
+              when `limits.rate_limit.trust_proxy` is on).
+    - "user": the authenticated user's id. When the caller is not signed
+              in, falls back to the verified fymo_uid cookie identity if
+              present, else the client IP, so the limit always binds rather
+              than silently not applying.
+    - "uid":  the verified fymo_uid anonymous identity, falling back to
+              the client IP when the cookie is missing or fails HMAC
+              verification (a cookieless caller must not get a fresh
+              bucket per request).
+
+    Stamps `__fymo_rate_limit__` and returns the function unchanged, so it
+    composes with @remote and @require_auth in any order.
+    """
+    if scope not in _VALID_SCOPES:
+        raise ValueError(f"rate_limit scope must be one of {_VALID_SCOPES}, got {scope!r}")
+    if not isinstance(per_minute, int) or per_minute < 1:
+        raise ValueError(f"rate_limit per_minute must be a positive int, got {per_minute!r}")
+
+    rule = RateLimitRule(per_minute=per_minute, scope=scope)
+
+    def decorate(fn: F) -> F:
+        fn.__fymo_rate_limit__ = rule
+        return fn
+
+    return decorate
+
+
+# One registry for the whole process, keyed by ((module, fn_name), scope_key).
+# Same seam pattern as identity._secret / auth_context._user_store: the
+# remote-function world has no FymoApp reference, so process-wide state lives
+# at module level.
+_registry = BucketRegistry()
+
+
+def reset_rate_limit_state() -> None:
+    """Drop every bucket (tests / re-init)."""
+    global _registry
+    _registry = BucketRegistry()
+
+
+def _cookies_from_environ(environ: dict) -> dict:
+    cookies: dict = {}
+    if environ.get("HTTP_COOKIE"):
+        c = SimpleCookie()
+        c.load(environ["HTTP_COOKIE"])
+        cookies = {k: v.value for k, v in c.items()}
+    return cookies
+
+
+def _authenticated_user_id(environ: dict) -> Optional[int]:
+    """Resolve the signed-in user's id, or None.
+
+    Walks the same resolver chain current_user() does, but against an event
+    built straight from the environ, since enforcement runs before the
+    router opens the request scope. A resolver blowing up (e.g. a stale
+    fymo_session cookie on an app with auth disabled, where the UserStore
+    seam raises) counts as "not signed in" for limiting purposes rather
+    than failing the request.
+    """
+    try:
+        from fymo.auth.context import _fymo_session_resolver, _session_resolvers
+    except ImportError:
+        return None
+    event = {
+        "cookies": _cookies_from_environ(environ),
+        "headers": {
+            k[5:].replace("_", "-").lower(): v
+            for k, v in environ.items() if k.startswith("HTTP_")
+        },
+        "remote_addr": environ.get("REMOTE_ADDR", ""),
+    }
+    for resolve in (_fymo_session_resolver, *_session_resolvers):
+        try:
+            user = resolve(event)
+        except Exception:
+            continue
+        if user is not None:
+            return user.id
+    return None
+
+
+def _verified_uid(environ: dict) -> Optional[str]:
+    """The fymo_uid cookie's uid, only if it HMAC-verifies. Never mints a
+    fresh uid: a cookieless retry loop would then get a new bucket per
+    request and the limit would never bind."""
+    raw = _read_cookie(environ, _UID_COOKIE)
+    if raw is None:
+        return None
+    return _verify(raw)
+
+
+def _scope_key(rule: RateLimitRule, environ: dict) -> str:
+    """Map (rule.scope, request) to a bucket-key string.
+
+    Keys are prefixed by kind ("user:", "uid:", "ip:") so a fallback key can
+    never collide with a different scope's bucket for the same string.
+    """
+    if rule.scope == "user":
+        user_id = _authenticated_user_id(environ)
+        if user_id is not None:
+            return f"user:{user_id}"
+    if rule.scope in ("user", "uid"):
+        uid = _verified_uid(environ)
+        if uid is not None:
+            return f"uid:{uid}"
+    from fymo.remote import context as _context
+    return "ip:" + resolve_client_ip(environ, _context._trust_proxy)
+
+
+def enforce_rate_limit(fn: Callable, fn_key: "tuple[str, str]", environ: dict) -> Optional[RateLimited]:
+    """Take a token for this call; return a RateLimited to serialize when
+    the function's budget is exhausted, None when the call may proceed (or
+    the function carries no @rate_limit marker)."""
+    rule: Optional[RateLimitRule] = getattr(fn, "__fymo_rate_limit__", None)
+    if rule is None:
+        return None
+    key = (fn_key, _scope_key(rule, environ))
+    allowed, _remaining = _registry.check_key(key, rule.per_minute, rule.per_minute / 60.0)
+    if allowed:
+        return None
+    return RateLimited(retry_after=retry_after_seconds(rule.per_minute))

--- a/fymo/remote/rate_limit.py
+++ b/fymo/remote/rate_limit.py
@@ -60,6 +60,21 @@ def rate_limit(per_minute: int, scope: str = "ip") -> Callable[[F], F]:
               verification (a cookieless caller must not get a fresh
               bucket per request).
 
+    Two cost/threat trade-offs to know when picking a scope:
+
+    - scope="user" resolves the session BEFORE the limit binds, so every
+      request carrying auth credentials pays the resolver walk (for a
+      token provider like Clerk, a JWT verification) even when the answer
+      is 429. That is the same cost any function calling current_user()
+      already pays per request; the middleware's IP-keyed edge limiter is
+      what bounds it. The per-user budget protects the function body and
+      whatever it spends, not the session resolution itself.
+    - scope="uid" (and unauthenticated scope="user") keys on a cookie the
+      server hands out freely, so a determined client can farm several
+      valid cookies and rotate them for extra budget. It defends against
+      accidental retry loops and over-eager polling, not adversaries; for
+      adversarial traffic, "ip" (or the edge limiter) is the backstop.
+
     Stamps `__fymo_rate_limit__` and returns the function unchanged, so it
     composes with @remote and @require_auth in any order.
     """
@@ -113,6 +128,15 @@ def _authenticated_user_id(environ: dict) -> Optional[int]:
         from fymo.auth.context import _fymo_session_resolver, _session_resolvers
     except ImportError:
         return None
+    # Mirror request_scope's event shape (fymo/remote/context.py), same
+    # trust_proxy-aware scheme resolution included: a resolver reading a
+    # key that's absent here would KeyError, get swallowed by the except
+    # below, and silently degrade the scope to uid/ip instead of surfacing
+    # the mismatch. "uid" is the one deliberate omission, it isn't resolved
+    # until the router opens the real scope, and no session resolver reads
+    # it (a session is what identifies the caller here, not the anon uid).
+    from fymo.core.middleware import resolve_scheme
+    from fymo.remote import context as _context
     event = {
         "cookies": _cookies_from_environ(environ),
         "headers": {
@@ -120,6 +144,7 @@ def _authenticated_user_id(environ: dict) -> Optional[int]:
             for k, v in environ.items() if k.startswith("HTTP_")
         },
         "remote_addr": environ.get("REMOTE_ADDR", ""),
+        "scheme": resolve_scheme(environ, _context._trust_proxy),
     }
     for resolve in (_fymo_session_resolver, *_session_resolvers):
         try:

--- a/fymo/remote/router.py
+++ b/fymo/remote/router.py
@@ -15,6 +15,7 @@ from fymo.remote.context import request_scope
 from fymo.remote.discovery import is_exposed_remote_fn
 from fymo.remote.errors import RemoteError
 from fymo.remote.identity import _ensure_uid
+from fymo.remote.rate_limit import enforce_rate_limit
 
 try:
     import pydantic
@@ -63,6 +64,16 @@ def _200(
             headers.append(("Set-Cookie", c))
     start_response("200 OK", headers)
     return [body]
+
+
+def _remote_error_payload(e: RemoteError) -> dict:
+    """Envelope body for a RemoteError. RateLimited additionally carries
+    retry_after, surfaced so clients can back off instead of retrying blind."""
+    payload = {"type": "error", "status": e.status, "error": e.code, "message": str(e)}
+    retry_after = getattr(e, "retry_after", None)
+    if retry_after is not None:
+        payload["retry_after"] = retry_after
+    return payload
 
 
 def _b64url_decode(s: str) -> str:
@@ -210,6 +221,13 @@ def handle_remote(environ: dict, start_response) -> Iterable[bytes]:
     if fn is None:
         return _200(start_response, {"type": "error", "status": 404, "error": "unknown_function"})
 
+    # 5b. Per-function rate limit (@rate_limit marker). Checked before body
+    # parse and arg validation: an over-budget caller shouldn't cost us
+    # anything beyond the token-bucket lookup.
+    limited = enforce_rate_limit(fn, (module_name, fn_name), environ)
+    if limited is not None:
+        return _200(start_response, _remote_error_payload(limited))
+
     # 6. Body parse + payload decode
     try:
         length = int(environ.get("CONTENT_LENGTH") or 0)
@@ -254,11 +272,7 @@ def handle_remote(environ: dict, start_response) -> Iterable[bytes]:
                 result = fn(*validated)
         except RemoteError as e:
             extra_cookies = consume_pending_cookies()
-            return _200(
-                start_response,
-                {"type": "error", "status": e.status, "error": e.code, "message": str(e)},
-                set_cookie, extra_cookies,
-            )
+            return _200(start_response, _remote_error_payload(e), set_cookie, extra_cookies)
         except Exception as e:
             extra_cookies = consume_pending_cookies()
             payload = {"type": "error", "status": 500, "error": "internal"}

--- a/fymo/remote/router.py
+++ b/fymo/remote/router.py
@@ -222,8 +222,11 @@ def handle_remote(environ: dict, start_response) -> Iterable[bytes]:
         return _200(start_response, {"type": "error", "status": 404, "error": "unknown_function"})
 
     # 5b. Per-function rate limit (@rate_limit marker). Checked before body
-    # parse and arg validation: an over-budget caller shouldn't cost us
-    # anything beyond the token-bucket lookup.
+    # parse and arg validation so an over-budget caller never reaches the
+    # function or its validation. For scope="ip"/"uid" the check costs only
+    # a cookie HMAC and a token-bucket lookup; scope="user" additionally
+    # pays a session-resolution pass (see rate_limit.py's docstring for the
+    # cost trade-off, which the WSGI edge limiter bounds).
     limited = enforce_rate_limit(fn, (module_name, fn_name), environ)
     if limited is not None:
         return _200(start_response, _remote_error_payload(limited))

--- a/journal/journal_026.md
+++ b/journal/journal_026.md
@@ -1,0 +1,140 @@
+# Journal Entry 026: One Expensive Function Shouldn't Share a Budget With Its Cheap Neighbors
+
+**Date**: July 16, 2026
+**Focus**: Per-function rate limiting for remote functions (issue #54)
+**Status**: Shipped
+
+## The Shape of the Complaint
+
+The middleware rate limiter works, and I still like it: token buckets
+keyed by client IP and path prefix, in-process, no Redis, opportunistic
+sweep so memory stays bounded. But the key is the problem. Everything
+under `/_fymo/remote/` matches one prefix rule, which means the function
+that calls an LLM and costs actual money per invocation draws from the
+exact same budget as the function that reads three rows out of SQLite.
+A retry loop against the expensive one, or a component polling it a
+little too eagerly, turns into uncapped real cost, and the only defense
+was hand-rolling a second limiter inside your own app code. The issue
+asked for something narrow: the same in-process token-bucket approach,
+just scoped to a single function. Not distributed limiting. That's still
+a v2 problem and I wrote as much in the middleware docstring months ago.
+
+## The Decorator Is the Easy Part
+
+fymo already has a house pattern for "attach metadata to a remote
+function without wrapping it": `@remote` stamps `__fymo_remote__`,
+`@require_auth` stamps `__fymo_require_auth__` after `functools.wraps`
+has done its dict-copying, and there's a test file whose whole job is
+proving the markers survive every stacking order. So `@rate_limit`
+does the same thing:
+
+```python
+@remote
+@require_auth
+@rate_limit(per_minute=3, scope="user")
+def do_the_expensive_thing(...): ...
+```
+
+It stamps a frozen `RateLimitRule` on the function and returns the
+function untouched. No wrapper means signature reflection and the
+router's identity-keyed signature cache never notice it exists. I wrote
+the stacking-order tests first, all six permutations that matter, and
+watched them fail with a `ModuleNotFoundError` before the module
+existed. Cheap insurance, and it caught nothing this time, which is
+what it's supposed to do most of the time.
+
+## Not Duplicating the Bucket
+
+The tempting shortcut was a little dict of buckets inside the new
+module. I've been burned by that exact move before: entry 012 was
+partly about two copies of one rule drifting until the drift became a
+dispatch bug. The middleware's limiter already had everything the new
+one needs, the bucket math, the lock, and crucially the idle-bucket
+sweep that keeps a long-running process from leaking one bucket per
+client forever. What it didn't have was a seam: bucket mechanics and
+WSGI policy (path rules, environ, config) lived in one class.
+
+So the mechanics moved to `fymo/core/ratelimit.py`: the token bucket,
+a `BucketRegistry` owning the lock and the sweep and a single
+`check_key(key, capacity, rate)` primitive, plus the trust_proxy-aware
+client-IP resolution and the retry-after math. The middleware's
+`RateLimiter` now subclasses the registry and keeps only its policy.
+Inheritance over composition here for a blunt reason: the middleware
+tests poke `rl._buckets` and `rl._last_sweep` directly, and I wanted
+those tests passing byte-for-byte unchanged as the proof that behavior
+didn't move. They do. The old names (`_TokenBucket`,
+`_SWEEP_INTERVAL_SECONDS`) re-export from the middleware module since
+that was their original home.
+
+## Scope Is Where the Thinking Was
+
+`per_minute` is easy. `scope` is the part the issue was actually about:
+for a cost-sensitive authenticated mutation, the limit that helps is
+"per signed-in user," not "per IP" (one NAT'd office shouldn't share a
+budget, and one abuser shouldn't get a fresh budget per coffee shop).
+Three scopes, each with a decided fallback rather than a silent no-op:
+
+- `ip` resolves the client the same way the middleware does, first
+  X-Forwarded-For hop only when `trust_proxy` is on. Same trust
+  boundary, same function, literally shared code now.
+- `uid` keys on the `fymo_uid` cookie, but only if the HMAC verifies.
+  A forged or missing cookie falls back to IP. The subtle trap here:
+  the router happily *issues* a fresh uid to a cookieless caller, so
+  keying on "the uid this request will end up with" would hand a retry
+  loop a brand-new bucket per request. Only an existing verified
+  cookie counts.
+- `user` keys on the authenticated user's id. Unauthenticated callers
+  fall down the uid chain, then IP. The limit always binds on
+  something.
+
+One wrinkle: enforcement runs right after the function resolves,
+before body parse and argument validation, because an over-budget
+caller shouldn't cost more than a dict lookup. But that's also before
+the router opens its request scope, and `current_user()` refuses to
+run outside one. So the scope-key resolver builds the same event shape
+from the raw environ and walks the same resolver chain directly. A
+resolver blowing up (say, a stale session cookie on an app that never
+enabled auth, where the UserStore seam raises) counts as "not signed
+in" and falls through, instead of turning a rate-limit check into a
+500.
+
+## The Envelope
+
+Over-limit responses go through the same machinery as every other
+domain error: a new `RateLimited(RemoteError)` with status 429, code
+`rate_limited`, and a `retry_after` the router now surfaces in the
+envelope, transported over HTTP 200 like all envelope errors. App code
+can raise it manually too and gets the identical shape. I resisted
+adding rate-limit headers to this path; the middleware's 429 already
+does headers for the transport-level case, and the envelope is the
+contract the `$remote` client actually reads.
+
+## Proving It Outside Pytest
+
+Unit tests can lie about wiring, so I scaffolded a throwaway copy of
+the todo example, added a `@remote @rate_limit(per_minute=2)` function,
+ran a real `fymo build`, served it with wsgiref, and curled it three
+times. First two: `{"type": "result", "result": "[\"charged\"]"}`.
+Third: `{"type": "error", "status": 429, "error": "rate_limited",
+"retry_after": 30}`. The build's hygiene check also earned its keep by
+refusing to build until the function carried `@remote`, which
+incidentally exercised the exact decorator stack from the issue sketch
+against real code rather than a test fixture.
+
+The suite sits at 810 passing, up from 784, with every pre-existing
+middleware limiter test untouched and green.
+
+## What I Left Out
+
+No `fymo.yml` surface. The configuration is per-function and belongs
+next to the function it protects; a yml override layer (tighten a limit
+at deploy time without touching code) could sit on top of the same
+marker later if anyone needs it. And still no cross-worker sharing:
+both limiters are per-process by design, and the honest place to fix
+that is a shared backend for `BucketRegistry`, which is now one class
+instead of two scattered dicts. That was the other quiet payoff of not
+duplicating the bucket.
+
+---
+
+*End of Journal Entry 026*

--- a/tests/remote/test_rate_limit.py
+++ b/tests/remote/test_rate_limit.py
@@ -109,16 +109,31 @@ def test_marker_survives_rate_limit_above_require_auth():
     assert getattr(expensive, "__fymo_require_auth__", False) is True
 
 
-def test_all_three_markers_survive_full_stack():
-    @remote
-    @require_auth
-    @rate_limit(per_minute=3, scope="user")
-    def expensive() -> str:
-        return "x"
+def test_all_three_markers_survive_every_stacking_order():
+    """All six permutations of @remote/@require_auth/@rate_limit. Only
+    require_auth wraps (and functools.wraps copies the inner __dict__), so
+    every order must preserve all three markers; a regression in any one
+    decorator's stamping strategy shows up as the failing order's name."""
+    import itertools
 
-    assert expensive.__fymo_rate_limit__.per_minute == 3
-    assert getattr(expensive, "__fymo_remote__", False) is True
-    assert getattr(expensive, "__fymo_require_auth__", False) is True
+    decorators = {
+        "remote": remote,
+        "require_auth": require_auth,
+        "rate_limit": rate_limit(per_minute=3, scope="user"),
+    }
+    for order in itertools.permutations(decorators):
+        def expensive() -> str:
+            return "x"
+        fn = expensive
+        # Apply innermost-first, i.e. reversed(order) matches reading the
+        # stack top-down as @order[0] / @order[1] / @order[2].
+        for name in reversed(order):
+            fn = decorators[name](fn)
+
+        assert getattr(fn, "__fymo_rate_limit__", None) is not None, order
+        assert fn.__fymo_rate_limit__.per_minute == 3, order
+        assert getattr(fn, "__fymo_remote__", False) is True, order
+        assert getattr(fn, "__fymo_require_auth__", False) is True, order
 
 
 def test_rate_limit_exported_from_fymo_remote():

--- a/tests/remote/test_rate_limit.py
+++ b/tests/remote/test_rate_limit.py
@@ -1,0 +1,128 @@
+"""Unit tests for fymo.remote.rate_limit's @rate_limit marker decorator.
+
+The decorator stamps configuration on the function object (the same
+marker-attribute pattern as @remote's __fymo_remote__ and @require_auth's
+__fymo_require_auth__) so the router can enforce a per-function budget at
+dispatch time. The marker must survive functools.wraps stacking in any
+decorator order, mirroring tests/auth/test_context.py.
+"""
+import pytest
+
+from fymo.auth.context import require_auth
+from fymo.remote.decorators import remote
+from fymo.remote.rate_limit import rate_limit
+
+
+def test_rate_limit_stamps_marker_attribute():
+    @rate_limit(per_minute=3)
+    def expensive() -> str:
+        return "x"
+
+    rule = getattr(expensive, "__fymo_rate_limit__", None)
+    assert rule is not None
+    assert rule.per_minute == 3
+    assert rule.scope == "ip"
+
+
+def test_explicit_scope_is_stored():
+    @rate_limit(per_minute=5, scope="user")
+    def expensive() -> str:
+        return "x"
+
+    rule = expensive.__fymo_rate_limit__
+    assert rule.per_minute == 5
+    assert rule.scope == "user"
+
+
+def test_undecorated_function_has_no_marker():
+    def plain() -> str:
+        return "x"
+
+    assert getattr(plain, "__fymo_rate_limit__", None) is None
+
+
+def test_decorator_returns_function_unchanged():
+    """No wrapper: like @remote, it only stamps and hands the same object back,
+    so signature reflection and identity-keyed caches are unaffected."""
+    def expensive() -> str:
+        return "x"
+
+    assert rate_limit(per_minute=3)(expensive) is expensive
+
+
+def test_invalid_scope_raises_value_error():
+    with pytest.raises(ValueError, match="scope"):
+        @rate_limit(per_minute=3, scope="galaxy")
+        def expensive() -> str:
+            return "x"
+
+
+def test_per_minute_below_one_raises_value_error():
+    with pytest.raises(ValueError, match="per_minute"):
+        @rate_limit(per_minute=0)
+        def expensive() -> str:
+            return "x"
+
+
+# ---------------- stacking orders ----------------
+
+
+def test_marker_survives_remote_above_rate_limit():
+    @remote
+    @rate_limit(per_minute=3)
+    def expensive() -> str:
+        return "x"
+
+    assert expensive.__fymo_rate_limit__.per_minute == 3
+    assert getattr(expensive, "__fymo_remote__", False) is True
+
+
+def test_marker_survives_rate_limit_above_remote():
+    @rate_limit(per_minute=3)
+    @remote
+    def expensive() -> str:
+        return "x"
+
+    assert expensive.__fymo_rate_limit__.per_minute == 3
+    assert getattr(expensive, "__fymo_remote__", False) is True
+
+
+def test_marker_survives_require_auth_above_rate_limit():
+    """@require_auth wraps with functools.wraps, which copies the inner
+    function's __dict__ (carrying __fymo_rate_limit__) onto the wrapper."""
+    @require_auth
+    @rate_limit(per_minute=3, scope="user")
+    def expensive() -> str:
+        return "x"
+
+    assert expensive.__fymo_rate_limit__.scope == "user"
+    assert getattr(expensive, "__fymo_require_auth__", False) is True
+
+
+def test_marker_survives_rate_limit_above_require_auth():
+    @rate_limit(per_minute=3, scope="user")
+    @require_auth
+    def expensive() -> str:
+        return "x"
+
+    assert expensive.__fymo_rate_limit__.scope == "user"
+    assert getattr(expensive, "__fymo_require_auth__", False) is True
+
+
+def test_all_three_markers_survive_full_stack():
+    @remote
+    @require_auth
+    @rate_limit(per_minute=3, scope="user")
+    def expensive() -> str:
+        return "x"
+
+    assert expensive.__fymo_rate_limit__.per_minute == 3
+    assert getattr(expensive, "__fymo_remote__", False) is True
+    assert getattr(expensive, "__fymo_require_auth__", False) is True
+
+
+def test_rate_limit_exported_from_fymo_remote():
+    import fymo.remote
+
+    assert fymo.remote.rate_limit is rate_limit
+    assert issubclass(fymo.remote.RateLimited, fymo.remote.RemoteError)

--- a/tests/remote/test_router_rate_limit.py
+++ b/tests/remote/test_router_rate_limit.py
@@ -1,0 +1,322 @@
+"""Router enforcement of @rate_limit: per-(function, scope-key) budgets
+checked at dispatch time, before the function runs.
+
+Over-limit responses use the standard envelope over HTTP 200, matching
+every other RemoteError the router serializes.
+"""
+import base64
+import io
+import json
+import sys
+
+import pytest
+
+from fymo.remote import devalue
+from fymo.remote import router as router_mod
+from fymo.remote.identity import _sign
+from fymo.remote.rate_limit import reset_rate_limit_state
+
+
+MODULE_SRC = (
+    "from fymo.remote import rate_limit\n"
+    "@rate_limit(per_minute=2)\n"
+    "def pricey() -> str: return 'paid'\n"
+    "def cheap() -> str: return 'free'\n"
+    "@rate_limit(per_minute=2, scope='uid')\n"
+    "def per_uid() -> str: return 'uid-scoped'\n"
+    "@rate_limit(per_minute=1, scope='user')\n"
+    "def per_user() -> str: return 'user-scoped'\n"
+)
+
+
+def _scaffold(tmp_path, files):
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return tmp_path
+
+
+def _b64url(s: str) -> str:
+    return base64.urlsafe_b64encode(s.encode("utf-8")).rstrip(b"=").decode("ascii")
+
+
+def _make_environ(path: str, args: list, *, cookies: str = "", ip: str = "127.0.0.1",
+                  xff: str | None = None):
+    body_obj = {"payload": _b64url(devalue.stringify(args))}
+    raw = json.dumps(body_obj).encode()
+    env = {
+        "REQUEST_METHOD": "POST",
+        "PATH_INFO": path,
+        "CONTENT_LENGTH": str(len(raw)),
+        "CONTENT_TYPE": "application/json",
+        "HTTP_COOKIE": cookies,
+        "HTTP_HOST": "x",
+        "HTTP_ORIGIN": "http://x",
+        "wsgi.url_scheme": "http",
+        "REMOTE_ADDR": ip,
+        "wsgi.input": io.BytesIO(raw),
+    }
+    if xff is not None:
+        env["HTTP_X_FORWARDED_FOR"] = xff
+    return env
+
+
+def _call(environ):
+    responses = []
+    def sr(status, headers): responses.append((status, headers))
+    body = b"".join(router_mod.handle_remote(environ, sr))
+    return responses[0], json.loads(body)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_buckets():
+    reset_rate_limit_state()
+    yield
+    reset_rate_limit_state()
+
+
+@pytest.fixture
+def limited_project(tmp_path, monkeypatch):
+    proj = _scaffold(tmp_path, {
+        "app/__init__.py": "",
+        "app/remote/__init__.py": "",
+        "app/remote/billing.py": MODULE_SRC,
+    })
+    monkeypatch.syspath_prepend(str(proj))
+
+    from fymo.remote.discovery import file_hash
+    h = file_hash(proj / "app/remote/billing.py")
+    monkeypatch.setattr(
+        router_mod, "_resolve_module_for_hash",
+        lambda hash_: "billing" if hash_ == h else None,
+    )
+
+    yield proj, h
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
+
+
+def _uid_cookie(uid: str) -> str:
+    return f"fymo_uid={uid}.{_sign(uid)}"
+
+
+# ---------------- ip scope ----------------
+
+
+def test_under_limit_passes(limited_project):
+    _, h = limited_project
+    for _ in range(2):
+        (status, _), body = _call(_make_environ(f"/_fymo/remote/{h}/pricey", []))
+        assert status.startswith("200")
+        assert body["type"] == "result"
+        assert devalue.parse(body["result"]) == "paid"
+
+
+def test_over_limit_returns_429_envelope_over_http_200(limited_project):
+    _, h = limited_project
+    _call(_make_environ(f"/_fymo/remote/{h}/pricey", []))
+    _call(_make_environ(f"/_fymo/remote/{h}/pricey", []))
+    (status, _), body = _call(_make_environ(f"/_fymo/remote/{h}/pricey", []))
+    assert status.startswith("200")
+    assert body["type"] == "error"
+    assert body["status"] == 429
+    assert body["error"] == "rate_limited"
+    assert body["retry_after"] >= 1
+
+
+def test_other_functions_in_module_unaffected(limited_project):
+    _, h = limited_project
+    for _ in range(3):
+        _call(_make_environ(f"/_fymo/remote/{h}/pricey", []))
+    (_, _), body = _call(_make_environ(f"/_fymo/remote/{h}/cheap", []))
+    assert body["type"] == "result"
+    assert devalue.parse(body["result"]) == "free"
+
+
+def test_separate_ips_get_separate_buckets(limited_project):
+    _, h = limited_project
+    for _ in range(2):
+        _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="1.1.1.1"))
+    (_, _), blocked = _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="1.1.1.1"))
+    assert blocked["status"] == 429
+    (_, _), other = _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="2.2.2.2"))
+    assert other["type"] == "result"
+
+
+def test_ip_scope_honors_trust_proxy_xff(limited_project, monkeypatch):
+    """Same trust boundary as the middleware limiter: the forwarded hop only
+    counts when the app was configured with trust_proxy on."""
+    _, h = limited_project
+    from fymo.remote import context as context_mod
+    monkeypatch.setattr(context_mod, "_trust_proxy", True)
+    for _ in range(2):
+        _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="10.0.0.1", xff="9.9.9.9"))
+    (_, _), blocked = _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="10.0.0.1", xff="9.9.9.9"))
+    assert blocked["status"] == 429
+    # A different forwarded client behind the same proxy gets a fresh bucket.
+    (_, _), other = _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="10.0.0.1", xff="8.8.8.8"))
+    assert other["type"] == "result"
+
+
+def test_ip_scope_ignores_xff_without_trust_proxy(limited_project):
+    _, h = limited_project
+    for _ in range(2):
+        _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="10.0.0.1", xff="9.9.9.9"))
+    (_, _), blocked = _call(_make_environ(f"/_fymo/remote/{h}/pricey", [], ip="10.0.0.1", xff="SPOOFED"))
+    assert blocked["status"] == 429
+
+
+def test_function_never_runs_when_over_limit(limited_project, tmp_path):
+    """Enforcement happens before dispatch: a limited call must not produce
+    the function's side effects."""
+    proj, _ = limited_project
+    marker = tmp_path / "calls.txt"
+    src = (
+        "from fymo.remote import rate_limit\n"
+        f"MARKER = {str(marker)!r}\n"
+        "@rate_limit(per_minute=1)\n"
+        "def tracked() -> str:\n"
+        "    with open(MARKER, 'a') as f: f.write('x')\n"
+        "    return 'ok'\n"
+    )
+    (proj / "app/remote/billing.py").write_text(src)
+    from fymo.remote.discovery import file_hash
+    new_h = file_hash(proj / "app/remote/billing.py")
+    import fymo.remote.router as rm
+    old_resolver = rm._resolve_module_for_hash
+    rm._resolve_module_for_hash = lambda hash_: "billing" if hash_ == new_h else None
+    try:
+        for name in list(sys.modules):
+            if name == "app" or name.startswith("app."):
+                del sys.modules[name]
+        _call(_make_environ(f"/_fymo/remote/{new_h}/tracked", []))
+        (_, _), body = _call(_make_environ(f"/_fymo/remote/{new_h}/tracked", []))
+        assert body["status"] == 429
+        assert marker.read_text() == "x"
+    finally:
+        rm._resolve_module_for_hash = old_resolver
+
+
+# ---------------- uid scope ----------------
+
+
+def test_uid_scope_separate_cookies_get_separate_buckets(limited_project):
+    _, h = limited_project
+    alice, bob = _uid_cookie("u_alice"), _uid_cookie("u_bob")
+    for _ in range(2):
+        _call(_make_environ(f"/_fymo/remote/{h}/per_uid", [], cookies=alice))
+    (_, _), blocked = _call(_make_environ(f"/_fymo/remote/{h}/per_uid", [], cookies=alice))
+    assert blocked["status"] == 429
+    # Same IP, different uid: fresh bucket.
+    (_, _), other = _call(_make_environ(f"/_fymo/remote/{h}/per_uid", [], cookies=bob))
+    assert other["type"] == "result"
+
+
+def test_uid_scope_falls_back_to_ip_without_cookie(limited_project):
+    """A cookieless retry loop would get a fresh uid per request, so the
+    limit must bind on IP instead of silently not applying."""
+    _, h = limited_project
+    for _ in range(2):
+        _call(_make_environ(f"/_fymo/remote/{h}/per_uid", []))
+    (_, _), blocked = _call(_make_environ(f"/_fymo/remote/{h}/per_uid", []))
+    assert blocked["status"] == 429
+
+
+def test_uid_scope_ignores_forged_cookie(limited_project):
+    """A cookie that fails HMAC verification must not mint fresh buckets."""
+    _, h = limited_project
+    for i in range(2):
+        _call(_make_environ(
+            f"/_fymo/remote/{h}/per_uid", [],
+            cookies=f"fymo_uid=u_forged{i}.AAAAAAAAAAAAAAAAAAAAAA",
+        ))
+    (_, _), blocked = _call(_make_environ(
+        f"/_fymo/remote/{h}/per_uid", [],
+        cookies="fymo_uid=u_forged9.AAAAAAAAAAAAAAAAAAAAAA",
+    ))
+    assert blocked["status"] == 429
+
+
+# ---------------- user scope ----------------
+
+
+@pytest.fixture
+def user_store(tmp_path, monkeypatch):
+    from fymo.auth import context as auth_context
+    from fymo.auth.store import SqliteUserStore
+    store = SqliteUserStore(project_root=tmp_path)
+    monkeypatch.setattr(auth_context, "_user_store", store)
+    yield store
+
+
+def _session_cookie(user) -> str:
+    from fymo.auth.session import make_session_token
+    return f"fymo_session={make_session_token(user.id, user.session_epoch)}"
+
+
+def test_user_scope_keys_on_authenticated_user(limited_project, user_store):
+    _, h = limited_project
+    alice = user_store.create("alice@x.com", None)
+    bob = user_store.create("bob@x.com", None)
+
+    (_, _), first = _call(_make_environ(
+        f"/_fymo/remote/{h}/per_user", [], cookies=_session_cookie(alice)))
+    assert first["type"] == "result"
+    (_, _), blocked = _call(_make_environ(
+        f"/_fymo/remote/{h}/per_user", [], cookies=_session_cookie(alice)))
+    assert blocked["status"] == 429
+    # Same IP, different signed-in user: fresh bucket.
+    (_, _), other = _call(_make_environ(
+        f"/_fymo/remote/{h}/per_user", [], cookies=_session_cookie(bob)))
+    assert other["type"] == "result"
+
+
+def test_user_scope_falls_back_to_uid_when_unauthenticated(limited_project, user_store):
+    _, h = limited_project
+    alice, bob = _uid_cookie("u_anon1"), _uid_cookie("u_anon2")
+    (_, _), first = _call(_make_environ(f"/_fymo/remote/{h}/per_user", [], cookies=alice))
+    assert first["type"] == "result"
+    (_, _), blocked = _call(_make_environ(f"/_fymo/remote/{h}/per_user", [], cookies=alice))
+    assert blocked["status"] == 429
+    (_, _), other = _call(_make_environ(f"/_fymo/remote/{h}/per_user", [], cookies=bob))
+    assert other["type"] == "result"
+
+
+def test_user_scope_falls_back_to_ip_with_no_identity_at_all(limited_project):
+    """No session, no uid cookie, and no user store configured: the limit
+    still binds on IP rather than silently not applying."""
+    _, h = limited_project
+    (_, _), first = _call(_make_environ(f"/_fymo/remote/{h}/per_user", []))
+    assert first["type"] == "result"
+    (_, _), blocked = _call(_make_environ(f"/_fymo/remote/{h}/per_user", []))
+    assert blocked["status"] == 429
+
+
+# ---------------- RateLimited raised from app code ----------------
+
+
+def test_app_raised_rate_limited_surfaces_retry_after(limited_project):
+    proj, _ = limited_project
+    src = (
+        "from fymo.remote import RateLimited\n"
+        "def manual() -> str: raise RateLimited('slow down', retry_after=7)\n"
+    )
+    (proj / "app/remote/billing.py").write_text(src)
+    from fymo.remote.discovery import file_hash
+    new_h = file_hash(proj / "app/remote/billing.py")
+    import fymo.remote.router as rm
+    old_resolver = rm._resolve_module_for_hash
+    rm._resolve_module_for_hash = lambda hash_: "billing" if hash_ == new_h else None
+    try:
+        for name in list(sys.modules):
+            if name == "app" or name.startswith("app."):
+                del sys.modules[name]
+        (status, _), body = _call(_make_environ(f"/_fymo/remote/{new_h}/manual", []))
+        assert status.startswith("200")
+        assert body["status"] == 429
+        assert body["error"] == "rate_limited"
+        assert body["retry_after"] == 7
+    finally:
+        rm._resolve_module_for_hash = old_resolver


### PR DESCRIPTION
## Summary

The middleware limiter is keyed by (IP, path prefix), so every function behind /_fymo/remote/ shares one budget; one expensive function (an LLM call, a per-call-billed API) could not be limited apart from the cheap reads next to it. This adds per-function granularity within the existing in-process token-bucket approach.

- `@rate_limit(per_minute=N, scope="ip"|"user"|"uid")` in fymo/remote/rate_limit.py, marker-attribute pattern like @remote/@require_auth (stamps `__fymo_rate_limit__`, no wrapper), survives any decorator stacking order (all six permutations tested)
- Enforcement in the router after function resolution, before body parse and arg validation; over-limit returns the standard envelope over HTTP 200: `{"type":"error","status":429,"error":"rate_limited","retry_after":N}` via a new RateLimited(RemoteError)
- Bucket core extracted from middleware.py into fymo/core/ratelimit.py (token bucket, registry with lock + idle sweep, trust_proxy-aware IP resolution); middleware.RateLimiter now subclasses it, byte-for-byte behavior preserved, its 35 tests pass unchanged
- Scope semantics: "ip" = trust_proxy-aware client IP; "uid" = HMAC-verified fymo_uid cookie, falling back to IP (never mints a fresh uid, so cookieless retry loops still bind); "user" = authenticated user id, falling back to verified uid, then IP. Cost and threat trade-offs documented in the decorator docstring (scope="user" resolves the session before the limit binds, same cost any current_user() call already pays; uid scope defends against retry loops, not adversaries farming cookies)
- Decorator-only in this pass; a fymo.yml override could layer on later

Closes #54

## Test plan

- [x] TDD: 27 new tests (stamping/validation/stacking; under/over limit; per-IP/uid/user bucket separation; trust_proxy honored and ignored; forged-cookie rejection; fallback chains; side-effect proof the function never runs when limited; app-raised RateLimited surfacing retry_after)
- [x] Full suite 810 passed / 123 skipped; tests/core/test_middleware.py untouched and green
- [x] Independent review compared the extraction line-by-line against pre-branch middleware (refill formula, sweep, key shape, header emission all identical) and confirmed router ordering introduces no new existence oracle
- [x] Live: real build + server, curl on a per_minute=2 function: charged, charged, then 429 with retry_after 30, all HTTP 200