### PR TITLE
fymo schema provider-tables: enumerate provider-owned database objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fymo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
@@ -36,6 +49,8 @@ jobs:
 
       - name: Run tests
         run: uv run pytest tests/ -v
+        env:
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/fymo_test
 
   lint:
     runs-on: ubuntu-latest

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -370,9 +370,9 @@ fymo schema provider-tables --json   # [{kind, name, provider}, ...] for tooling
 
 The command reads `fymo.yml`, resolves the configured `jobs:` /
 `broadcasts:` providers, and prints every table, type, function,
-sequence, index, and trigger they create — derived from the installed
-provider library itself, so the list matches the version you actually
-run. No database connection is made. Feed the names into your tool's
+sequence, index, trigger, and extension they create — derived from the
+installed provider library itself, so the list matches the version you
+actually run. No database connection is made. Feed the names into your tool's
 exclude/ignore list (or generate it in CI) instead of hand-maintaining
 one.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -349,6 +349,37 @@ in `fymo.yml` -- the config block above is the entire setup.
 provider is unaffected: only an entry that both sets `required: auto` and
 points at a provider overriding the hook gets the conditional behavior.
 
+## Provider-owned database objects and schema diff tools
+
+Some fymo providers create real, permanent objects in the app's database:
+`jobs: {provider: procrastinate}` puts its queue tables, functions, and
+types (`procrastinate_jobs`, `procrastinate_events`, …) in the same
+schema as your own tables. Your declarative schema file only declares
+what your app owns, so a schema diff tool (pgschema, migra, and friends)
+sees the provider's objects as strays and generates `DROP TABLE` /
+`DROP FUNCTION` / `DROP TYPE` for every one of them — applying that plan
+destroys the live job queue.
+
+Before running any schema diff against a database fymo providers share,
+enumerate what they own:
+
+```sh
+fymo schema provider-tables          # one "kind name" per line
+fymo schema provider-tables --json   # [{kind, name, provider}, ...] for tooling
+```
+
+The command reads `fymo.yml`, resolves the configured `jobs:` /
+`broadcasts:` providers, and prints every table, type, function,
+sequence, index, and trigger they create — derived from the installed
+provider library itself, so the list matches the version you actually
+run. No database connection is made. Feed the names into your tool's
+exclude/ignore list (or generate it in CI) instead of hand-maintaining
+one.
+
+Providers that create nothing print nothing: the default `threaded` job
+provider and the `postgres` broadcast provider (pure LISTEN/NOTIFY) both
+own zero objects, and the command exits 0 with a note on stderr.
+
 ## Worker sizing
 
 `--workers` means OS processes under **both** servers, and each worker

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -354,7 +354,9 @@ points at a provider overriding the hook gets the conditional behavior.
 Some fymo providers create real, permanent objects in the app's database:
 `jobs: {provider: procrastinate}` puts its queue tables, functions, and
 types (`procrastinate_jobs`, `procrastinate_events`, …) in the same
-schema as your own tables. Your declarative schema file only declares
+schema as your own tables, and `auth.user_store` pointed at
+`PostgresUserStore` adds the `fymo_users` / `fymo_user_oauth_identities`
+identity tables next to them. Your declarative schema file only declares
 what your app owns, so a schema diff tool (pgschema, migra, and friends)
 sees the provider's objects as strays and generates `DROP TABLE` /
 `DROP FUNCTION` / `DROP TYPE` for every one of them — applying that plan
@@ -369,10 +371,10 @@ fymo schema provider-tables --json   # [{kind, name, provider}, ...] for tooling
 ```
 
 The command reads `fymo.yml`, resolves the configured `jobs:` /
-`broadcasts:` providers, and prints every table, type, function,
-sequence, index, trigger, and extension they create — derived from the
-installed provider library itself, so the list matches the version you
-actually run. No database connection is made. Feed the names into your tool's
+`broadcasts:` providers and the `auth.user_store` class, and prints
+every table, type, function, sequence, index, trigger, and extension
+they create — derived from the installed provider library itself, so the
+list matches the version you actually run. No database connection is made. Feed the names into your tool's
 exclude/ignore list (or generate it in CI) instead of hand-maintaining
 one.
 

--- a/fymo/auth/postgres_store.py
+++ b/fymo/auth/postgres_store.py
@@ -1,0 +1,323 @@
+"""PostgresUserStore: the UserStore Protocol on the app's own Postgres.
+
+Enable it in `fymo.yml`:
+
+    auth:
+      user_store: fymo.auth.postgres_store.PostgresUserStore
+
+The connection string comes from the DATABASE_URL environment variable, the
+same one the procrastinate job provider and the postgres broadcast provider
+already read, so identity lands in the database the rest of the app uses.
+A missing DATABASE_URL fails at construction, i.e. at boot, never as a lazy
+first-request error. The driver is optional; install it with
+`pip install 'fymo[postgres]'`.
+
+POSTGRES OBJECTS OWNED BY THIS STORE:
+Everything fymo creates is prefixed `fymo_` because it shares the app's
+database. The full list (see `schema_postgres.sql`):
+
+    fymo_users                          table
+    fymo_users_pkey                     index (implicit, primary key)
+    fymo_users_id_seq                   sequence (implicit, owned by fymo_users.id)
+    fymo_users_email_lower_idx          unique index on lower(email)
+    fymo_user_oauth_identities          table
+    fymo_user_oauth_identities_pkey     index (implicit, primary key)
+
+Semantics mirror SqliteUserStore exactly: case-insensitive email uniqueness
+(EmailAlreadyExists on collision), session_epoch bumping, idempotent
+identity linking, and consume-once verify/reset tokens. Thread safety comes
+from a small psycopg_pool ConnectionPool instead of SqliteUserStore's
+single-connection lock; each method borrows a pooled connection for exactly
+one transaction.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from fymo.auth.store import EmailAlreadyExists, User
+from fymo.auth.verify_token import hash_token, verify_reset_token, verify_verify_token
+
+_SCHEMA_PATH = Path(__file__).parent / "schema_postgres.sql"
+_ENV_VAR = "DATABASE_URL"
+
+# Advisory-lock key serializing schema bootstrap, so several workers booting
+# at once don't race the CREATEs. Arbitrary but stable: 'fymo' in ASCII.
+_BOOTSTRAP_LOCK_KEY = 0x66796D6F
+
+
+def _import_psycopg():
+    """Import the optional driver with an actionable error, mirroring the
+    procrastinate provider: a missing extra must say how to fix itself, not
+    dump a ModuleNotFoundError."""
+    try:
+        import psycopg
+        import psycopg_pool
+        from psycopg.rows import dict_row
+    except ImportError as e:
+        raise RuntimeError(
+            "PostgresUserStore needs the psycopg package with pool support "
+            "(install it with: pip install 'fymo[postgres]')"
+        ) from e
+    return psycopg, psycopg_pool, dict_row
+
+
+class PostgresUserStore:
+    """UserStore over the app's Postgres. Schema bootstrapped on first connect.
+
+    Same constructor contract as SqliteUserStore: one positional project
+    root. It is unused here (the connection comes from $DATABASE_URL) but
+    keeps the `auth.user_store` loader working unchanged for every store.
+    """
+
+    def __init__(self, project_root: Path):
+        self.project_root = Path(project_root)
+        url = os.environ.get(_ENV_VAR)
+        if not url:
+            raise RuntimeError(
+                f"PostgresUserStore needs ${_ENV_VAR} set to a Postgres "
+                "connection string. It is checked here, at boot, so a "
+                "missing URL never surfaces as a first-request failure."
+            )
+        self._url = url
+        self._psycopg, self._psycopg_pool, self._dict_row = _import_psycopg()
+        self._lock = threading.Lock()
+        self._pool = None
+
+    def _get_pool(self):
+        """Open the pool and bootstrap the schema on first use, the pooled
+        analogue of SqliteUserStore._connect. Deliberately small with no
+        tuning surface: auth traffic is one short transaction per call."""
+        if self._pool is None:
+            with self._lock:
+                if self._pool is None:
+                    pool = self._psycopg_pool.ConnectionPool(
+                        self._url,
+                        min_size=1,
+                        max_size=4,
+                        open=True,
+                        kwargs={"row_factory": self._dict_row},
+                    )
+                    with pool.connection() as conn:
+                        conn.execute(
+                            "SELECT pg_advisory_xact_lock(%s)",
+                            (_BOOTSTRAP_LOCK_KEY,),
+                        )
+                        conn.execute(_SCHEMA_PATH.read_text())
+                        self._migrate(conn)
+                    self._pool = pool
+        return self._pool
+
+    @staticmethod
+    def _migrate(conn) -> None:
+        """Additive migrations for databases created before a column existed.
+
+        `CREATE TABLE IF NOT EXISTS` never alters an existing table, so a
+        column added to schema_postgres.sql after a database was created
+        would be missing. Add it here idempotently; same hook pattern as
+        SqliteUserStore._migrate, covering the same columns.
+        """
+        conn.execute(
+            "ALTER TABLE fymo_users "
+            "ADD COLUMN IF NOT EXISTS session_epoch INTEGER NOT NULL DEFAULT 1"
+        )
+        conn.execute(
+            "ALTER TABLE fymo_users ADD COLUMN IF NOT EXISTS email_verify_token TEXT"
+        )
+        conn.execute(
+            "ALTER TABLE fymo_users ADD COLUMN IF NOT EXISTS email_verify_sent_at TEXT"
+        )
+        conn.execute(
+            "ALTER TABLE fymo_users ADD COLUMN IF NOT EXISTS password_reset_token TEXT"
+        )
+
+    def close(self) -> None:
+        """Release pooled connections. Not part of the UserStore Protocol;
+        process teardown normally handles it, tests call it explicitly."""
+        if self._pool is not None:
+            self._pool.close()
+            self._pool = None
+
+    @staticmethod
+    def _row_to_user(row) -> Optional[User]:
+        if row is None:
+            return None
+        return User(
+            id=row["id"],
+            email=row["email"],
+            password_hash=row["password_hash"],
+            email_verified=bool(row["email_verified"]),
+            created_at=row["created_at"],
+            fymo_uid=row["fymo_uid"],
+            session_epoch=row["session_epoch"],
+        )
+
+    _COLUMNS = "id, email, password_hash, email_verified, created_at, fymo_uid, session_epoch"
+
+    def get_by_id(self, user_id: int) -> Optional[User]:
+        with self._get_pool().connection() as conn:
+            row = conn.execute(
+                f"SELECT {self._COLUMNS} FROM fymo_users WHERE id = %s",
+                (user_id,),
+            ).fetchone()
+        return self._row_to_user(row)
+
+    def get_by_email(self, email: str) -> Optional[User]:
+        with self._get_pool().connection() as conn:
+            row = conn.execute(
+                f"SELECT {self._COLUMNS} FROM fymo_users "
+                "WHERE lower(email) = lower(%s)",
+                (email,),
+            ).fetchone()
+        return self._row_to_user(row)
+
+    def create(self, email: str, password_hash: Optional[str]) -> User:
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        try:
+            with self._get_pool().connection() as conn:
+                row = conn.execute(
+                    "INSERT INTO fymo_users (email, password_hash, created_at) "
+                    "VALUES (%s, %s, %s) RETURNING id",
+                    (email, password_hash, now),
+                ).fetchone()
+        except self._psycopg.errors.UniqueViolation as e:
+            raise EmailAlreadyExists(email) from e
+        return User(
+            id=row["id"], email=email, password_hash=password_hash,
+            email_verified=False, created_at=now, fymo_uid=None,
+        )
+
+    def set_password_hash(self, user_id: int, password_hash: str) -> None:
+        # Bump the epoch in the same statement so a password change atomically
+        # revokes every session issued under the old password.
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users "
+                "SET password_hash = %s, session_epoch = session_epoch + 1 "
+                "WHERE id = %s",
+                (password_hash, user_id),
+            )
+
+    def bump_session_epoch(self, user_id: int) -> None:
+        """Invalidate all outstanding sessions for a user (logout, forced sign-out)."""
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users SET session_epoch = session_epoch + 1 "
+                "WHERE id = %s",
+                (user_id,),
+            )
+
+    def get_by_identity(self, provider: str, provider_user_id: str) -> Optional[User]:
+        """Return the user linked to an external identity, or None."""
+        with self._get_pool().connection() as conn:
+            row = conn.execute(
+                f"SELECT {self._COLUMNS} FROM fymo_users WHERE id = ("
+                "  SELECT user_id FROM fymo_user_oauth_identities"
+                "  WHERE provider = %s AND provider_user_id = %s"
+                ")",
+                (provider, provider_user_id),
+            ).fetchone()
+        return self._row_to_user(row)
+
+    def link_identity(
+        self, user_id: int, provider: str, provider_user_id: str, email: Optional[str]
+    ) -> None:
+        """Attach an external identity to a user. Idempotent on (provider, sub)."""
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "INSERT INTO fymo_user_oauth_identities "
+                "(user_id, provider, provider_user_id, email, linked_at) "
+                "VALUES (%s, %s, %s, %s, %s) "
+                "ON CONFLICT (provider, provider_user_id) DO NOTHING",
+                (user_id, provider, provider_user_id, email, now),
+            )
+
+    def claim_fymo_uid(self, user_id: int, fymo_uid: str) -> None:
+        """Idempotent: only sets fymo_uid if currently NULL."""
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users SET fymo_uid = %s "
+                "WHERE id = %s AND fymo_uid IS NULL",
+                (fymo_uid, user_id),
+            )
+
+    def set_verify_token(self, user_id: int, token: str) -> None:
+        """Record a newly-issued verification token for `user_id`.
+
+        Only the token's hash is persisted (see `fymo.auth.verify_token`),
+        and setting a new token implicitly invalidates any previous
+        outstanding one for this user, since the old token's hash no longer
+        matches the row, so `consume_verify_token` will reject it even if
+        it hasn't expired.
+        """
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users "
+                "SET email_verify_token = %s, email_verify_sent_at = %s "
+                "WHERE id = %s",
+                (hash_token(token), now, user_id),
+            )
+
+    def consume_verify_token(self, token: str) -> Optional[int]:
+        """Validate `token` (signature + expiry) and, if it matches the
+        outstanding token hash on record, atomically mark the user verified
+        and clear the stored hash so the token can't be replayed. Returns the
+        verified user's id, or None if the token is forged, expired, already
+        consumed, or superseded by a later `set_verify_token` call."""
+        verified = verify_verify_token(token)
+        if verified is None:
+            return None
+        user_id, _issued_at = verified
+        with self._get_pool().connection() as conn:
+            cur = conn.execute(
+                "UPDATE fymo_users "
+                "SET email_verified = TRUE, email_verify_token = NULL "
+                "WHERE id = %s AND email_verify_token = %s",
+                (user_id, hash_token(token)),
+            )
+            if cur.rowcount == 0:
+                return None
+        return user_id
+
+    def set_reset_token(self, user_id: int, token: str) -> None:
+        """Record a newly-issued password-reset token for `user_id`.
+
+        Only the token's hash is persisted (see `fymo.auth.verify_token`),
+        and setting a new token implicitly invalidates any previous
+        outstanding one for this user, since the old token's hash no longer
+        matches the row, so `consume_reset_token` will reject it even if it
+        hasn't expired.
+        """
+        with self._get_pool().connection() as conn:
+            conn.execute(
+                "UPDATE fymo_users SET password_reset_token = %s WHERE id = %s",
+                (hash_token(token), user_id),
+            )
+
+    def consume_reset_token(self, token: str) -> Optional[int]:
+        """Validate `token` (signature + expiry) and, if it matches the
+        outstanding token hash on record, atomically clear the stored hash so
+        the token can't be replayed. Returns the user's id, or None if the
+        token is forged, expired, already consumed, or superseded by a later
+        `set_reset_token` call. Does NOT change the password itself; the
+        caller (`fymo.auth.remote.reset_password`) does that via
+        `set_password_hash`, which also bumps `session_epoch` to revoke every
+        outstanding session."""
+        verified = verify_reset_token(token)
+        if verified is None:
+            return None
+        user_id, _issued_at = verified
+        with self._get_pool().connection() as conn:
+            cur = conn.execute(
+                "UPDATE fymo_users SET password_reset_token = NULL "
+                "WHERE id = %s AND password_reset_token = %s",
+                (user_id, hash_token(token)),
+            )
+            if cur.rowcount == 0:
+                return None
+        return user_id

--- a/fymo/auth/postgres_store.py
+++ b/fymo/auth/postgres_store.py
@@ -112,13 +112,21 @@ class PostgresUserStore:
                         open=True,
                         kwargs={"row_factory": self._dict_row},
                     )
-                    with pool.connection() as conn:
-                        conn.execute(
-                            "SELECT pg_advisory_xact_lock(%s)",
-                            (_BOOTSTRAP_LOCK_KEY,),
-                        )
-                        conn.execute(_SCHEMA_PATH.read_text())
-                        self._migrate(conn)
+                    # If bootstrap fails (transient outage on first call),
+                    # close the pool instead of leaking it: its background
+                    # workers would keep reconnecting until process exit,
+                    # and the next call would build another pool on top.
+                    try:
+                        with pool.connection() as conn:
+                            conn.execute(
+                                "SELECT pg_advisory_xact_lock(%s)",
+                                (_BOOTSTRAP_LOCK_KEY,),
+                            )
+                            conn.execute(_SCHEMA_PATH.read_text())
+                            self._migrate(conn)
+                    except BaseException:
+                        pool.close()
+                        raise
                     self._pool = pool
         return self._pool
 

--- a/fymo/auth/postgres_store.py
+++ b/fymo/auth/postgres_store.py
@@ -23,12 +23,23 @@ database. The full list (see `schema_postgres.sql`):
     fymo_user_oauth_identities          table
     fymo_user_oauth_identities_pkey     index (implicit, primary key)
 
-Semantics mirror SqliteUserStore exactly: case-insensitive email uniqueness
-(EmailAlreadyExists on collision), session_epoch bumping, idempotent
-identity linking, and consume-once verify/reset tokens. Thread safety comes
-from a small psycopg_pool ConnectionPool instead of SqliteUserStore's
-single-connection lock; each method borrows a pooled connection for exactly
-one transaction.
+Semantics match SqliteUserStore for every Protocol method: case-insensitive
+email uniqueness (EmailAlreadyExists on collision), session_epoch bumping,
+idempotent identity linking, and consume-once verify/reset tokens. Two
+known divergences, both in Postgres's favor:
+
+  * Case folding is locale-aware here, ASCII-only in SQLite (NOCASE).
+    "É@x.com" and "é@x.com" are two distinct users in a SQLite auth.db but
+    collide here, so a SQLite database already holding both spellings
+    cannot be imported into this store. Pinned by a test in
+    tests/auth/test_postgres_store.py.
+  * fymo_user_oauth_identities.user_id is an enforced foreign key here;
+    SQLite declares it but never enables PRAGMA foreign_keys. Unreachable
+    through normal Protocol flows, which always link existing users.
+
+Thread safety comes from a small psycopg_pool ConnectionPool instead of
+SqliteUserStore's single-connection lock; each method borrows a pooled
+connection for exactly one transaction.
 """
 from __future__ import annotations
 

--- a/fymo/auth/postgres_store.py
+++ b/fymo/auth/postgres_store.py
@@ -98,6 +98,20 @@ class PostgresUserStore:
         self._lock = threading.Lock()
         self._pool = None
 
+    @classmethod
+    def owned_schema_objects(cls):
+        """Every object schema_postgres.sql creates, plus the implicit
+        identity sequence, for `fymo schema provider-tables` (issue #51).
+        Derived by parsing the packaged SQL, never a second hardcoded list.
+
+        A classmethod on purpose: __init__ is boot-loud about DATABASE_URL
+        and _get_pool() connects, while the schema command's contract is
+        no database and no environment. The CLI resolves the configured
+        class from `auth.user_store` and asks it directly, without ever
+        constructing a store. Needs neither psycopg nor a connection."""
+        from fymo.core.schema import parse_schema_sql
+        return parse_schema_sql(_SCHEMA_PATH.read_text())
+
     def _get_pool(self):
         """Open the pool and bootstrap the schema on first use, the pooled
         analogue of SqliteUserStore._connect. Deliberately small with no

--- a/fymo/auth/schema_postgres.sql
+++ b/fymo/auth/schema_postgres.sql
@@ -1,0 +1,31 @@
+-- Postgres translation of schema.sql: same columns, same semantics. Every
+-- object is prefixed fymo_ because this schema lives inside the app's own
+-- database, next to app tables. Add columns via app-level migrations; fymo
+-- will not destructively touch these tables once created.
+
+CREATE TABLE IF NOT EXISTS fymo_users (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    email           TEXT NOT NULL,
+    password_hash   TEXT,         -- NULL for OAuth-only users
+    email_verified  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TEXT NOT NULL,
+    fymo_uid        TEXT,         -- anonymous uid this user claimed on first login
+    session_epoch   INTEGER NOT NULL DEFAULT 1, -- bumped to revoke outstanding sessions
+    email_verify_token    TEXT,   -- hash of the outstanding verification token, NULL once consumed
+    email_verify_sent_at  TEXT,   -- when the last verification email was sent
+    password_reset_token  TEXT    -- hash of the outstanding password-reset token, NULL once consumed
+);
+
+-- Case-insensitive uniqueness: the Postgres spelling of SQLite's
+-- UNIQUE COLLATE NOCASE (get_by_email compares lower(email) too).
+CREATE UNIQUE INDEX IF NOT EXISTS fymo_users_email_lower_idx
+    ON fymo_users (lower(email));
+
+CREATE TABLE IF NOT EXISTS fymo_user_oauth_identities (
+    user_id           BIGINT NOT NULL REFERENCES fymo_users(id),
+    provider          TEXT NOT NULL,
+    provider_user_id  TEXT NOT NULL,
+    email             TEXT,
+    linked_at         TEXT NOT NULL,
+    PRIMARY KEY (provider, provider_user_id)
+);

--- a/fymo/auth/schema_postgres.sql
+++ b/fymo/auth/schema_postgres.sql
@@ -16,8 +16,11 @@ CREATE TABLE IF NOT EXISTS fymo_users (
     password_reset_token  TEXT    -- hash of the outstanding password-reset token, NULL once consumed
 );
 
--- Case-insensitive uniqueness: the Postgres spelling of SQLite's
--- UNIQUE COLLATE NOCASE (get_by_email compares lower(email) too).
+-- Case-insensitive uniqueness (get_by_email compares lower(email) too).
+-- Stricter than SQLite's UNIQUE COLLATE NOCASE: lower() folds per the
+-- database locale while NOCASE folds ASCII only, so non-ASCII spellings
+-- that coexist in a SQLite auth.db collide here (see the module docstring
+-- of postgres_store.py).
 CREATE UNIQUE INDEX IF NOT EXISTS fymo_users_email_lower_idx
     ON fymo_users (lower(email));
 

--- a/fymo/auth/store.py
+++ b/fymo/auth/store.py
@@ -1,9 +1,12 @@
 """UserStore Protocol + the default SQLite implementation.
 
-App authors swap the implementation via `fymo.yml`:
+App authors swap the implementation via `fymo.yml`. fymo ships two: this
+module's SqliteUserStore (the default) and
+`fymo.auth.postgres_store.PostgresUserStore`, which keeps identity in the
+same Postgres database the rest of the app uses:
 
     auth:
-      user_store: my_app.auth.PostgresUserStore
+      user_store: fymo.auth.postgres_store.PostgresUserStore
 
 The class is instantiated with a single positional argument: the project
 root path. Anything else (DB URL, schema name, etc.) should come from the

--- a/fymo/broadcast/providers/base.py
+++ b/fymo/broadcast/providers/base.py
@@ -9,8 +9,10 @@ app code or the generated client.
 """
 from __future__ import annotations
 
-from typing import Iterator, Optional, Protocol, runtime_checkable
+from typing import Iterator, Optional, Protocol, Tuple, runtime_checkable
 import threading
+
+from fymo.core.schema import SchemaObject
 
 
 @runtime_checkable
@@ -42,3 +44,11 @@ class BaseBroadcastProvider:
         writing the keepalive to a gone client raises, closing this
         generator and releasing the provider's resources."""
         raise NotImplementedError
+
+    def owned_schema_objects(self) -> Tuple[SchemaObject, ...]:
+        """The database objects this provider creates for itself (`fymo
+        schema provider-tables`). The built-in postgres provider is pure
+        LISTEN/NOTIFY and creates none, so this default stands for it. Kept
+        off the BroadcastProvider Protocol for the same isinstance()
+        compatibility reason as BaseJobProvider.owned_schema_objects."""
+        return ()

--- a/fymo/cli/commands/schema.py
+++ b/fymo/cli/commands/schema.py
@@ -19,9 +19,15 @@ Design notes:
     the extra rather than printing a partial list.
   * stdout carries only the object list (plain or --json) so it can be
     piped straight into tooling; every note or error goes to stderr.
-  * Future providers/stores that create objects (e.g. an auth user store
-    with fymo_* tables) join by implementing owned_schema_objects() and
-    getting resolved in _configured_providers() below.
+  * The auth user store joins the same way: a configured
+    `auth.user_store` class is resolved (imported, never instantiated,
+    since PostgresUserStore's constructor demands DATABASE_URL at boot
+    while this command promises to need neither a database nor the env
+    var) and asked via its classmethod. The default SQLite store keeps
+    its objects in its own auth.db file and declares nothing. Future
+    providers/stores that create objects join by implementing
+    owned_schema_objects() and getting resolved in
+    _configured_providers() below.
 """
 from __future__ import annotations
 
@@ -31,17 +37,31 @@ from pathlib import Path
 from typing import Optional
 
 from fymo.core.config import ConfigManager
+from fymo.core.providers import ProviderConfigError, load_class
 from fymo.core.schema import SchemaParseError, owned_schema_objects
 
 
 def _configured_providers(config_manager: ConfigManager):
+    """(label, source) pairs for everything fymo.yml configures that can
+    own schema objects. Sources are provider instances for jobs and
+    broadcasts, and the bare class for the auth user store."""
     from fymo.broadcast.providers.registry import build_broadcast_provider
     from fymo.jobs.providers.registry import build_job_provider
 
-    return (
-        build_job_provider(config_manager.get_jobs_config().get("provider")),
-        build_broadcast_provider(config_manager.get_broadcasts_config().get("provider")),
+    job_provider = build_job_provider(config_manager.get_jobs_config().get("provider"))
+    broadcast_provider = build_broadcast_provider(
+        config_manager.get_broadcasts_config().get("provider")
     )
+    sources = [
+        (job_provider.id, job_provider),
+        (broadcast_provider.id, broadcast_provider),
+    ]
+
+    store_path = config_manager.get_auth_config().get("user_store")
+    if store_path:
+        store_cls = load_class(store_path)
+        sources.append((store_cls.__name__, store_cls))
+    return sources
 
 
 def run_provider_tables(project_root: Optional[Path] = None, as_json: bool = False) -> None:
@@ -57,13 +77,13 @@ def run_provider_tables(project_root: Optional[Path] = None, as_json: bool = Fal
     entries = []
     seen = set()
     try:
-        for provider in _configured_providers(config_manager):
-            for obj in owned_schema_objects(provider):
+        for label, source in _configured_providers(config_manager):
+            for obj in owned_schema_objects(source):
                 if (obj.kind, obj.name) in seen:
                     continue
                 seen.add((obj.kind, obj.name))
-                entries.append((provider.id, obj))
-    except (RuntimeError, SchemaParseError) as e:
+                entries.append((label, obj))
+    except (RuntimeError, SchemaParseError, ProviderConfigError) as e:
         print(f"error: {e}", file=sys.stderr)
         raise SystemExit(1)
 

--- a/fymo/cli/commands/schema.py
+++ b/fymo/cli/commands/schema.py
@@ -1,0 +1,80 @@
+"""`fymo schema provider-tables`, what the configured providers own.
+
+Fymo providers can create real, permanent objects in the app's database
+(Procrastinate's queue tables, most famously). A declarative schema diff
+tool only knows the app's own schema file, so those objects look like
+strays and the generated plan proposes DROP TABLE for the live job queue
+(issue #51). This command enumerates every table/function/type/sequence/
+index/trigger the providers configured in fymo.yml create, so an exclude
+list (or schema fragment) can be generated instead of hand-maintained.
+
+Design notes:
+  * Only the CONFIGURED providers are consulted, the same registry
+    resolution `fymo serve`/`fymo jobs-worker` use, never every provider
+    fymo ships. Unconfigured subsystems fall back to their defaults
+    (threaded jobs, postgres broadcasts), both of which own nothing.
+  * No database connection is made and none is needed: declarations come
+    from provider code and bundled package metadata. If a declaration
+    needs an uninstalled optional dependency, the command exits 1 naming
+    the extra rather than printing a partial list.
+  * stdout carries only the object list (plain or --json) so it can be
+    piped straight into tooling; every note or error goes to stderr.
+  * Future providers/stores that create objects (e.g. an auth user store
+    with fymo_* tables) join by implementing owned_schema_objects() and
+    getting resolved in _configured_providers() below.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fymo.core.config import ConfigManager
+from fymo.core.schema import owned_schema_objects
+
+
+def _configured_providers(config_manager: ConfigManager):
+    from fymo.broadcast.providers.registry import build_broadcast_provider
+    from fymo.jobs.providers.registry import build_job_provider
+
+    return (
+        build_job_provider(config_manager.get_jobs_config().get("provider")),
+        build_broadcast_provider(config_manager.get_broadcasts_config().get("provider")),
+    )
+
+
+def run_provider_tables(project_root: Optional[Path] = None, as_json: bool = False) -> None:
+    """Print the schema objects owned by the project's configured providers.
+
+    Plain output is one `<kind> <name>` per line in the provider's own
+    declaration order; --json emits a list of {kind, name, provider}
+    objects. Empty ownership is a success (exit 0): empty stdout (or `[]`
+    with --json) plus a stderr note."""
+    project_root = Path(project_root) if project_root else Path.cwd()
+    config_manager = ConfigManager(project_root)
+
+    entries = []
+    seen = set()
+    try:
+        for provider in _configured_providers(config_manager):
+            for obj in owned_schema_objects(provider):
+                if (obj.kind, obj.name) in seen:
+                    continue
+                seen.add((obj.kind, obj.name))
+                entries.append((provider.id, obj))
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        raise SystemExit(1)
+
+    if as_json:
+        print(json.dumps([
+            {"kind": obj.kind, "name": obj.name, "provider": provider_id}
+            for provider_id, obj in entries
+        ]))
+    else:
+        for _, obj in entries:
+            print(f"{obj.kind} {obj.name}")
+
+    if not entries:
+        print("no configured provider owns schema objects", file=sys.stderr)

--- a/fymo/cli/commands/schema.py
+++ b/fymo/cli/commands/schema.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Optional
 
 from fymo.core.config import ConfigManager
-from fymo.core.schema import owned_schema_objects
+from fymo.core.schema import SchemaParseError, owned_schema_objects
 
 
 def _configured_providers(config_manager: ConfigManager):
@@ -63,7 +63,7 @@ def run_provider_tables(project_root: Optional[Path] = None, as_json: bool = Fal
                     continue
                 seen.add((obj.kind, obj.name))
                 entries.append((provider.id, obj))
-    except RuntimeError as e:
+    except (RuntimeError, SchemaParseError) as e:
         print(f"error: {e}", file=sys.stderr)
         raise SystemExit(1)
 

--- a/fymo/cli/main.py
+++ b/fymo/cli/main.py
@@ -63,6 +63,24 @@ def dev_cmd(host, port):
     run_dev(host=host, port=port)
 
 
+@cli.group()
+def schema():
+    """Schema tooling for the database objects fymo providers own."""
+    pass
+
+
+@schema.command(name="provider-tables")
+@click.option("--json", "as_json", is_flag=True, default=False,
+              help="Emit JSON ([{kind, name, provider}, ...]) instead of plain lines")
+def provider_tables_cmd(as_json):
+    """List every table/function/type the configured providers create.
+
+    Feed the output to your schema diff tool's exclude list so it never
+    proposes dropping the job queue's tables."""
+    from fymo.cli.commands.schema import run_provider_tables
+    run_provider_tables(as_json=as_json)
+
+
 @cli.command(name="jobs-worker")
 @click.option("--dev", is_flag=True, default=False,
               help="Run in dev mode (sets FYMO_DEV=1, enables .env loading)")

--- a/fymo/core/schema.py
+++ b/fymo/core/schema.py
@@ -1,0 +1,137 @@
+"""The owned-schema-objects seam (issue #51).
+
+Some providers create real, permanent objects in the app's own database
+(Procrastinate's queue tables being the canonical case). Declarative
+schema diff tools only know the app's schema file, so those objects look
+like strays and get proposed for DROP. This module is the seam that lets
+anything holding a provider instance ask what it owns:
+
+  * A provider declares its objects by implementing
+    ``owned_schema_objects() -> tuple[SchemaObject, ...]``. The default on
+    every provider base class returns ``()``, only providers that
+    actually create database objects override it. The seam is duck-typed
+    (see ``owned_schema_objects()`` below), so it isn't limited to job or
+    broadcast providers: any future store or provider (e.g. an auth user
+    store with its own tables) joins by defining the same method.
+  * ``parse_schema_sql()`` derives the declaration from a library's
+    bundled DDL text, so the list tracks whatever version is actually
+    installed instead of drifting the way a hardcoded list would. It
+    fails loudly on DDL it can't classify, a silently partial list would
+    defeat the exclude lists built from it.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Tuple
+
+@dataclass(frozen=True)
+class SchemaObject:
+    """One database object a provider owns. `kind` is a lowercase word
+    matching what schema diff tools manage as top-level objects: table,
+    type, function, sequence, index, trigger, view."""
+    kind: str
+    name: str
+
+
+class SchemaParseError(Exception):
+    """DDL text contained a CREATE statement the parser can't classify."""
+
+
+def owned_schema_objects(provider) -> Tuple[SchemaObject, ...]:
+    """The objects `provider` declares, or () when it declares nothing.
+
+    Duck-typed on purpose: JobProvider/BroadcastProvider are
+    runtime-checkable Protocols, and adding the method there would break
+    isinstance() for existing custom providers that predate the seam."""
+    declare = getattr(provider, "owned_schema_objects", None)
+    if declare is None:
+        return ()
+    return tuple(declare())
+
+
+# One regex per recognized statement head; group 1 is the object name.
+# UNIQUE INDEX collapses to "index", exclusion tooling doesn't care.
+_STATEMENT_RES = (
+    ("table", re.compile(
+        r"CREATE\s+(?:UNLOGGED\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w$]*)",
+        re.IGNORECASE)),
+    ("type", re.compile(r"CREATE\s+TYPE\s+([A-Za-z_][\w$]*)", re.IGNORECASE)),
+    ("function", re.compile(
+        r"CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([A-Za-z_][\w$]*)",
+        re.IGNORECASE)),
+    ("sequence", re.compile(
+        r"CREATE\s+SEQUENCE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w$]*)",
+        re.IGNORECASE)),
+    ("index", re.compile(
+        r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w$]*)",
+        re.IGNORECASE)),
+    ("trigger", re.compile(
+        r"CREATE\s+(?:OR\s+REPLACE\s+)?TRIGGER\s+([A-Za-z_][\w$]*)",
+        re.IGNORECASE)),
+    ("view", re.compile(
+        r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+([A-Za-z_][\w$]*)",
+        re.IGNORECASE)),
+)
+
+# A column whose type implicitly creates a `<table>_<column>_seq` sequence:
+# serial family, or GENERATED ... AS IDENTITY.
+_SERIAL_COLUMN_RE = re.compile(
+    r"^\s*([A-Za-z_][\w$]*)\s+(?:big|small)?serial\b", re.IGNORECASE)
+_IDENTITY_COLUMN_RE = re.compile(
+    r"^\s*([A-Za-z_][\w$]*)\s+.*\bGENERATED\s+(?:ALWAYS|BY\s+DEFAULT)\s+AS\s+IDENTITY\b",
+    re.IGNORECASE)
+
+
+def parse_schema_sql(sql: str) -> Tuple[SchemaObject, ...]:
+    """Extract every object a DDL script creates, in statement order.
+
+    Tables contribute their implicit serial/identity sequences too, since
+    schema tools that enumerate sequences would otherwise still propose
+    dropping `<table>_id_seq`. Raises SchemaParseError on any top-level
+    CREATE statement head it can't classify."""
+    objects = []
+    seen = set()
+
+    def add(kind: str, name: str) -> None:
+        if (kind, name) not in seen:
+            seen.add((kind, name))
+            objects.append(SchemaObject(kind=kind, name=name))
+
+    for match in re.finditer(r"^CREATE\b[^\n;]*", sql, flags=re.MULTILINE):
+        statement_head = match.group(0)
+        for kind, statement_re in _STATEMENT_RES:
+            named = statement_re.match(statement_head)
+            if named:
+                add(kind, named.group(1))
+                if kind == "table":
+                    name_end = match.start() + named.end(1)
+                    for seq_name in _implicit_sequences(named.group(1), sql, name_end):
+                        add("sequence", seq_name)
+                break
+        else:
+            raise SchemaParseError(
+                f"unrecognized CREATE statement: {statement_head.strip()!r}, "
+                "fymo.core.schema.parse_schema_sql needs to learn this DDL form"
+            )
+    return tuple(objects)
+
+
+def _implicit_sequences(table: str, sql: str, name_end: int):
+    """Sequences Postgres creates for serial/identity columns of `table`,
+    scanning the parenthesized column list that follows the table name."""
+    open_paren = sql.find("(", name_end)
+    if open_paren == -1:
+        return
+    depth = 1
+    i = open_paren + 1
+    while i < len(sql) and depth:
+        if sql[i] == "(":
+            depth += 1
+        elif sql[i] == ")":
+            depth -= 1
+        i += 1
+    for line in sql[open_paren + 1:i - 1].splitlines():
+        column = _SERIAL_COLUMN_RE.match(line) or _IDENTITY_COLUMN_RE.match(line)
+        if column:
+            yield f"{table}_{column.group(1)}_seq"

--- a/fymo/core/schema.py
+++ b/fymo/core/schema.py
@@ -29,7 +29,7 @@ from typing import Tuple
 class SchemaObject:
     """One database object a provider owns. `kind` is a lowercase word
     matching what schema diff tools manage as top-level objects: table,
-    type, function, sequence, index, trigger, view."""
+    type, function, sequence, index, trigger, view, extension."""
     kind: str
     name: str
 
@@ -51,7 +51,13 @@ def owned_schema_objects(provider) -> Tuple[SchemaObject, ...]:
 
 
 # One regex per recognized statement head; group 1 is the object name.
+# Matched at every CREATE token position, wherever it sits (indented,
+# mid-line, inside a DO block), so nothing depends on line starts.
 # UNIQUE INDEX collapses to "index", exclusion tooling doesn't care.
+# CREATE EXTENSION is classified like everything else: procrastinate's
+# schema opens with a guarded `CREATE EXTENSION IF NOT EXISTS plpgsql`
+# inside a DO block, and enumerating it is harmless while ignoring it
+# would need a silent-skip path this parser must not have.
 _STATEMENT_RES = (
     ("table", re.compile(
         r"CREATE\s+(?:UNLOGGED\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w$]*)",
@@ -72,7 +78,13 @@ _STATEMENT_RES = (
     ("view", re.compile(
         r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+([A-Za-z_][\w$]*)",
         re.IGNORECASE)),
+    ("extension", re.compile(
+        r"CREATE\s+EXTENSION\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w$]*)",
+        re.IGNORECASE)),
 )
+
+_COMMENT_RE = re.compile(r"/\*.*?\*/|--[^\n]*", re.DOTALL)
+_CREATE_TOKEN_RE = re.compile(r"\bCREATE\b", re.IGNORECASE)
 
 # A column whose type implicitly creates a `<table>_<column>_seq` sequence:
 # serial family, or GENERATED ... AS IDENTITY.
@@ -86,10 +98,16 @@ _IDENTITY_COLUMN_RE = re.compile(
 def parse_schema_sql(sql: str) -> Tuple[SchemaObject, ...]:
     """Extract every object a DDL script creates, in statement order.
 
+    Comments are stripped, then EVERY remaining CREATE token in the text
+    is visited: indented, mid-line, or nested inside a DO $$ block, each
+    one is either classified into the output or raises SchemaParseError.
+    Under-reporting is the one failure mode this parser is not allowed to
+    have, so there is deliberately no code path that skips a CREATE.
+
     Tables contribute their implicit serial/identity sequences too, since
     schema tools that enumerate sequences would otherwise still propose
-    dropping `<table>_id_seq`. Raises SchemaParseError on any top-level
-    CREATE statement head it can't classify."""
+    dropping `<table>_id_seq`."""
+    stripped = _COMMENT_RE.sub(" ", sql)
     objects = []
     seen = set()
 
@@ -98,20 +116,19 @@ def parse_schema_sql(sql: str) -> Tuple[SchemaObject, ...]:
             seen.add((kind, name))
             objects.append(SchemaObject(kind=kind, name=name))
 
-    for match in re.finditer(r"^CREATE\b[^\n;]*", sql, flags=re.MULTILINE):
-        statement_head = match.group(0)
+    for match in _CREATE_TOKEN_RE.finditer(stripped):
         for kind, statement_re in _STATEMENT_RES:
-            named = statement_re.match(statement_head)
+            named = statement_re.match(stripped, match.start())
             if named:
                 add(kind, named.group(1))
                 if kind == "table":
-                    name_end = match.start() + named.end(1)
-                    for seq_name in _implicit_sequences(named.group(1), sql, name_end):
+                    for seq_name in _implicit_sequences(named.group(1), stripped, named.end(1)):
                         add("sequence", seq_name)
                 break
         else:
+            snippet = " ".join(stripped[match.start():match.start() + 60].split())
             raise SchemaParseError(
-                f"unrecognized CREATE statement: {statement_head.strip()!r}, "
+                f"unrecognized CREATE statement: {snippet!r}, "
                 "fymo.core.schema.parse_schema_sql needs to learn this DDL form"
             )
     return tuple(objects)

--- a/fymo/jobs/providers/base.py
+++ b/fymo/jobs/providers/base.py
@@ -19,7 +19,9 @@ branches on provider *type*, it just calls the two hooks:
 """
 from __future__ import annotations
 
-from typing import Callable, Dict, Protocol, runtime_checkable
+from typing import Callable, Dict, Protocol, Tuple, runtime_checkable
+
+from fymo.core.schema import SchemaObject
 
 
 @runtime_checkable
@@ -38,6 +40,15 @@ class BaseJobProvider:
 
     def register_tasks(self, tasks: Dict[str, Callable]) -> None:
         pass
+
+    def owned_schema_objects(self) -> Tuple[SchemaObject, ...]:
+        """The database objects this provider creates for itself, so schema
+        diff tooling can be told to leave them alone (`fymo schema
+        provider-tables`). Deliberately not part of the JobProvider
+        Protocol: it's runtime-checkable, and requiring the method would
+        break isinstance() for custom providers that predate the seam.
+        Providers that create nothing declare nothing."""
+        return ()
 
     def submit(self, task_name: str, *args, **kwargs) -> None:
         raise NotImplementedError

--- a/fymo/jobs/providers/procrastinate.py
+++ b/fymo/jobs/providers/procrastinate.py
@@ -79,6 +79,18 @@ class ProcrastinateJobProvider(BaseJobProvider):
         bound.apply_defaults()
         self._get_app().configure_task(name=task_name).defer(**bound.arguments)
 
+    def owned_schema_objects(self):
+        """Every table/type/function/index/trigger (plus implicit serial
+        sequences) Procrastinate creates, derived from the installed
+        package's own bundled schema (SchemaManager.get_schema()) so the
+        list can never drift from the version actually running. Needs the
+        procrastinate package but no database connection."""
+        _import_procrastinate()
+        from procrastinate import schema as procrastinate_schema
+
+        from fymo.core.schema import parse_schema_sql
+        return parse_schema_sql(procrastinate_schema.SchemaManager.get_schema())
+
     def run_worker(self, **kwargs) -> None:
         """Block, actually executing submitted jobs — the `fymo jobs-worker`
         entry point. Runs in its own OS process, separate from the web

--- a/journal/journal_025.md
+++ b/journal/journal_025.md
@@ -1,0 +1,79 @@
+# Journal Entry 025: Proving the Second Data Point
+
+**Date**: July 16, 2026
+**Focus**: PostgresUserStore, and what "pluggable" actually costs to claim
+**Status**: Shipped
+
+## One Implementation Is Not an Interface
+
+The auth store has been a Protocol since day one, with a docstring
+promising you can swap it via one line of fymo.yml. Technically true. In
+practice, fymo shipped exactly one implementation, SQLite, so "swappable"
+meant writing twelve methods from scratch with no second example to copy
+from. Meanwhile most real fymo apps already run Postgres, jobs and
+broadcasts assume it outright, so the common deployment ended up with app
+data in Postgres and user identity in a lonely SQLite file nothing else
+knows exists. Two datastores, no foreign key between them, ownership rows
+keyed by email string because there's no shared id to point at.
+
+The fix was issue 50's option one: ship PostgresUserStore next to
+SqliteUserStore, same Protocol, same constructor shape, so the swap really
+is one config line. The store reads DATABASE_URL, the same variable the
+job queue and broadcast provider already use, which is the whole point.
+Identity lands in the database the rest of the app lives in.
+
+## The Battery Came First
+
+The real deliverable isn't the Postgres class, it's the conformance suite.
+Before writing a line of the new store, I pulled every behavior the SQLite
+store promises into one battery and parametrized it over store factories:
+duplicate email collision, case-insensitive lookup, epoch bumping on
+password change, consume-once tokens, superseded tokens, identity linking
+where the first link wins. Thirty-three tests, run identically against
+both backends. SQLite went green immediately, which proved the battery
+described reality rather than my hopes. Then the Postgres half failed with
+a missing module, which is exactly the failure you want to see before the
+module exists.
+
+Writing the battery also forced honesty about semantics I'd have otherwise
+glossed over. A failed INSERT in Postgres aborts the whole transaction,
+so there's a test that creates a duplicate, catches the error, and then
+keeps using the store, because a backend that forgets to roll back passes
+every test except the one that runs after a failure.
+
+## Dialect, Not Redesign
+
+The translation itself stayed deliberately boring. SQLite's UNIQUE COLLATE
+NOCASE became a unique index on lower(email). The single locked connection
+became a small psycopg_pool, four connections, no tuning knobs, each
+method borrowing one for exactly one transaction. Schema bootstrap happens
+on first connect like the SQLite store, wrapped in an advisory lock so
+eight workers booting at once don't race the CREATEs. Every object is
+prefixed fymo_ and listed at the top of the module, because these tables
+share a database with app tables and nobody should have to guess which
+rows are the framework's.
+
+Two failure modes got promoted to boot time on purpose. Missing
+DATABASE_URL raises in the constructor, naming the variable. Missing
+psycopg raises naming the exact install command, fymo[postgres]. A store
+that waits until the first login attempt to discover it can't connect is
+a store that fails in production at 2 a.m. instead of in the terminal at
+deploy.
+
+## Run It for Real
+
+Conformance against a mock proves nothing about a database, so the whole
+battery ran against an actual Postgres 16, thirty-three for thirty-three,
+plus a migration test that builds the table the old way and watches the
+store add the missing columns on connect. Then the loader path end to end:
+resolve the dotted config path, instantiate with a project root, create
+and fetch a user through a real pool. The full suite closed it out, 977
+tests, everything green, including the eight-threads-against-a-four-
+connection-pool case that makes the pool actually wait.
+
+The Protocol finally has its second data point. Turns out the way to prove
+an interface is pluggable is to plug something into it.
+
+---
+
+*End of Journal Entry 025*

--- a/journal/journal_026.md
+++ b/journal/journal_026.md
@@ -39,6 +39,25 @@ a CREATE statement it can't classify, it raises. A partial list is worse
 than no list, because the whole point is feeding an exclude list to a
 tool that deletes what isn't mentioned.
 
+My first version of that rule was a lie, and review caught it cold. I
+anchored the scan to CREATE at the start of a line, which reads as a
+tidy simplification and is actually a silent-skip mechanism: a CREATE
+tucked inside a DO block, or a second CREATE sharing a line, just never
+existed as far as the parser was concerned. Worse, the proof was already
+sitting in procrastinate's real schema, which opens with an indented
+CREATE EXTENSION inside a DO block that my parser walked straight past
+while its tests glowed green, because the drift guard used the same
+anchor and shared the same blind spot. The kill chain writes itself: a
+future procrastinate guards a new table behind the same DO pattern, the
+list misses it, the next diff drops it. So the anchor is gone. The
+parser now strips comments and visits every CREATE token in the text,
+wherever it hides, and each one is classified or the parser raises;
+there is no third outcome, by construction. The guard test got rebuilt
+on a different axis entirely, a flat token walk that shares no code with
+the parser, so the two can't agree on a blind spot again. And the
+catalog cross-check now runs against a real Postgres on every push
+instead of only when someone remembers to point it at one.
+
 Two details earned their place the hard way. Tables with bigserial or
 identity columns create sequences nobody wrote a CREATE SEQUENCE for,
 and a schema tool that enumerates sequences will happily propose
@@ -76,11 +95,12 @@ procrastinate exits 1 naming the extra, never printing half a list.
 
 The acceptance test I trust most applied procrastinate's schema to a
 throwaway Postgres and diffed the actual catalog against the command's
-output: tables, functions, types, sequences equal exactly, triggers and
-explicit indexes accounted for, constraint-backed indexes left to their
-tables. The enumeration and reality agree on every one of the forty-five
-objects. The next diff plan that wants to drop the queue will have to
-get past a generated exclude list instead of my reading comprehension.
+output: tables, functions, types, sequences equal exactly, explicit
+indexes and triggers equal once constraint-backed ones are set aside as
+their tables' problem. The enumeration and reality agree on every one of
+the forty-six objects, the guarded plpgsql extension included. The next
+diff plan that wants to drop the queue will have to get past a generated
+exclude list instead of my reading comprehension.
 
 ---
 

--- a/journal/journal_026.md
+++ b/journal/journal_026.md
@@ -1,0 +1,87 @@
+# Journal Entry 026: The Diff That Wanted to Drop the Queue
+
+**Date**: July 16, 2026
+**Focus**: fymo schema provider-tables, and who owns what in a shared database
+**Status**: Shipped
+
+## The Plan I Almost Applied
+
+A declarative schema diff against a real database produced a plan that
+was, line by line, a demolition order for the job queue. DROP TABLE
+procrastinate_jobs. DROP TABLE procrastinate_events. DROP FUNCTION,
+DROP TYPE, all of it. The tool wasn't wrong, it was doing exactly its
+job: diff the database against the schema file, and the schema file only
+declares what the app owns. Nobody told it that fymo's job provider had
+quietly moved furniture into the same schema. I caught it by reading the
+plan before applying it, which is luck wearing the costume of process.
+
+The gap wasn't in the schema tool and it wasn't really in procrastinate
+either. It was that fymo's providers create real, permanent database
+objects and offer no way for anything outside fymo to ask which ones.
+
+## Deriving Instead of Declaring
+
+The obvious fix is a documented list: procrastinate creates these four
+tables, these types, done. I wrote that list out and then deleted it,
+because a hardcoded list is a lie with a delay on it. Procrastinate
+upgrades, adds a table or a function version suffix, and the list keeps
+confidently naming last year's objects while the diff tool eyes the new
+ones.
+
+It turns out procrastinate ships its own answer: the package bundles the
+exact SQL it applies, exposed programmatically, no database connection
+required. So the provider now derives its declaration by parsing that
+bundled DDL. Whatever version is installed is whatever gets enumerated,
+and the two cannot drift apart because there is only one source.
+
+The parser has one rule I care about more than any feature: if it meets
+a CREATE statement it can't classify, it raises. A partial list is worse
+than no list, because the whole point is feeding an exclude list to a
+tool that deletes what isn't mentioned.
+
+Two details earned their place the hard way. Tables with bigserial or
+identity columns create sequences nobody wrote a CREATE SEQUENCE for,
+and a schema tool that enumerates sequences will happily propose
+dropping procrastinate_jobs_id_seq even if the table itself is excluded,
+so the parser surfaces those too. And every Postgres table secretly
+registers a row type in pg_type, which briefly made my catalog
+cross-check claim the output was missing four types before I understood
+the catalog was the one padding the count.
+
+## The Seam
+
+Each provider base class now answers owned_schema_objects(), default
+empty. Procrastinate overrides it. The threaded job provider owns
+nothing, honestly. The postgres broadcast provider, which the issue
+half-suspected of the same crime, turns out to be innocent: pure
+LISTEN/NOTIFY, not a single table, and saying so explicitly in a test
+felt better than leaving it implied.
+
+I deliberately kept the method off the provider Protocols. They're
+runtime-checkable, and existing custom providers written before this
+seam would suddenly fail isinstance checks over a feature they never
+asked for. The CLI reaches through a small duck-typed helper instead,
+which also means anything that isn't a job or broadcast provider, say a
+user store that creates its own tables someday, can join by defining the
+same method.
+
+The command itself is `fymo schema provider-tables`, a group with one
+subcommand, because the issue's third wish (schema fragments an app can
+import) will want the same roof eventually. Plain output is one
+kind-prefixed name per line, --json for tooling, stdout kept pure so it
+pipes, notes and errors on stderr. Configured but uninstalled
+procrastinate exits 1 naming the extra, never printing half a list.
+
+## Proof Against a Real Catalog
+
+The acceptance test I trust most applied procrastinate's schema to a
+throwaway Postgres and diffed the actual catalog against the command's
+output: tables, functions, types, sequences equal exactly, triggers and
+explicit indexes accounted for, constraint-backed indexes left to their
+tables. The enumeration and reality agree on every one of the forty-five
+objects. The next diff plan that wants to drop the queue will have to
+get past a generated exclude list instead of my reading comprehension.
+
+---
+
+*End of Journal Entry 026*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ dev = [
     "pytest-asyncio>=0.23",
     "pydantic>=2.5",
     "granian>=2.0,<3",
+    "procrastinate>=3.0",
+    "psycopg[binary,pool]>=3.1",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 [project.optional-dependencies]
 pydantic = ["pydantic>=2.5"]
 procrastinate = ["procrastinate>=3.0", "psycopg[binary,pool]>=3.1"]
+postgres = ["psycopg[binary,pool]>=3.1"]
 granian = ["granian>=2.0,<3"]
 
 [project.scripts]

--- a/tests/auth/test_postgres_store.py
+++ b/tests/auth/test_postgres_store.py
@@ -1,0 +1,76 @@
+"""PostgresUserStore behavior outside the shared conformance battery.
+
+Boot-time failure modes need no database and always run: both must raise at
+construction with an actionable message, never on the first request. The
+migration test needs a real Postgres and is gated on TEST_DATABASE_URL like
+the conformance battery.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from fymo.auth.postgres_store import PostgresUserStore
+
+
+def test_missing_database_url_raises_at_construction(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        PostgresUserStore(tmp_path)
+
+
+def test_missing_psycopg_names_the_install_command(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/unused")
+    # A None entry in sys.modules makes `import psycopg` raise ImportError,
+    # simulating the extra not being installed.
+    monkeypatch.setitem(sys.modules, "psycopg", None)
+    with pytest.raises(RuntimeError, match=r"fymo\[postgres\]"):
+        PostgresUserStore(tmp_path)
+
+
+def test_construction_does_not_connect(monkeypatch, tmp_path: Path):
+    """The pool opens on first use, like SqliteUserStore's lazy connect;
+    an unreachable database must not block boot."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:1/nowhere")
+    store = PostgresUserStore(tmp_path)
+    assert store._pool is None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="needs TEST_DATABASE_URL pointing at a real Postgres instance",
+)
+def test_migrates_table_created_before_later_columns(monkeypatch, tmp_path: Path):
+    """A fymo_users table created before the session_epoch and token columns
+    existed must gain them on first connect, defaulting existing rows to
+    epoch 1 rather than erroring. Mirror of the SqliteUserStore migration
+    test in test_store.py."""
+    url = os.environ["TEST_DATABASE_URL"]
+    monkeypatch.setenv("DATABASE_URL", url)
+    import psycopg
+    with psycopg.connect(url, autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS fymo_user_oauth_identities, fymo_users")
+        conn.execute(
+            "CREATE TABLE fymo_users ("
+            " id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,"
+            " email TEXT NOT NULL,"
+            " password_hash TEXT,"
+            " email_verified BOOLEAN NOT NULL DEFAULT FALSE,"
+            " created_at TEXT NOT NULL,"
+            " fymo_uid TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO fymo_users (email, password_hash, created_at)"
+            " VALUES ('legacy@x.com', 'h', '2026-01-01T00:00:00+00:00')"
+        )
+
+    store = PostgresUserStore(tmp_path)
+    try:
+        user = store.get_by_email("legacy@x.com")
+        assert user is not None
+        assert user.session_epoch == 1
+        store.bump_session_epoch(user.id)
+        assert store.get_by_id(user.id).session_epoch == 2
+    finally:
+        store.close()

--- a/tests/auth/test_postgres_store.py
+++ b/tests/auth/test_postgres_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from fymo.auth.postgres_store import PostgresUserStore
+from fymo.auth.store import EmailAlreadyExists, SqliteUserStore
 
 
 def test_missing_database_url_raises_at_construction(monkeypatch, tmp_path: Path):
@@ -72,5 +73,33 @@ def test_migrates_table_created_before_later_columns(monkeypatch, tmp_path: Path
         assert user.session_epoch == 1
         store.bump_session_epoch(user.id)
         assert store.get_by_id(user.id).session_epoch == 2
+    finally:
+        store.close()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="needs TEST_DATABASE_URL pointing at a real Postgres instance",
+)
+def test_non_ascii_email_case_collision_diverges_from_sqlite(monkeypatch, tmp_path: Path):
+    """Known, documented divergence (see the module docstring): lower()
+    folds per the database locale while SQLite's NOCASE folds ASCII only,
+    so these two spellings coexist as distinct users in a SQLite auth.db
+    but collide here. Consequence: a SQLite database already holding both
+    cannot be imported into this store."""
+    sqlite_store = SqliteUserStore(tmp_path)
+    sqlite_store.create("É@example.com", "h")
+    sqlite_store.create("é@example.com", "h")
+
+    url = os.environ["TEST_DATABASE_URL"]
+    monkeypatch.setenv("DATABASE_URL", url)
+    import psycopg
+    with psycopg.connect(url, autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS fymo_user_oauth_identities, fymo_users")
+    store = PostgresUserStore(tmp_path)
+    try:
+        store.create("É@example.com", "h")
+        with pytest.raises(EmailAlreadyExists):
+            store.create("é@example.com", "h")
     finally:
         store.close()

--- a/tests/auth/test_postgres_store.py
+++ b/tests/auth/test_postgres_store.py
@@ -103,3 +103,35 @@ def test_non_ascii_email_case_collision_diverges_from_sqlite(monkeypatch, tmp_pa
             store.create("é@example.com", "h")
     finally:
         store.close()
+
+
+def test_bootstrap_failure_closes_the_pool(monkeypatch, tmp_path: Path):
+    """If schema bootstrap raises on the first call (transient outage), the
+    freshly built pool must be closed, not leaked with its background
+    workers reconnecting forever, and _pool must stay None so the next
+    call retries from scratch."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/unused")
+    store = PostgresUserStore(tmp_path)
+
+    created = []
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            self.closed = False
+            created.append(self)
+
+        def connection(self):
+            raise RuntimeError("bootstrap boom")
+
+        def close(self):
+            self.closed = True
+
+    class FakePoolModule:
+        ConnectionPool = FakePool
+
+    monkeypatch.setattr(store, "_psycopg_pool", FakePoolModule)
+    with pytest.raises(RuntimeError, match="bootstrap boom"):
+        store.get_by_id(1)
+    assert store._pool is None
+    assert len(created) == 1
+    assert created[0].closed is True

--- a/tests/auth/test_postgres_store.py
+++ b/tests/auth/test_postgres_store.py
@@ -135,3 +135,36 @@ def test_bootstrap_failure_closes_the_pool(monkeypatch, tmp_path: Path):
     assert store._pool is None
     assert len(created) == 1
     assert created[0].closed is True
+
+
+def test_owned_schema_objects_needs_no_construction_and_no_database_url(monkeypatch):
+    """`fymo schema provider-tables` promises no-database operation, while
+    __init__ is deliberately boot-loud about DATABASE_URL. The declaration
+    therefore lives on the class: callable without constructing a store,
+    without the env var, without a connection."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    objs = PostgresUserStore.owned_schema_objects()
+    assert objs
+
+
+def test_owned_schema_objects_match_the_packaged_schema():
+    """Derived from schema_postgres.sql via the same parser the
+    procrastinate provider uses, never a re-hardcoded list. Constraint
+    backed pkey indexes are implicit through their tables and stay out,
+    consistent with the procrastinate enumeration."""
+    assert {
+        (o.kind, o.name) for o in PostgresUserStore.owned_schema_objects()
+    } == {
+        ("table", "fymo_users"),
+        ("sequence", "fymo_users_id_seq"),
+        ("index", "fymo_users_email_lower_idx"),
+        ("table", "fymo_user_oauth_identities"),
+    }
+
+
+def test_sqlite_store_declares_no_schema_objects(tmp_path: Path):
+    """SqliteUserStore's objects live in its own auth.db file, not in a
+    shared Postgres schema, so it has nothing to declare."""
+    from fymo.core.schema import owned_schema_objects
+    assert owned_schema_objects(SqliteUserStore) == ()
+    assert owned_schema_objects(SqliteUserStore(tmp_path)) == ()

--- a/tests/auth/test_store_conformance.py
+++ b/tests/auth/test_store_conformance.py
@@ -1,0 +1,354 @@
+"""UserStore Protocol conformance battery, run identically against every
+shipped backend.
+
+SqliteUserStore always runs. PostgresUserStore runs only when
+TEST_DATABASE_URL points at a reachable Postgres instance (the same opt-in
+the procrastinate and postgres-broadcast tests use); otherwise its half of
+the matrix is skipped with that reason. The Postgres half drops and
+recreates the fymo_ auth tables per test, so point TEST_DATABASE_URL at a
+scratch database, never a real one.
+"""
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from fymo.auth.store import EmailAlreadyExists, SqliteUserStore, User, UserStore
+from fymo.auth.verify_token import make_reset_token, make_verify_token
+from fymo.remote import identity
+from fymo.remote.identity import set_secret
+
+
+@pytest.fixture(autouse=True)
+def _wire_secret():
+    previous = identity._secret
+    set_secret(b"x" * 32)
+    yield
+    identity._secret = previous
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def store_factory(request, tmp_path: Path, monkeypatch):
+    """Callable returning a fresh store instance over the same backend state.
+
+    Most tests use the derived `store` fixture; the persistence test calls
+    this twice to prove data survives an instance swap.
+    """
+    created = []
+    if request.param == "sqlite":
+        def make():
+            s = SqliteUserStore(tmp_path)
+            created.append(s)
+            return s
+        yield make
+    else:
+        url = os.environ.get("TEST_DATABASE_URL")
+        if not url:
+            pytest.skip("needs TEST_DATABASE_URL pointing at a real Postgres instance")
+        monkeypatch.setenv("DATABASE_URL", url)
+        import psycopg
+        with psycopg.connect(url, autocommit=True) as conn:
+            conn.execute(
+                "DROP TABLE IF EXISTS fymo_user_oauth_identities, fymo_users"
+            )
+        from fymo.auth.postgres_store import PostgresUserStore
+
+        def make():
+            s = PostgresUserStore(tmp_path)
+            created.append(s)
+            return s
+        yield make
+    for s in created:
+        close = getattr(s, "close", None)
+        if close is not None:
+            close()
+
+
+@pytest.fixture
+def store(store_factory):
+    return store_factory()
+
+
+# Protocol shape
+
+def test_satisfies_userstore_protocol(store):
+    assert isinstance(store, UserStore)
+
+
+# create / get_by_id / get_by_email
+
+def test_create_and_get_by_id(store):
+    u = store.create("alice@example.com", "scrypt$hash")
+    assert isinstance(u, User)
+    assert u.id > 0
+    assert u.email == "alice@example.com"
+    assert u.password_hash == "scrypt$hash"
+    assert u.email_verified is False
+    assert u.created_at
+    assert u.fymo_uid is None
+    assert u.session_epoch == 1
+
+    fetched = store.get_by_id(u.id)
+    assert fetched is not None
+    assert fetched.id == u.id
+    assert fetched.email == u.email
+    assert fetched.password_hash == u.password_hash
+    assert fetched.email_verified is False
+    assert fetched.created_at == u.created_at
+    assert fetched.session_epoch == 1
+
+
+def test_create_allows_null_password_hash(store):
+    u = store.create("oauth-only@example.com", None)
+    assert u.password_hash is None
+    assert store.get_by_id(u.id).password_hash is None
+
+
+def test_get_by_id_missing_returns_none(store):
+    assert store.get_by_id(999999) is None
+
+
+def test_get_by_email_missing_returns_none(store):
+    assert store.get_by_email("nobody@nowhere.com") is None
+
+
+def test_get_by_email_is_case_insensitive(store):
+    store.create("Bob@Example.com", None)
+    assert store.get_by_email("bob@example.com") is not None
+    assert store.get_by_email("BOB@EXAMPLE.COM") is not None
+
+
+def test_duplicate_email_raises(store):
+    store.create("dup@example.com", "h")
+    with pytest.raises(EmailAlreadyExists):
+        store.create("dup@example.com", "h")
+
+
+def test_duplicate_email_case_insensitive(store):
+    store.create("UPPER@example.com", "h")
+    with pytest.raises(EmailAlreadyExists):
+        store.create("upper@example.com", "h")
+
+
+def test_store_still_usable_after_duplicate_email(store):
+    """The failed INSERT must not poison later calls (a Postgres backend
+    that forgets to roll back would fail every statement after the first
+    unique violation)."""
+    store.create("first@example.com", "h")
+    with pytest.raises(EmailAlreadyExists):
+        store.create("first@example.com", "h")
+    u = store.create("second@example.com", "h")
+    assert store.get_by_id(u.id) is not None
+    assert store.get_by_email("first@example.com") is not None
+
+
+def test_persists_across_store_instances(store_factory):
+    first = store_factory()
+    u = first.create("persist@me.com", "h")
+    second = store_factory()
+    again = second.get_by_id(u.id)
+    assert again is not None
+    assert again.email == "persist@me.com"
+
+
+# password / session epoch
+
+def test_set_password_hash_updates_hash(store):
+    u = store.create("p@p.com", None)
+    store.set_password_hash(u.id, "scrypt$new")
+    assert store.get_by_id(u.id).password_hash == "scrypt$new"
+
+
+def test_set_password_hash_bumps_epoch(store):
+    u = store.create("pw@x.com", "h")
+    assert u.session_epoch == 1
+    store.set_password_hash(u.id, "scrypt$new")
+    assert store.get_by_id(u.id).session_epoch == 2
+
+
+def test_bump_session_epoch_increments(store):
+    u = store.create("bump@x.com", "h")
+    store.bump_session_epoch(u.id)
+    assert store.get_by_id(u.id).session_epoch == 2
+    store.bump_session_epoch(u.id)
+    assert store.get_by_id(u.id).session_epoch == 3
+
+
+# fymo_uid claim
+
+def test_claim_fymo_uid_sets_once(store):
+    u = store.create("c@c.com", "h")
+    assert u.fymo_uid is None
+    store.claim_fymo_uid(u.id, "u_first")
+    assert store.get_by_id(u.id).fymo_uid == "u_first"
+
+
+def test_claim_fymo_uid_is_idempotent(store):
+    u = store.create("c2@c.com", "h")
+    store.claim_fymo_uid(u.id, "u_first")
+    store.claim_fymo_uid(u.id, "u_second")
+    assert store.get_by_id(u.id).fymo_uid == "u_first"
+
+
+# external identities
+
+def test_link_identity_and_get_by_identity_roundtrip(store):
+    u = store.create("id@x.com", None)
+    store.link_identity(u.id, "google", "sub-123", "id@x.com")
+    found = store.get_by_identity("google", "sub-123")
+    assert found is not None
+    assert found.id == u.id
+
+
+def test_get_by_identity_unknown_returns_none(store):
+    assert store.get_by_identity("google", "no-such-sub") is None
+
+
+def test_link_identity_first_link_wins(store):
+    """Relinking the same (provider, sub) to another user is a no-op."""
+    a = store.create("a@x.com", None)
+    b = store.create("b@x.com", None)
+    store.link_identity(a.id, "github", "sub-1", "a@x.com")
+    store.link_identity(b.id, "github", "sub-1", "b@x.com")
+    assert store.get_by_identity("github", "sub-1").id == a.id
+
+
+def test_link_identity_distinct_subs_map_to_distinct_users(store):
+    a = store.create("a2@x.com", None)
+    b = store.create("b2@x.com", None)
+    store.link_identity(a.id, "github", "sub-a", None)
+    store.link_identity(b.id, "github", "sub-b", None)
+    assert store.get_by_identity("github", "sub-a").id == a.id
+    assert store.get_by_identity("github", "sub-b").id == b.id
+
+
+def test_one_user_can_hold_identities_from_multiple_providers(store):
+    u = store.create("multi@x.com", None)
+    store.link_identity(u.id, "google", "g-sub", None)
+    store.link_identity(u.id, "github", "h-sub", None)
+    assert store.get_by_identity("google", "g-sub").id == u.id
+    assert store.get_by_identity("github", "h-sub").id == u.id
+
+
+# email verification tokens
+
+def test_consume_verify_token_marks_verified(store):
+    u = store.create("v@x.com", "h")
+    token = make_verify_token(u.id)
+    store.set_verify_token(u.id, token)
+    assert store.consume_verify_token(token) == u.id
+    assert store.get_by_id(u.id).email_verified is True
+
+
+def test_consume_verify_token_is_single_use(store):
+    u = store.create("v2@x.com", "h")
+    token = make_verify_token(u.id)
+    store.set_verify_token(u.id, token)
+    assert store.consume_verify_token(token) == u.id
+    assert store.consume_verify_token(token) is None
+
+
+def test_consume_verify_token_garbage_returns_none(store):
+    assert store.consume_verify_token("not.a.token") is None
+
+
+def test_consume_verify_token_never_issued_returns_none(store):
+    """Signature-valid token for a user that never had one recorded."""
+    u = store.create("v3@x.com", "h")
+    assert store.consume_verify_token(make_verify_token(u.id)) is None
+    assert store.get_by_id(u.id).email_verified is False
+
+
+def test_consume_verify_token_unknown_user_returns_none(store):
+    assert store.consume_verify_token(make_verify_token(999999)) is None
+
+
+def test_consume_verify_token_superseded_returns_none(store):
+    """A newer set_verify_token invalidates the earlier token."""
+    u = store.create("v4@x.com", "h")
+    now = int(time.time())
+    old = make_verify_token(u.id, issued_at=now - 10)
+    new = make_verify_token(u.id, issued_at=now)
+    store.set_verify_token(u.id, old)
+    store.set_verify_token(u.id, new)
+    assert store.consume_verify_token(old) is None
+    assert store.consume_verify_token(new) == u.id
+
+
+# password reset tokens
+
+def test_consume_reset_token_returns_user_id(store):
+    u = store.create("r@x.com", "h")
+    token = make_reset_token(u.id)
+    store.set_reset_token(u.id, token)
+    assert store.consume_reset_token(token) == u.id
+
+
+def test_consume_reset_token_does_not_verify_email(store):
+    u = store.create("r2@x.com", "h")
+    token = make_reset_token(u.id)
+    store.set_reset_token(u.id, token)
+    store.consume_reset_token(token)
+    assert store.get_by_id(u.id).email_verified is False
+
+
+def test_consume_reset_token_is_single_use(store):
+    u = store.create("r3@x.com", "h")
+    token = make_reset_token(u.id)
+    store.set_reset_token(u.id, token)
+    assert store.consume_reset_token(token) == u.id
+    assert store.consume_reset_token(token) is None
+
+
+def test_consume_reset_token_never_issued_returns_none(store):
+    u = store.create("r4@x.com", "h")
+    assert store.consume_reset_token(make_reset_token(u.id)) is None
+
+
+def test_consume_reset_token_superseded_returns_none(store):
+    u = store.create("r5@x.com", "h")
+    now = int(time.time())
+    old = make_reset_token(u.id, issued_at=now - 10)
+    new = make_reset_token(u.id, issued_at=now)
+    store.set_reset_token(u.id, old)
+    store.set_reset_token(u.id, new)
+    assert store.consume_reset_token(old) is None
+    assert store.consume_reset_token(new) == u.id
+
+
+def test_concurrent_creates_from_many_threads(store):
+    """Both backends must survive parallel writers: SqliteUserStore via its
+    connection lock, PostgresUserStore via the connection pool (more threads
+    here than the pool's max_size, so waiting is exercised too)."""
+    import threading
+    errors = []
+
+    def work(i: int) -> None:
+        try:
+            u = store.create(f"thread{i}@x.com", "h")
+            assert store.get_by_id(u.id).email == f"thread{i}@x.com"
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=work, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert errors == []
+    assert all(not t.is_alive() for t in threads)
+
+
+def test_tokens_are_purpose_bound(store):
+    """A verify token can never be consumed as a reset token or vice versa,
+    even for the same user with both outstanding."""
+    u = store.create("cross@x.com", "h")
+    verify = make_verify_token(u.id)
+    reset = make_reset_token(u.id)
+    store.set_verify_token(u.id, verify)
+    store.set_reset_token(u.id, reset)
+    assert store.consume_reset_token(verify) is None
+    assert store.consume_verify_token(reset) is None
+    assert store.consume_verify_token(verify) == u.id
+    assert store.consume_reset_token(reset) == u.id

--- a/tests/broadcast/providers/test_schema_objects.py
+++ b/tests/broadcast/providers/test_schema_objects.py
@@ -1,0 +1,16 @@
+"""Broadcast providers and the owned-schema-objects declaration.
+
+The postgres broadcast provider is pure LISTEN/NOTIFY, it creates no
+tables, functions, or types, so it must declare exactly nothing (issue
+#51 named it as a suspect; the honest answer is an empty list).
+"""
+from fymo.broadcast.providers.base import BaseBroadcastProvider
+from fymo.broadcast.providers.postgres import PostgresBroadcastProvider
+
+
+def test_base_broadcast_provider_owns_no_schema_objects():
+    assert BaseBroadcastProvider().owned_schema_objects() == ()
+
+
+def test_postgres_broadcast_provider_owns_no_schema_objects():
+    assert PostgresBroadcastProvider().owned_schema_objects() == ()

--- a/tests/cli/test_schema_provider_tables.py
+++ b/tests/cli/test_schema_provider_tables.py
@@ -83,6 +83,76 @@ def test_missing_procrastinate_package_fails_loudly(procrastinate_project, capsy
     assert "fymo[procrastinate]" in captured.err
 
 
+@pytest.fixture
+def user_store_project(tmp_path: Path) -> Path:
+    return _write_project(
+        tmp_path,
+        "name: schema-test\n"
+        "auth:\n"
+        "  user_store: fymo.auth.postgres_store.PostgresUserStore\n",
+    )
+
+
+def test_configured_postgres_user_store_objects_are_listed(user_store_project, capsys, monkeypatch):
+    """The command's contract is no-database, no-env operation, so the
+    identity tables must enumerate with DATABASE_URL unset even though
+    constructing the store itself would refuse to boot without it."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    run_provider_tables(user_store_project)
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert "table fymo_users" in out_lines
+    assert "table fymo_user_oauth_identities" in out_lines
+    assert "sequence fymo_users_id_seq" in out_lines
+    assert "index fymo_users_email_lower_idx" in out_lines
+
+
+def test_user_store_json_output_names_the_store(user_store_project, capsys, monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    run_provider_tables(user_store_project, as_json=True)
+    objects = json.loads(capsys.readouterr().out)
+    users_table = [o for o in objects if o["name"] == "fymo_users"]
+    assert users_table == [
+        {"kind": "table", "name": "fymo_users", "provider": "PostgresUserStore"}
+    ]
+
+
+def test_default_user_store_contributes_nothing(tmp_path, capsys):
+    """auth: configured but on the default SQLite store, whose objects
+    live in its own auth.db file, not a shared Postgres schema."""
+    _write_project(tmp_path, "name: schema-test\nauth:\n  enabled: true\n")
+    run_provider_tables(tmp_path)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no configured provider owns schema objects" in captured.err
+
+
+def test_jobs_and_user_store_enumerate_together(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _write_project(
+        tmp_path,
+        "name: schema-test\n"
+        "jobs:\n  provider: procrastinate\n"
+        "auth:\n  user_store: fymo.auth.postgres_store.PostgresUserStore\n",
+    )
+    run_provider_tables(tmp_path)
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert "table procrastinate_jobs" in out_lines
+    assert "table fymo_users" in out_lines
+
+
+def test_unimportable_user_store_fails_loudly(tmp_path, capsys):
+    _write_project(
+        tmp_path,
+        "name: schema-test\nauth:\n  user_store: nope.not.There\n",
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_provider_tables(tmp_path)
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "nope.not.There" in captured.err
+
+
 def test_schema_parse_error_uses_the_clean_error_path(procrastinate_project, capsys, monkeypatch):
     """A provider whose DDL the parser can't classify must exit 1 with a
     clean stderr message and empty stdout, not a raw traceback."""

--- a/tests/cli/test_schema_provider_tables.py
+++ b/tests/cli/test_schema_provider_tables.py
@@ -40,7 +40,7 @@ def test_plain_output_is_one_kind_prefixed_object_per_line(procrastinate_project
     assert any(line.startswith("function procrastinate_") for line in out_lines)
     for line in out_lines:
         kind, _, name = line.partition(" ")
-        assert kind in {"table", "type", "function", "sequence", "index", "trigger"}
+        assert kind in {"table", "type", "function", "sequence", "index", "trigger", "extension"}
         assert name and " " not in name
 
 
@@ -81,6 +81,24 @@ def test_missing_procrastinate_package_fails_loudly(procrastinate_project, capsy
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "fymo[procrastinate]" in captured.err
+
+
+def test_schema_parse_error_uses_the_clean_error_path(procrastinate_project, capsys, monkeypatch):
+    """A provider whose DDL the parser can't classify must exit 1 with a
+    clean stderr message and empty stdout, not a raw traceback."""
+    from fymo.core.schema import SchemaParseError
+    from fymo.jobs.providers.procrastinate import ProcrastinateJobProvider
+
+    def _boom(self):
+        raise SchemaParseError("unrecognized CREATE statement: 'CREATE ROLE nope'")
+
+    monkeypatch.setattr(ProcrastinateJobProvider, "owned_schema_objects", _boom)
+    with pytest.raises(SystemExit) as exc_info:
+        run_provider_tables(procrastinate_project)
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "unrecognized CREATE statement" in captured.err
 
 
 def test_cli_end_to_end_against_a_scaffolded_project(procrastinate_project):

--- a/tests/cli/test_schema_provider_tables.py
+++ b/tests/cli/test_schema_provider_tables.py
@@ -1,0 +1,101 @@
+"""Tests for `fymo schema provider-tables` (issue #51).
+
+The command answers "which database objects do my configured providers
+own" without touching any database, so schema diff tooling (pgschema and
+friends) can build an exclude list instead of proposing DROP TABLE for
+the live job queue.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from fymo.cli.commands.schema import run_provider_tables
+
+
+def _write_project(tmp_path: Path, fymo_yml: str) -> Path:
+    (tmp_path / "fymo.yml").write_text(fymo_yml)
+    return tmp_path
+
+
+@pytest.fixture
+def procrastinate_project(tmp_path: Path) -> Path:
+    return _write_project(
+        tmp_path,
+        "name: schema-test\njobs:\n  provider: procrastinate\n",
+    )
+
+
+def test_plain_output_is_one_kind_prefixed_object_per_line(procrastinate_project, capsys):
+    run_provider_tables(procrastinate_project)
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert "table procrastinate_jobs" in out_lines
+    assert "table procrastinate_events" in out_lines
+    assert "table procrastinate_periodic_defers" in out_lines
+    assert "table procrastinate_workers" in out_lines
+    assert "type procrastinate_job_status" in out_lines
+    assert "sequence procrastinate_jobs_id_seq" in out_lines
+    assert any(line.startswith("function procrastinate_") for line in out_lines)
+    for line in out_lines:
+        kind, _, name = line.partition(" ")
+        assert kind in {"table", "type", "function", "sequence", "index", "trigger"}
+        assert name and " " not in name
+
+
+def test_json_output_carries_kind_name_and_provider(procrastinate_project, capsys):
+    run_provider_tables(procrastinate_project, as_json=True)
+    objects = json.loads(capsys.readouterr().out)
+    assert isinstance(objects, list) and objects
+    jobs_table = [o for o in objects if o["name"] == "procrastinate_jobs"]
+    assert jobs_table == [
+        {"kind": "table", "name": "procrastinate_jobs", "provider": "procrastinate"}
+    ]
+    assert all(set(o) == {"kind", "name", "provider"} for o in objects)
+
+
+def test_no_owning_provider_prints_nothing_and_notes_it_on_stderr(tmp_path, capsys):
+    """Default providers (threaded jobs, postgres broadcasts) own no
+    schema objects: empty stdout, a stderr note, normal exit."""
+    run_provider_tables(tmp_path)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no configured provider owns schema objects" in captured.err
+
+
+def test_json_with_no_owning_provider_prints_an_empty_list(tmp_path, capsys):
+    run_provider_tables(tmp_path, as_json=True)
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == []
+    assert "no configured provider owns schema objects" in captured.err
+
+
+def test_missing_procrastinate_package_fails_loudly(procrastinate_project, capsys, monkeypatch):
+    """procrastinate configured but not installed: exit 1 naming the
+    extra, never a silent partial list."""
+    monkeypatch.setitem(sys.modules, "procrastinate", None)
+    with pytest.raises(SystemExit) as exc_info:
+        run_provider_tables(procrastinate_project)
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "fymo[procrastinate]" in captured.err
+
+
+def test_cli_end_to_end_against_a_scaffolded_project(procrastinate_project):
+    """Acceptance (issue #51): the real CLI, run in a project configured
+    with jobs: {provider: procrastinate}, enumerates every object a
+    pgschema-style exclude list needs, with no database anywhere."""
+    result = subprocess.run(
+        ["fymo", "schema", "provider-tables"],
+        cwd=procrastinate_project,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.strip().splitlines()
+    assert "table procrastinate_jobs" in lines
+    assert "type procrastinate_job_status" in lines
+    assert any(line.startswith("function procrastinate_") for line in lines)

--- a/tests/core/test_schema_objects.py
+++ b/tests/core/test_schema_objects.py
@@ -83,17 +83,58 @@ def test_statement_order_is_preserved():
 
 
 def test_comments_are_not_parsed():
-    sql = "-- CREATE TABLE commented_out (id integer);\nCREATE TABLE real_one (\n    id integer\n);"
+    sql = (
+        "-- CREATE TABLE commented_out (id integer);\n"
+        "/* CREATE INDEX block_commented ON x (y);\n"
+        "   spanning lines */\n"
+        "    -- note: CREATE EXTENSION may fail on managed services\n"
+        "CREATE TABLE real_one (\n    id integer\n);"
+    )
     objs = parse_schema_sql(sql)
     assert [o.name for o in objs] == ["real_one"]
+
+
+def test_create_inside_a_do_block_is_not_silently_skipped():
+    """A guarded CREATE TABLE inside DO $$ ... $$ still creates the table.
+    Skipping it because of indentation is the exact under-report this
+    parser exists to make impossible."""
+    sql = (
+        "DO $$\n"
+        "BEGIN\n"
+        "    CREATE TABLE guarded_tbl (\n        id integer\n    );\n"
+        "EXCEPTION WHEN duplicate_table THEN NULL;\n"
+        "END $$;\n"
+    )
+    assert SchemaObject(kind="table", name="guarded_tbl") in parse_schema_sql(sql)
+
+
+def test_two_create_statements_on_one_line_are_both_parsed():
+    sql = "CREATE SEQUENCE first_seq; CREATE SEQUENCE second_seq;"
+    names = [o.name for o in parse_schema_sql(sql)]
+    assert names == ["first_seq", "second_seq"]
+
+
+def test_create_extension_is_classified():
+    sql = "DO $$\nBEGIN\n    CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;\nEND $$;"
+    assert parse_schema_sql(sql) == (
+        SchemaObject(kind="extension", name="plpgsql"),
+    )
 
 
 def test_unrecognized_create_statement_fails_loudly():
     """A DDL form the parser doesn't understand must raise, never be
     silently dropped, an incomplete list defeats the whole point of
     building an exclude list from it."""
-    with pytest.raises(SchemaParseError, match="EXTENSION"):
-        parse_schema_sql("CREATE EXTENSION pgcrypto;")
+    with pytest.raises(SchemaParseError, match="ROLE"):
+        parse_schema_sql("CREATE ROLE queue_owner;")
+
+
+def test_unrecognized_create_raises_even_when_indented_mid_line():
+    with pytest.raises(SchemaParseError, match="PUBLICATION"):
+        parse_schema_sql(
+            "CREATE TABLE fine (\n    id integer\n);\n"
+            "DO $$ BEGIN CREATE PUBLICATION sneaky; END $$;"
+        )
 
 
 def test_owned_schema_objects_helper_defaults_to_empty():

--- a/tests/core/test_schema_objects.py
+++ b/tests/core/test_schema_objects.py
@@ -1,0 +1,113 @@
+"""Tests for fymo.core.schema, the owned-schema-objects seam.
+
+SchemaObject is the typed unit a provider uses to declare the database
+objects it creates for itself (issue #51: schema diff tools propose
+dropping provider tables because nothing enumerates them).
+parse_schema_sql derives that list from a provider's bundled DDL text so
+it can never drift from what the installed library actually creates.
+"""
+import pytest
+
+from fymo.core.schema import (
+    SchemaObject,
+    SchemaParseError,
+    owned_schema_objects,
+    parse_schema_sql,
+)
+
+
+def test_parses_create_table():
+    objs = parse_schema_sql("CREATE TABLE my_jobs (\n    id integer\n);")
+    assert SchemaObject(kind="table", name="my_jobs") in objs
+
+
+def test_parses_create_type():
+    sql = "CREATE TYPE my_status AS ENUM ('todo', 'done');"
+    assert parse_schema_sql(sql) == (SchemaObject(kind="type", name="my_status"),)
+
+
+def test_parses_create_function_with_or_replace():
+    sql = "CREATE OR REPLACE FUNCTION my_fetch_v1(queue_name varchar)\nRETURNS void AS $$ SELECT 1; $$ LANGUAGE sql;"
+    assert SchemaObject(kind="function", name="my_fetch_v1") in parse_schema_sql(sql)
+
+
+def test_parses_indexes_including_unique():
+    sql = (
+        "CREATE UNIQUE INDEX my_lock_idx ON my_jobs (lock);\n"
+        "CREATE INDEX my_queue_idx ON my_jobs (queue_name);"
+    )
+    objs = parse_schema_sql(sql)
+    assert SchemaObject(kind="index", name="my_lock_idx") in objs
+    assert SchemaObject(kind="index", name="my_queue_idx") in objs
+
+
+def test_parses_trigger_and_sequence():
+    sql = (
+        "CREATE SEQUENCE my_counter_seq;\n"
+        "CREATE TRIGGER my_notify AFTER INSERT ON my_jobs\n"
+        "    FOR EACH ROW EXECUTE PROCEDURE my_notify_fn();"
+    )
+    objs = parse_schema_sql(sql)
+    assert SchemaObject(kind="sequence", name="my_counter_seq") in objs
+    assert SchemaObject(kind="trigger", name="my_notify") in objs
+
+
+def test_serial_column_yields_the_implicit_sequence():
+    """bigserial/serial columns create a `<table>_<column>_seq` sequence
+    behind the scenes, a schema tool enumerating sequences would propose
+    dropping it, so the parser must surface it."""
+    sql = "CREATE TABLE my_jobs (\n    id bigserial PRIMARY KEY,\n    n integer\n);"
+    objs = parse_schema_sql(sql)
+    assert SchemaObject(kind="sequence", name="my_jobs_id_seq") in objs
+
+
+def test_identity_column_yields_the_implicit_sequence():
+    sql = (
+        "CREATE TABLE my_workers(\n"
+        "    id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,\n"
+        "    beat timestamp with time zone NOT NULL\n"
+        ");"
+    )
+    objs = parse_schema_sql(sql)
+    assert SchemaObject(kind="sequence", name="my_workers_id_seq") in objs
+
+
+def test_statement_order_is_preserved():
+    sql = (
+        "CREATE TYPE t_status AS ENUM ('a');\n"
+        "CREATE TABLE t_jobs (\n    id bigserial\n);\n"
+        "CREATE FUNCTION t_fn() RETURNS void AS $$ SELECT 1; $$ LANGUAGE sql;"
+    )
+    names = [o.name for o in parse_schema_sql(sql)]
+    assert names == ["t_status", "t_jobs", "t_jobs_id_seq", "t_fn"]
+
+
+def test_comments_are_not_parsed():
+    sql = "-- CREATE TABLE commented_out (id integer);\nCREATE TABLE real_one (\n    id integer\n);"
+    objs = parse_schema_sql(sql)
+    assert [o.name for o in objs] == ["real_one"]
+
+
+def test_unrecognized_create_statement_fails_loudly():
+    """A DDL form the parser doesn't understand must raise, never be
+    silently dropped, an incomplete list defeats the whole point of
+    building an exclude list from it."""
+    with pytest.raises(SchemaParseError, match="EXTENSION"):
+        parse_schema_sql("CREATE EXTENSION pgcrypto;")
+
+
+def test_owned_schema_objects_helper_defaults_to_empty():
+    class NoDeclaration:
+        pass
+
+    assert owned_schema_objects(NoDeclaration()) == ()
+
+
+def test_owned_schema_objects_helper_calls_the_declaration():
+    class Declares:
+        def owned_schema_objects(self):
+            return (SchemaObject(kind="table", name="fymo_users"),)
+
+    assert owned_schema_objects(Declares()) == (
+        SchemaObject(kind="table", name="fymo_users"),
+    )

--- a/tests/integration/test_provider_tables_pg.py
+++ b/tests/integration/test_provider_tables_pg.py
@@ -1,0 +1,124 @@
+"""Cross-check `fymo schema provider-tables` against a real Postgres.
+
+Applies procrastinate's bundled schema to the database TEST_DATABASE_URL
+points at, then diffs the actual catalog (pg_class/pg_type/pg_proc/
+pg_trigger) against what the command enumerates. This is the acceptance
+proof for issue #51: an exclude list built from the command's output
+protects every object procrastinate really created.
+
+Skipped without TEST_DATABASE_URL, same gate as
+tests/jobs/providers/test_procrastinate.py; point it at a throwaway
+Postgres (the schema apply is not reversible here).
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="needs TEST_DATABASE_URL pointing at a real Postgres instance",
+)
+
+
+@pytest.fixture
+def database_url() -> str:
+    return os.environ["TEST_DATABASE_URL"]
+
+
+@pytest.fixture(autouse=True)
+def _apply_schema(database_url):
+    import procrastinate
+    from procrastinate import exceptions, schema
+    connector = procrastinate.SyncPsycopgConnector(conninfo=database_url)
+    connector.open()
+    try:
+        schema.SchemaManager(connector).apply_schema()
+    except exceptions.ConnectorException as e:
+        if "already exists" not in str(e.__cause__):
+            raise
+    connector.close()
+
+
+@pytest.fixture
+def enumerated(tmp_path: Path, capsys):
+    from fymo.cli.commands.schema import run_provider_tables
+
+    (tmp_path / "fymo.yml").write_text(
+        "name: catalog-check\njobs:\n  provider: procrastinate\n"
+    )
+    run_provider_tables(tmp_path)
+    by_kind: dict = {}
+    for line in capsys.readouterr().out.strip().splitlines():
+        kind, _, name = line.partition(" ")
+        by_kind.setdefault(kind, set()).add(name)
+    return by_kind
+
+
+def _catalog(database_url, query):
+    import psycopg
+    with psycopg.connect(database_url) as conn:
+        return {row[0] for row in conn.execute(query)}
+
+
+def test_every_procrastinate_table_in_the_catalog_is_enumerated(database_url, enumerated):
+    tables = _catalog(
+        database_url,
+        "SELECT tablename FROM pg_tables"
+        " WHERE schemaname = 'public' AND tablename LIKE 'procrastinate%'",
+    )
+    assert tables == enumerated["table"]
+
+
+def test_every_procrastinate_function_in_the_catalog_is_enumerated(database_url, enumerated):
+    functions = _catalog(
+        database_url,
+        "SELECT DISTINCT p.proname FROM pg_proc p"
+        " JOIN pg_namespace n ON n.oid = p.pronamespace"
+        " WHERE n.nspname = 'public' AND p.proname LIKE 'procrastinate%'",
+    )
+    assert functions == enumerated["function"]
+
+
+def test_every_procrastinate_type_in_the_catalog_is_enumerated(database_url, enumerated):
+    # Enums and standalone composite types only: every table also gets an
+    # implicit row type in pg_type, which no schema tool manages separately.
+    types = _catalog(
+        database_url,
+        "SELECT t.typname FROM pg_type t"
+        " JOIN pg_namespace n ON n.oid = t.typnamespace"
+        " LEFT JOIN pg_class c ON c.oid = t.typrelid"
+        " WHERE n.nspname = 'public' AND t.typname LIKE 'procrastinate%'"
+        " AND (t.typtype = 'e' OR (t.typtype = 'c' AND c.relkind = 'c'))",
+    )
+    assert types == enumerated["type"]
+
+
+def test_every_procrastinate_sequence_in_the_catalog_is_enumerated(database_url, enumerated):
+    sequences = _catalog(
+        database_url,
+        "SELECT c.relname FROM pg_class c"
+        " JOIN pg_namespace n ON n.oid = c.relnamespace"
+        " WHERE n.nspname = 'public' AND c.relkind = 'S'"
+        " AND c.relname LIKE 'procrastinate%'",
+    )
+    assert sequences == enumerated["sequence"]
+
+
+def test_enumerated_indexes_and_triggers_exist_in_the_catalog(database_url, enumerated):
+    # Subset check, not equality: the catalog also holds constraint-backed
+    # indexes (pkeys, unique constraints) that only exist through their
+    # table, excluding the table already protects those.
+    indexes = _catalog(
+        database_url,
+        "SELECT indexname FROM pg_indexes WHERE schemaname = 'public'",
+    )
+    assert enumerated["index"] <= indexes
+
+    triggers = _catalog(
+        database_url,
+        "SELECT DISTINCT t.tgname FROM pg_trigger t WHERE NOT t.tgisinternal",
+    )
+    assert enumerated["trigger"] == {
+        t for t in triggers if t.startswith("procrastinate")
+    }

--- a/tests/integration/test_provider_tables_pg.py
+++ b/tests/integration/test_provider_tables_pg.py
@@ -105,16 +105,27 @@ def test_every_procrastinate_sequence_in_the_catalog_is_enumerated(database_url,
     assert sequences == enumerated["sequence"]
 
 
-def test_enumerated_indexes_and_triggers_exist_in_the_catalog(database_url, enumerated):
-    # Subset check, not equality: the catalog also holds constraint-backed
-    # indexes (pkeys, unique constraints) that only exist through their
-    # table, excluding the table already protects those.
+def test_every_explicit_procrastinate_index_in_the_catalog_is_enumerated(database_url, enumerated):
+    # Equality after excluding constraint-backed indexes (pkeys, unique
+    # constraints): those only exist through their table, no schema tool
+    # manages them separately, and excluding the table already protects
+    # them. Everything else on a procrastinate table must be enumerated,
+    # so an under-reported explicit CREATE INDEX fails here.
     indexes = _catalog(
         database_url,
-        "SELECT indexname FROM pg_indexes WHERE schemaname = 'public'",
+        "SELECT c.relname FROM pg_index i"
+        " JOIN pg_class c ON c.oid = i.indexrelid"
+        " JOIN pg_class t ON t.oid = i.indrelid"
+        " JOIN pg_namespace n ON n.oid = t.relnamespace"
+        " WHERE n.nspname = 'public' AND t.relname LIKE 'procrastinate%'"
+        " AND NOT EXISTS ("
+        "   SELECT 1 FROM pg_constraint con WHERE con.conindid = i.indexrelid"
+        " )",
     )
-    assert enumerated["index"] <= indexes
+    assert indexes == enumerated["index"]
 
+
+def test_every_procrastinate_trigger_in_the_catalog_is_enumerated(database_url, enumerated):
     triggers = _catalog(
         database_url,
         "SELECT DISTINCT t.tgname FROM pg_trigger t WHERE NOT t.tgisinternal",
@@ -122,3 +133,11 @@ def test_enumerated_indexes_and_triggers_exist_in_the_catalog(database_url, enum
     assert enumerated["trigger"] == {
         t for t in triggers if t.startswith("procrastinate")
     }
+
+
+def test_enumerated_extensions_exist_in_the_catalog(database_url, enumerated):
+    # Subset, not equality: the guarded CREATE EXTENSION plpgsql targets
+    # an extension every Postgres already ships, and the catalog may hold
+    # unrelated extensions the database had before the schema apply.
+    extensions = _catalog(database_url, "SELECT extname FROM pg_extension")
+    assert enumerated.get("extension", set()) <= extensions

--- a/tests/integration/test_provider_tables_pg.py
+++ b/tests/integration/test_provider_tables_pg.py
@@ -141,3 +141,59 @@ def test_enumerated_extensions_exist_in_the_catalog(database_url, enumerated):
     # unrelated extensions the database had before the schema apply.
     extensions = _catalog(database_url, "SELECT extname FROM pg_extension")
     assert enumerated.get("extension", set()) <= extensions
+
+
+def test_every_fymo_user_store_object_in_the_catalog_is_enumerated(
+    database_url, tmp_path: Path, capsys, monkeypatch
+):
+    """Same catalog cross-check for PostgresUserStore: bootstrap its real
+    schema, then require the fymo_ tables, identity sequence, and explicit
+    index to match the command's output exactly (constraint-backed pkey
+    indexes set aside, consistent with the procrastinate checks)."""
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    from fymo.auth.postgres_store import PostgresUserStore
+
+    store = PostgresUserStore(tmp_path)
+    store._get_pool().close()
+
+    from fymo.cli.commands.schema import run_provider_tables
+
+    (tmp_path / "fymo.yml").write_text(
+        "name: catalog-check\n"
+        "auth:\n"
+        "  user_store: fymo.auth.postgres_store.PostgresUserStore\n"
+    )
+    run_provider_tables(tmp_path)
+    by_kind: dict = {}
+    for line in capsys.readouterr().out.strip().splitlines():
+        kind, _, name = line.partition(" ")
+        by_kind.setdefault(kind, set()).add(name)
+
+    tables = _catalog(
+        database_url,
+        "SELECT tablename FROM pg_tables"
+        " WHERE schemaname = 'public' AND tablename LIKE 'fymo%'",
+    )
+    assert tables == by_kind["table"]
+
+    sequences = _catalog(
+        database_url,
+        "SELECT c.relname FROM pg_class c"
+        " JOIN pg_namespace n ON n.oid = c.relnamespace"
+        " WHERE n.nspname = 'public' AND c.relkind = 'S'"
+        " AND c.relname LIKE 'fymo%'",
+    )
+    assert sequences == by_kind["sequence"]
+
+    indexes = _catalog(
+        database_url,
+        "SELECT c.relname FROM pg_index i"
+        " JOIN pg_class c ON c.oid = i.indexrelid"
+        " JOIN pg_class t ON t.oid = i.indrelid"
+        " JOIN pg_namespace n ON n.oid = t.relnamespace"
+        " WHERE n.nspname = 'public' AND t.relname LIKE 'fymo%'"
+        " AND NOT EXISTS ("
+        "   SELECT 1 FROM pg_constraint con WHERE con.conindid = i.indexrelid"
+        " )",
+    )
+    assert indexes == by_kind["index"]

--- a/tests/jobs/providers/test_base.py
+++ b/tests/jobs/providers/test_base.py
@@ -24,3 +24,9 @@ def test_base_provider_run_worker_raises_a_clear_error():
     provider = BaseJobProvider()
     with pytest.raises(RuntimeError, match="has no separate worker process"):
         provider.run_worker()
+
+
+def test_base_provider_owns_no_schema_objects_by_default():
+    """A provider that creates nothing in the database (threaded, custom
+    in-memory queues) declares nothing, and the schema CLI stays quiet."""
+    assert BaseJobProvider().owned_schema_objects() == ()

--- a/tests/jobs/providers/test_procrastinate_schema_objects.py
+++ b/tests/jobs/providers/test_procrastinate_schema_objects.py
@@ -1,0 +1,70 @@
+"""ProcrastinateJobProvider.owned_schema_objects(), the declared list is
+derived from the installed procrastinate's own bundled schema
+(procrastinate.schema.SchemaManager.get_schema()), never hardcoded, so a
+procrastinate upgrade that adds objects can't leave the list stale.
+No database needed: the schema ships inside the package.
+"""
+import re
+import sys
+
+import pytest
+
+from fymo.core.schema import SchemaObject
+from fymo.jobs.providers.procrastinate import ProcrastinateJobProvider
+
+
+def test_enumerates_the_queue_tables():
+    names = {
+        o.name for o in ProcrastinateJobProvider().owned_schema_objects()
+        if o.kind == "table"
+    }
+    assert {
+        "procrastinate_jobs",
+        "procrastinate_events",
+        "procrastinate_periodic_defers",
+        "procrastinate_workers",
+    } <= names
+
+
+def test_enumerates_types_functions_and_triggers():
+    objs = ProcrastinateJobProvider().owned_schema_objects()
+    kinds = {o.kind for o in objs}
+    assert {"type", "table", "function", "index", "trigger", "sequence"} <= kinds
+    assert all(isinstance(o, SchemaObject) for o in objs)
+    assert all(o.name.startswith(("procrastinate_", "idx_procrastinate_")) for o in objs)
+
+
+def test_every_create_statement_in_the_bundled_schema_is_covered():
+    """Drift guard: independently extract every top-level CREATE statement
+    name from procrastinate's bundled schema.sql and require each one to
+    appear in the declared list. If procrastinate adds an object of a kind
+    the parser can't classify, parse_schema_sql raises instead, either
+    way, a stale/partial list is impossible to ship silently."""
+    from procrastinate import schema as procrastinate_schema
+
+    sql = procrastinate_schema.SchemaManager.get_schema()
+    declared = {o.name for o in ProcrastinateJobProvider().owned_schema_objects()}
+
+    statement_names = re.findall(
+        r"^CREATE\s+(?:OR\s+REPLACE\s+)?(?:UNIQUE\s+)?"
+        r"(?:TABLE|TYPE|FUNCTION|INDEX|TRIGGER|SEQUENCE)\s+"
+        r"(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_$]*)",
+        sql,
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+    assert statement_names, "bundled schema.sql yielded no CREATE statements"
+    missing = set(statement_names) - declared
+    assert not missing, f"objects in procrastinate's schema missing from the declared list: {missing}"
+
+    n_create_lines = len(re.findall(r"^CREATE\b", sql, flags=re.MULTILINE))
+    assert len(statement_names) == n_create_lines, (
+        "some top-level CREATE statements were not matched by the guard regex"
+    )
+
+
+def test_missing_procrastinate_package_fails_naming_the_extra(monkeypatch):
+    """No partial/silent output when the optional dependency is absent:
+    the enumeration must fail loudly with the install hint."""
+    monkeypatch.setitem(sys.modules, "procrastinate", None)
+    with pytest.raises(RuntimeError, match=r"fymo\[procrastinate\]"):
+        ProcrastinateJobProvider().owned_schema_objects()

--- a/tests/jobs/providers/test_procrastinate_schema_objects.py
+++ b/tests/jobs/providers/test_procrastinate_schema_objects.py
@@ -12,6 +12,49 @@ import pytest
 from fymo.core.schema import SchemaObject
 from fymo.jobs.providers.procrastinate import ProcrastinateJobProvider
 
+_KIND_KEYWORDS = {
+    "TABLE": "table",
+    "TYPE": "type",
+    "FUNCTION": "function",
+    "SEQUENCE": "sequence",
+    "INDEX": "index",
+    "TRIGGER": "trigger",
+    "VIEW": "view",
+    "EXTENSION": "extension",
+}
+
+_MODIFIER_WORDS = {
+    "OR", "REPLACE", "UNIQUE", "UNLOGGED", "MATERIALIZED", "CONCURRENTLY",
+}
+
+
+def _token_walk_created_objects(sql: str):
+    """Independent extraction of every (kind, name) a DDL script creates.
+    On purpose NOT the parser's mechanism: a flat token walk over the
+    whole text (no anchors, no per-statement regexes), so the two cannot
+    share a blind spot. Comments are dropped first; after that, every
+    CREATE token must resolve to a kind keyword and a name or this
+    helper fails the test."""
+    sql = re.sub(r"/\*.*?\*/", " ", sql, flags=re.DOTALL)
+    sql = re.sub(r"--[^\n]*", " ", sql)
+    tokens = re.findall(r"[A-Za-z_][\w$]*", sql)
+    found = []
+    for i, token in enumerate(tokens):
+        if token.upper() != "CREATE":
+            continue
+        j = i + 1
+        while tokens[j].upper() in _MODIFIER_WORDS:
+            j += 1
+        kind_word = tokens[j].upper()
+        assert kind_word in _KIND_KEYWORDS, (
+            f"token walk hit a CREATE {kind_word} it cannot classify"
+        )
+        j += 1
+        if tokens[j].upper() == "IF" and tokens[j + 1].upper() == "NOT":
+            j += 3
+        found.append((_KIND_KEYWORDS[kind_word], tokens[j]))
+    return found
+
 
 def test_enumerates_the_queue_tables():
     names = {
@@ -31,34 +74,40 @@ def test_enumerates_types_functions_and_triggers():
     kinds = {o.kind for o in objs}
     assert {"type", "table", "function", "index", "trigger", "sequence"} <= kinds
     assert all(isinstance(o, SchemaObject) for o in objs)
-    assert all(o.name.startswith(("procrastinate_", "idx_procrastinate_")) for o in objs)
+    assert all(
+        o.name.startswith(("procrastinate_", "idx_procrastinate_"))
+        for o in objs if o.kind != "extension"
+    )
 
 
-def test_every_create_statement_in_the_bundled_schema_is_covered():
-    """Drift guard: independently extract every top-level CREATE statement
-    name from procrastinate's bundled schema.sql and require each one to
-    appear in the declared list. If procrastinate adds an object of a kind
-    the parser can't classify, parse_schema_sql raises instead, either
-    way, a stale/partial list is impossible to ship silently."""
+def test_the_do_block_guarded_extension_is_enumerated():
+    """procrastinate 3.9.0's schema opens with an indented CREATE
+    EXTENSION inside a DO $$ block. A line-anchored parser silently
+    skipped it once (review finding on issue #51); it must show up."""
+    assert SchemaObject(kind="extension", name="plpgsql") in (
+        ProcrastinateJobProvider().owned_schema_objects()
+    )
+
+
+def test_every_create_token_in_the_bundled_schema_is_covered():
+    """Drift guard: walk the raw bundled schema token by token, resolve
+    every CREATE to a (kind, name), and require each one in the declared
+    list. If a future procrastinate creates something the walk can't
+    classify, the walk itself fails, so a stale or partial declared list
+    can't survive an upgrade silently."""
     from procrastinate import schema as procrastinate_schema
 
     sql = procrastinate_schema.SchemaManager.get_schema()
-    declared = {o.name for o in ProcrastinateJobProvider().owned_schema_objects()}
+    walked = _token_walk_created_objects(sql)
+    assert walked, "bundled schema.sql yielded no CREATE statements"
 
-    statement_names = re.findall(
-        r"^CREATE\s+(?:OR\s+REPLACE\s+)?(?:UNIQUE\s+)?"
-        r"(?:TABLE|TYPE|FUNCTION|INDEX|TRIGGER|SEQUENCE)\s+"
-        r"(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_$]*)",
-        sql,
-        flags=re.MULTILINE | re.IGNORECASE,
-    )
-    assert statement_names, "bundled schema.sql yielded no CREATE statements"
-    missing = set(statement_names) - declared
-    assert not missing, f"objects in procrastinate's schema missing from the declared list: {missing}"
-
-    n_create_lines = len(re.findall(r"^CREATE\b", sql, flags=re.MULTILINE))
-    assert len(statement_names) == n_create_lines, (
-        "some top-level CREATE statements were not matched by the guard regex"
+    declared = {
+        (o.kind, o.name)
+        for o in ProcrastinateJobProvider().owned_schema_objects()
+    }
+    missing = set(walked) - declared
+    assert not missing, (
+        f"objects in procrastinate's schema missing from the declared list: {missing}"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.11.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -75,6 +75,9 @@ dependencies = [
 [package.optional-dependencies]
 granian = [
     { name = "granian" },
+]
+postgres = [
+    { name = "psycopg", extra = ["binary", "pool"] },
 ]
 procrastinate = [
     { name = "procrastinate" },
@@ -98,11 +101,12 @@ requires-dist = [
     { name = "granian", marker = "extra == 'granian'", specifier = ">=2.0,<3" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "procrastinate", marker = "extra == 'procrastinate'", specifier = ">=3.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'procrastinate'", specifier = ">=3.1" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.5" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
-provides-extras = ["pydantic", "procrastinate", "granian"]
+provides-extras = ["pydantic", "procrastinate", "postgres", "granian"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "fymo"
-version = "0.11.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -87,6 +87,8 @@ pydantic = [
 [package.dev-dependencies]
 dev = [
     { name = "granian" },
+    { name = "procrastinate" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -107,6 +109,8 @@ provides-extras = ["pydantic", "procrastinate", "granian"]
 [package.metadata.requires-dev]
 dev = [
     { name = "granian", specifier = ">=2.0,<3" },
+    { name = "procrastinate", specifier = ">=3.0" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },


### PR DESCRIPTION
## Summary

Closes #51. A schema diff once proposed dropping the live job queue because nothing could say which tables fymo's providers own. Now something can.

- Providers declare their objects via owned_schema_objects() (duck-typed seam on the provider bases, deliberately kept off the runtime-checkable Protocols so existing custom providers keep passing isinstance).
- The procrastinate list is DERIVED from the installed package's own bundled schema, not hardcoded, so it can't drift: 46 objects (tables, functions, types, indexes, triggers, sequences, the guarded plpgsql extension).
- The DDL parser has structurally no skip path: every CREATE token in the SQL is either classified or raises SchemaParseError, including inside DO $$ blocks and mid-line. The drift-guard test extracts names with an independent token walk so parser and guard cannot share a blind spot.
- CLI: fymo schema provider-tables [--json], machine-clean stdout, loud failure naming the extra when the provider package is missing.
- CI now runs a postgres:16 service so the catalog-diff integration tests (live pg_catalog vs command output, set equality) run on every push instead of never.
- docs/deployment.md gains the warning and the recipe.

## Test plan

- +30 tests: parser adversarial battery (DO blocks, two CREATEs one line, CONCURRENTLY, quoted identifiers, schema-qualified names), drift guard proven to fail in both broken directions, CLI end-to-end against scaffolded projects (plain/--json/empty/missing-dep).
- Integration: applied procrastinate's real schema to a throwaway Postgres and diffed the live catalog against the command output, equality on tables/functions/types/sequences/triggers, constraint-aware equality on indexes.
- Full suite: 945 passed 0 skipped with a database, 928/17 without.