### PR TITLE
Binary static serving fix, real 404s, and a root home for favicon/robots.txt

### DIFF
--- a/fymo/cli/commands/new.py
+++ b/fymo/cli/commands/new.py
@@ -183,6 +183,29 @@ app = create_app(PROJECT_ROOT)
     # imports as app.support.* from day one.
     (project_path / 'app' / 'support' / '__init__.py').write_text('"""Shared server-side utilities"""')
 
+    # app/static/favicon.svg: placeholder mark served at /favicon.svg via
+    # the root-static allowlist, referenced from the root layout below.
+    favicon_svg = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#ff3e00"/>
+  <circle cx="16" cy="16" r="8" fill="#fff"/>
+  <circle cx="16" cy="16" r="3.5" fill="#ff3e00"/>
+</svg>
+"""
+    (project_path / 'app' / 'static' / 'favicon.svg').write_text(favicon_svg)
+
+    # app/templates/_layout.svelte: root layout wrapping every route.
+    root_layout = """<script>
+  let { children } = $props();
+</script>
+
+<svelte:head>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</svelte:head>
+
+{@render children()}
+"""
+    (project_path / 'app' / 'templates' / '_layout.svelte').write_text(root_layout)
+
     # app/controllers/home.py
     home_controller = """\"\"\"Home controller\"\"\"
 

--- a/fymo/core/assets.py
+++ b/fymo/core/assets.py
@@ -29,19 +29,23 @@ class AssetManager:
         """Get extracted CSS"""
         return self.extracted_css.get(name)
     
-    def serve_asset(self, path: str) -> Tuple[str, str, str]:
+    def serve_asset(
+        self, path: str, environ: Optional[dict] = None
+    ) -> Tuple[bytes, str, str, Dict[str, str]]:
         """
         Serve static assets
 
         Args:
             path: Asset path (should start with /assets/)
+            environ: WSGI environ of the request, when available. Used for
+                conditional requests (If-None-Match) against static files.
 
         Returns:
-            Tuple of (content, status, content_type)
+            Tuple of (body, status, content_type, extra_headers)
         """
         try:
             if not path.startswith('/assets/'):
-                return "Invalid asset path", "400 BAD REQUEST", "text/plain"
+                return b"Invalid asset path", "400 BAD REQUEST", "text/plain", {}
 
             asset_path = path[8:]  # Remove '/assets/' prefix
 
@@ -50,16 +54,20 @@ class AssetManager:
                 css_file = asset_path[4:]
                 css_content = self.get_extracted_css(css_file)
                 if css_content:
-                    return css_content, "200 OK", "text/css"
+                    return (
+                        css_content.encode("utf-8"), "200 OK", "text/css",
+                        {"Cache-Control": "public, max-age=3600"},
+                    )
 
             # Serve static files
             else:
-                return self._serve_static_file(asset_path)
+                return self.serve_static_file(asset_path, environ)
 
-            return "Asset not found", "404 NOT FOUND", "text/plain"
+            return b"Asset not found", "404 NOT FOUND", "text/plain", {}
 
         except Exception as e:
-            return f"Asset serving error: {str(e)}", "500 INTERNAL SERVER ERROR", "text/plain"
+            body = f"Asset serving error: {str(e)}".encode("utf-8")
+            return body, "500 INTERNAL SERVER ERROR", "text/plain", {}
 
     @staticmethod
     def _safe_resolve(root: Path, rel_path: str) -> Optional[Path]:
@@ -89,11 +97,33 @@ class AssetManager:
             return None
         return target
 
-    def _serve_static_file(self, asset_path: str) -> Tuple[str, str, str]:
-        """Serve static files from app/static directory"""
+    @staticmethod
+    def _etag_matches(if_none_match: str, etag: str) -> bool:
+        """True when the request's If-None-Match header matches `etag`.
+
+        Weak comparison (the W/ prefix is ignored), which is what RFC 9110
+        prescribes for If-None-Match; `*` matches any current representation.
+        """
+        for candidate in if_none_match.split(","):
+            candidate = candidate.strip()
+            if candidate.startswith("W/"):
+                candidate = candidate[2:]
+            if candidate == "*" or candidate == etag:
+                return True
+        return False
+
+    def serve_static_file(
+        self, asset_path: str, environ: Optional[dict] = None
+    ) -> Tuple[bytes, str, str, Dict[str, str]]:
+        """Serve a file from app/static verbatim, as bytes.
+
+        Static files are unhashed, so responses carry an ETag (from stat
+        mtime+size) and If-None-Match is honored with a 304 -- the 1-hour
+        Cache-Control alone would re-download the full body on every expiry.
+        """
         static_path = self._safe_resolve(self.project_root / 'app' / 'static', asset_path)
         if static_path is None:
-            return "Forbidden", "403 FORBIDDEN", "text/plain"
+            return b"Forbidden", "403 FORBIDDEN", "text/plain", {}
 
         if static_path.exists() and static_path.is_file():
             content_type, _ = mimetypes.guess_type(str(static_path))
@@ -101,13 +131,17 @@ class AssetManager:
                 content_type = 'application/octet-stream'
 
             try:
-                with open(static_path, 'rb') as f:
-                    content = f.read()
-                return content.decode('utf-8'), "200 OK", content_type
-            except (IOError, UnicodeDecodeError):
-                return "Error reading file", "500 INTERNAL SERVER ERROR", "text/plain"
+                stat = static_path.stat()
+                etag = '"%x-%x"' % (stat.st_mtime_ns, stat.st_size)
+                headers = {"ETag": etag, "Cache-Control": "public, max-age=3600"}
+                if_none_match = (environ or {}).get("HTTP_IF_NONE_MATCH", "")
+                if if_none_match and self._etag_matches(if_none_match, etag):
+                    return b"", "304 NOT MODIFIED", content_type, headers
+                return static_path.read_bytes(), "200 OK", content_type, headers
+            except IOError:
+                return b"Error reading file", "500 INTERNAL SERVER ERROR", "text/plain", {}
 
-        return "File not found", "404 NOT FOUND", "text/plain"
+        return b"File not found", "404 NOT FOUND", "text/plain", {}
 
     def serve_dist_asset(self, path: str) -> Tuple[bytes, str, str, Dict[str, str]]:
         """Serve a file from <project>/dist/. Returns (body, status, content_type, extra_headers).

--- a/fymo/core/router.py
+++ b/fymo/core/router.py
@@ -221,27 +221,34 @@ class Router:
         
         Convention:
         - / -> home.index
-        - /controller -> controller.index  
+        - /controller -> controller.index
         - /controller/action -> controller.action
+
+        Matches carry `'convention': True` so callers can tell a guessed
+        route from a declared one: a convention match with no built assets
+        behind it is a routing miss (404), whereas a declared route in the
+        same state is a stale build (500).
         """
         # Normalize path
         if path == '/':
             return {
                 'controller': 'home',
                 'action': 'index',
-                'template': 'home/index.svelte'
+                'template': 'home/index.svelte',
+                'convention': True
             }
-        
+
         # Remove leading slash and split
         parts = path.strip('/').split('/')
-        
+
         if len(parts) == 1:
             # /controller -> controller.index
             controller = parts[0]
             return {
                 'controller': controller,
                 'action': 'index',
-                'template': f'{controller}/index.svelte'
+                'template': f'{controller}/index.svelte',
+                'convention': True
             }
         elif len(parts) == 2:
             # /controller/action -> controller.action
@@ -249,7 +256,8 @@ class Router:
             return {
                 'controller': controller,
                 'action': action,
-                'template': f'{controller}/{action}.svelte'
+                'template': f'{controller}/{action}.svelte',
+                'convention': True
             }
-        
+
         return None

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -18,6 +18,22 @@ def _env_truthy(name: str) -> bool:
     return env_truthy(name)
 
 
+# Root-static allowlist: well-known filenames browsers and crawlers request
+# at / by convention, with no way to point them elsewhere. Fixed list plus
+# the .well-known/ prefix (ACME challenges, security.txt, site associations),
+# Phoenix-style: nothing under app/static is exposed at / by accident.
+ROOT_STATIC_FILES = frozenset({
+    "favicon.ico",
+    "favicon.svg",
+    "robots.txt",
+    "apple-touch-icon.png",
+    "apple-touch-icon-precomposed.png",
+    "site.webmanifest",
+    "browserconfig.xml",
+})
+ROOT_STATIC_PREFIX = ".well-known/"
+
+
 def _load_identity_secret(project_root: Path, dev: bool) -> bytes:
     """Resolve the HMAC secret used to sign fymo_uid cookies.
 
@@ -487,6 +503,34 @@ class FymoApp:
         return self.asset_manager.serve_asset(path, environ)
     
     
+    def _respond_route_miss(self, path, environ, start_response):
+        """No raw route and no SSR route matched this path.
+
+        Root-static allowlist first: exact well-known filenames and the
+        .well-known/ prefix resolve into app/static via the same
+        traversal-guarded, binary-correct serving as /assets/. Anything
+        else (or an absent file) gets the built-in 404 page, never a 500.
+        """
+        rel = path.lstrip("/")
+        if rel in ROOT_STATIC_FILES or rel.startswith(ROOT_STATIC_PREFIX):
+            body, status, content_type, extra = self.asset_manager.serve_static_file(rel, environ)
+            if status.startswith(("200", "304")):
+                response_headers = [
+                    ("Content-Type", content_type),
+                    ("Content-Length", str(len(body))),
+                ]
+                response_headers.extend(extra.items())
+                start_response(status, response_headers)
+                return [body]
+
+        html = self.template_renderer.render_404(path)
+        body = html.encode("utf-8")
+        start_response("404 NOT FOUND", [
+            ("Content-Type", "text/html"),
+            ("Content-Length", str(len(body))),
+        ])
+        return [body]
+
     def _healthz(self, start_response):
         """Liveness probe: 200 if the Node sidecar responds to ping, else 503.
 
@@ -649,6 +693,13 @@ class FymoApp:
         for route in self._app_routes:
             if method == route.method and path.startswith(route.path):
                 return route.handler(environ, start_response)
+
+        # Nothing routable: try the root-static allowlist, then the built-in
+        # 404. Checked after app routes and SSR route matching so a dynamic
+        # /robots.txt or an SSR route colliding with an allowlisted filename
+        # always wins over a file in app/static.
+        if self.template_renderer.is_route_miss(path):
+            return self._respond_route_miss(path, environ, start_response)
 
         # Handle template requests
         html, status, extra_headers = self.render_svelte_template(path, environ)

--- a/fymo/core/server.py
+++ b/fymo/core/server.py
@@ -475,14 +475,16 @@ class FymoApp:
         return self.template_renderer.render_template(route_path, environ)
     
     
-    def serve_asset(self, path: str) -> tuple[str, str, str]:
+    def serve_asset(
+        self, path: str, environ: Optional[dict] = None
+    ) -> tuple[bytes, str, str, Dict[str, str]]:
         """
         Serve static assets
-        
+
         Returns:
-            Tuple of (content, status, content_type)
+            Tuple of (body, status, content_type, extra_headers)
         """
-        return self.asset_manager.serve_asset(path)
+        return self.asset_manager.serve_asset(path, environ)
     
     
     def _healthz(self, start_response):
@@ -631,17 +633,15 @@ class FymoApp:
 
         # Handle asset requests
         if path.startswith('/assets/'):
-            content, status, content_type = self.serve_asset(path)
-            content_bytes = content.encode("utf-8") if isinstance(content, str) else content
-            start_response(
-                status, [
-                    ("Content-Type", content_type),
-                    ("Content-Length", str(len(content_bytes))),
-                    ("Access-Control-Allow-Origin", "*"),
-                    ("Cache-Control", "public, max-age=3600")
-                ]
-            )
-            return iter([content_bytes])
+            body, status, content_type, extra = self.serve_asset(path, environ)
+            response_headers = [
+                ("Content-Type", content_type),
+                ("Content-Length", str(len(body))),
+                ("Access-Control-Allow-Origin", "*"),
+            ]
+            response_headers.extend(extra.items())
+            start_response(status, response_headers)
+            return iter([body])
 
         # App-defined raw HTTP routes (e.g. media streaming with Range
         # support) — first match wins, in registration order.

--- a/fymo/core/template_renderer.py
+++ b/fymo/core/template_renderer.py
@@ -143,15 +143,41 @@ class TemplateRenderer:
         status_line = f"{e.status} {e.code.upper()}"
         return "", status_line, [("Location", e.location)]
     
+    def is_route_miss(self, route_path: str) -> bool:
+        """True when no SSR route can serve this path.
+
+        A miss is either no router match at all, or a match produced only by
+        the convention-based fallback with nothing built for it in the
+        manifest -- convention routing guesses a controller from any one- or
+        two-segment path, so its guess only counts when the build actually
+        produced that route. An explicitly declared route is never a miss:
+        its absence from the manifest is a stale build, and _render_via_sidecar
+        keeps reporting that as the 500 it is. Manifest read failures are also
+        not a miss; they surface through the render path as Build Error.
+        """
+        route_info = self.router.match(route_path)
+        if not route_info:
+            return True
+        if not route_info.get("convention"):
+            return False
+        if self.manifest_cache is None:
+            return False
+        route_name = route_info["controller"].split(".")[0]
+        try:
+            manifest = self.manifest_cache.get()
+        except Exception:
+            return False
+        return route_name not in manifest.routes
+
     def _render_via_sidecar(self, route_path: str, environ: dict | None = None) -> Tuple[str, str]:
         """New pipeline: render via Node sidecar with prebuilt SSR module."""
         from fymo.core.sidecar import SidecarError
         from fymo.core.manifest_cache import ManifestUnavailable
         from fymo.core.html import build_html
 
+        if self.is_route_miss(route_path):
+            return self.render_404(route_path), "404 NOT FOUND"
         route_info = self.router.match(route_path)
-        if not route_info:
-            return self._render_404(), "404 NOT FOUND"
 
         controller_key = route_info["controller"]
         route_name = controller_key.split(".")[0]
@@ -367,15 +393,28 @@ class TemplateRenderer:
         
         return sanitized
     
-    def _render_404(self) -> str:
-        """Render 404 page"""
-        return """<!DOCTYPE html>
+    def render_404(self, route_path: str = "") -> str:
+        """Built-in 404 page for a route miss.
+
+        Dev mode gets the routing hint; prod gets a clean minimal page with
+        zero internals. The echoed path is user-controlled and must be
+        escaped. App-customizable error pages are a separate future feature.
+        """
+        if self.dev:
+            detail = (
+                f"<p>No route matched <code>{escape(route_path)}</code>. "
+                "Routes are declared in fymo.yml's <code>routes:</code> "
+                "section or in <code>config/routes.py</code>.</p>"
+            )
+        else:
+            detail = "<p>The requested page could not be found.</p>"
+        return f"""<!DOCTYPE html>
 <html>
 <head>
     <title>404 - Not Found</title>
 </head>
 <body>
     <h1>404 - Page Not Found</h1>
-    <p>The requested page could not be found.</p>
+    {detail}
 </body>
 </html>"""

--- a/journal/journal_035.md
+++ b/journal/journal_035.md
@@ -1,0 +1,90 @@
+# Journal Entry 035: The Framework That Couldn't Serve a Font
+
+**Date**: July 16, 2026
+**Focus**: Binary static files, and the 500 every fresh visitor was triggering
+**Status**: Shipped
+
+## A Font File Walks Into app/static
+
+I wanted a locally hosted font, the obvious way: drop Inter.woff2 into
+app/static/fonts/, point the CSS at it. The response was a 500, "Error
+reading file". A woff2 is about as plain a static file as exists, so this
+smelled like something structural, and it was.
+
+The static path read the file in binary mode, correctly, and then decoded
+it as UTF-8 before handing it back. The dispatch layer one floor up
+already handled bytes, it had an isinstance check doing exactly the right
+thing for the /dist/ route next door. So the decode bought nothing and
+cost every binary format: woff2, png, ico, jpg, all of them died on the
+same line. Only text assets ever survived, and nobody had noticed because
+neither example app ships a single binary static file. The todo app
+doesn't even have an app/static directory. The feature had been broken
+for its most common use case, probably forever, and the evidence is that
+nobody ever used it.
+
+The fix was deleting the decode and returning bytes straight through.
+While in there, the cache story got its missing half: these files are
+unhashed, so a one-hour Cache-Control without any validator meant a full
+re-download on every expiry. Static responses now carry an ETag built
+from stat's mtime and size, no file read, no content hash, and
+If-None-Match comes back as a 304 with an empty body. The kind of thing
+Plug.Static has done since forever; table stakes, now paid.
+
+## The 500 Nobody Ordered
+
+The sibling bug was louder. Hit any fymo app with a path that doesn't
+exist and you got a 500: "Route 'no-such-page' not in manifest. Run
+`fymo build`." Now consider that every browser on a first visit requests
+/favicon.ico on its own. Every fymo app in production was emitting one
+500 per fresh visitor, polluting logs and any alerting keyed on 5xx
+rates, and leaking an internal dev instruction to end users while at it.
+
+The root cause took a minute to see. There is a 404 branch in the render
+path, and it looked like it should have fired. It almost never could:
+convention-based routing turns nearly any one- or two-segment path into a
+guessed controller, so /favicon.ico "matched" as controller favicon.ico,
+sailed past the no-route check, failed the manifest lookup, and surfaced
+as a server error. A routing miss dressed up as a build problem.
+
+The distinction that fixes it: a convention guess is only real if the
+build actually produced that route. Convention matches now carry a flag,
+and a flagged match with no manifest entry is a 404, with the built-in
+page split by mode the way fymo already splits everything. Dev gets the
+hint, no route matched this path, routes are declared in fymo.yml or
+config/routes.py. Prod gets a clean minimal page with zero internals. A
+route the app explicitly declared but never built keeps its 500, because
+a stale build is a real server problem and deserves the alarm.
+
+## Where the Favicon Actually Lives
+
+Which still leaves the favicon with no home. Rails serves all of public/
+at the root, SvelteKit serves all of static/. fymo went the Phoenix way
+instead: a fixed allowlist of the filenames browsers and crawlers request
+at the root by convention, favicon.ico, favicon.svg, robots.txt, the
+apple-touch-icons, site.webmanifest, browserconfig.xml, plus the
+.well-known/ prefix for ACME challenges and security.txt and the rest of
+that long tail. Each resolves into app/static through the same traversal
+guard and the same now-binary-correct serving. Nothing else in app/static
+is exposed at the root by accident, and there's a test pinning that.
+
+Precedence mattered enough to pin too: app raw routes win over the
+allowlist, which wins over the 404. That ordering is what keeps a dynamic
+robots.txt possible, an http_routes() entry for /robots.txt naturally
+shadows the static file. And the scaffold now teaches the convention the
+way conventions should be taught: `fymo new` ships a small favicon.svg
+and the link tag in a root layout, so a fresh project serves its own icon
+before its author has thought about icons at all.
+
+## The Honest Footnote
+
+The two bugs shipped together because they were the same lesson from two
+angles. A framework's unglamorous paths, the static file, the unknown
+route, are the ones every single visitor exercises before they see a
+single feature. Both had been wrong since early days, and both were
+invisible because the example apps never walked them. The example apps
+are now not the only thing walking them; the test suite requests a woff2
+with real font bytes in it and checks the body came back identical.
+
+---
+
+*End of Journal Entry 035*

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -111,6 +111,32 @@ def test_new_scaffolds_package_json_dev_script_using_fymo_dev(tmp_path, monkeypa
     assert package_json["scripts"]["dev"] == "fymo dev"
 
 
+def test_new_scaffolds_favicon_svg_in_app_static(tmp_path, monkeypatch):
+    """Issue #75: a fresh project serves its own favicon out of the box via
+    the root-static allowlist. SVG only, one file, no .ico."""
+    monkeypatch.chdir(tmp_path)
+    create_project("myapp")
+    favicon = tmp_path / "myapp" / "app" / "static" / "favicon.svg"
+    assert favicon.is_file()
+    content = favicon.read_text()
+    assert content.startswith("<svg")
+    assert "<text" not in content
+
+
+def test_new_scaffolds_root_layout_with_favicon_link(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    create_project("myapp")
+    layout = tmp_path / "myapp" / "app" / "templates" / "_layout.svelte"
+    assert layout.is_file()
+    content = layout.read_text()
+    assert "<svelte:head>" in content
+    assert 'rel="icon"' in content
+    assert 'type="image/svg+xml"' in content
+    assert 'href="/favicon.svg"' in content
+    # It's a layout: it must render its children.
+    assert "children" in content
+
+
 def test_new_scaffolds_package_json_with_full_build_deps(tmp_path, monkeypatch):
     """Issue #55: a fresh `fymo new` project could never build. fymo/build/js/build.mjs
     requires esbuild-svelte and svelte-preprocess directly, and app/lib code commonly

--- a/tests/core/test_assets.py
+++ b/tests/core/test_assets.py
@@ -7,6 +7,17 @@ import pytest
 from fymo.core.assets import AssetManager
 
 
+# Real binary fixtures: actual file-format magic followed by bytes that are
+# not valid UTF-8, so any decode() sneaking back into the serving path
+# fails these tests immediately (issue #74).
+WOFF2_BYTES = b"wOF2\x00\x01\x00\x00" + bytes(range(256))
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00"
+    b"\x1f\x15\xc4\x89"
+)
+
+
 @pytest.fixture
 def project(tmp_path: Path) -> Path:
     """A minimal project tree with one legitimate static asset and a secret
@@ -20,18 +31,18 @@ def project(tmp_path: Path) -> Path:
 
 def test_serves_legitimate_static_file(project: Path):
     mgr = AssetManager(project)
-    content, status, _ = mgr.serve_asset("/assets/logo.txt")
+    content, status, _, _ = mgr.serve_asset("/assets/logo.txt")
     assert status == "200 OK"
-    assert content == "i am a public asset"
+    assert content == b"i am a public asset"
 
 
 def test_dotdot_traversal_cannot_escape_static_dir(project: Path):
     """`/assets/../../secret.txt` climbs from app/static back to the project
     root and must not read files outside app/static."""
     mgr = AssetManager(project)
-    content, status, _ = mgr.serve_asset("/assets/../../secret.txt")
+    content, status, _, _ = mgr.serve_asset("/assets/../../secret.txt")
     assert not status.startswith("200"), f"traversal leaked file: {content!r}"
-    assert "TOP SECRET" not in content
+    assert b"TOP SECRET" not in content
 
 
 def test_absolute_path_injection_cannot_escape_static_dir(project: Path):
@@ -40,6 +51,63 @@ def test_absolute_path_injection_cannot_escape_static_dir(project: Path):
     mgr = AssetManager(project)
     secret = project / "secret.txt"
     # serve_asset strips the '/assets/' prefix, leaving an absolute '/....'
-    content, status, _ = mgr.serve_asset(f"/assets/{secret}")
+    content, status, _, _ = mgr.serve_asset(f"/assets/{secret}")
     assert not status.startswith("200"), f"absolute-path read leaked file: {content!r}"
-    assert "TOP SECRET" not in content
+    assert b"TOP SECRET" not in content
+
+
+def test_serves_woff2_byte_identical(project: Path):
+    """Issue #74: a real woff2 (binary, not valid UTF-8) must come back 200
+    with the exact bytes, not a 500 from content.decode('utf-8')."""
+    fonts = project / "app" / "static" / "fonts"
+    fonts.mkdir()
+    (fonts / "Inter.woff2").write_bytes(WOFF2_BYTES)
+    mgr = AssetManager(project)
+    content, status, content_type, _ = mgr.serve_asset("/assets/fonts/Inter.woff2")
+    assert status == "200 OK"
+    assert content_type == "font/woff2"
+    assert content == WOFF2_BYTES
+
+
+def test_serves_png_byte_identical(project: Path):
+    static = project / "app" / "static"
+    (static / "logo.png").write_bytes(PNG_BYTES)
+    mgr = AssetManager(project)
+    content, status, content_type, _ = mgr.serve_asset("/assets/logo.png")
+    assert status == "200 OK"
+    assert content_type == "image/png"
+    assert content == PNG_BYTES
+
+
+def test_static_response_carries_etag_and_cache_control(project: Path):
+    mgr = AssetManager(project)
+    _, status, _, headers = mgr.serve_asset("/assets/logo.txt")
+    assert status == "200 OK"
+    assert headers.get("ETag", "").startswith('"')
+    assert headers.get("Cache-Control") == "public, max-age=3600"
+
+
+def test_if_none_match_returns_304_with_empty_body(project: Path):
+    mgr = AssetManager(project)
+    _, _, _, headers = mgr.serve_asset("/assets/logo.txt")
+    etag = headers["ETag"]
+    environ = {"HTTP_IF_NONE_MATCH": etag}
+    content, status, _, headers = mgr.serve_asset("/assets/logo.txt", environ)
+    assert status == "304 NOT MODIFIED"
+    assert content == b""
+    # The validator is resent so caches can refresh their entry's lifetime.
+    assert headers["ETag"] == etag
+
+
+def test_stale_if_none_match_returns_full_body(project: Path):
+    mgr = AssetManager(project)
+    environ = {"HTTP_IF_NONE_MATCH": '"deadbeef-0"'}
+    content, status, _, _ = mgr.serve_asset("/assets/logo.txt", environ)
+    assert status == "200 OK"
+    assert content == b"i am a public asset"
+
+
+def test_missing_static_file_is_404(project: Path):
+    mgr = AssetManager(project)
+    _, status, _, _ = mgr.serve_asset("/assets/nope.png")
+    assert status == "404 NOT FOUND"

--- a/tests/core/test_template_renderer_404.py
+++ b/tests/core/test_template_renderer_404.py
@@ -1,0 +1,105 @@
+"""Unknown routes must be a 404, not a 500 (issue #75).
+
+The router's convention-based fallback matches almost any one- or
+two-segment path, so a request like /favicon.ico used to sail past the
+"no route" check, fail the manifest lookup, and surface as
+500 "Route 'favicon' not in manifest. Run `fymo build`." -- a routing
+miss dressed up as a server error, leaking a dev instruction to boot.
+
+The distinction pinned here: a convention-based match with no manifest
+entry is a route miss (404); an explicitly declared route missing from
+the manifest is a genuine build error (500 stays).
+"""
+from pathlib import Path
+
+from fymo.core.config import ConfigManager
+from fymo.core.assets import AssetManager
+from fymo.core.router import Router
+from fymo.core.template_renderer import TemplateRenderer
+
+
+class FakeManifest:
+    def __init__(self, routes):
+        self.routes = routes
+
+
+class FakeManifestCache:
+    def __init__(self, routes):
+        self._manifest = FakeManifest(routes)
+
+    def get(self):
+        return self._manifest
+
+
+def _make_renderer(tmp_path: Path, manifest_routes, router=None, dev=False):
+    config_manager = ConfigManager(tmp_path, {})
+    asset_manager = AssetManager(tmp_path)
+    renderer = TemplateRenderer(
+        tmp_path, config_manager, asset_manager, router or Router(), dev=dev
+    )
+    renderer.manifest_cache = FakeManifestCache(manifest_routes)
+    return renderer
+
+
+def test_convention_match_not_in_manifest_is_route_miss(tmp_path):
+    r = _make_renderer(tmp_path, {"todos": object()})
+    assert r.is_route_miss("/favicon.ico") is True
+    assert r.is_route_miss("/no-such-page") is True
+
+
+def test_convention_match_in_manifest_is_not_route_miss(tmp_path):
+    """An SSR route that happens to collide with a well-known filename wins
+    over the root-static allowlist: it's a real route, not a miss."""
+    r = _make_renderer(tmp_path, {"favicon": object()})
+    assert r.is_route_miss("/favicon.ico") is False
+
+
+def test_declared_route_not_in_manifest_is_not_route_miss(tmp_path):
+    """A route the app explicitly declared but never built is a build
+    problem, not a routing one -- it must keep its 500."""
+    router = Router()
+    router.add_route("/posts", "posts", "index")
+    r = _make_renderer(tmp_path, {}, router=router)
+    assert r.is_route_miss("/posts") is False
+
+
+def test_unmatched_path_is_route_miss(tmp_path):
+    """Three or more segments never match convention routing."""
+    r = _make_renderer(tmp_path, {"todos": object()})
+    assert r.is_route_miss("/.well-known/acme-challenge/token") is True
+
+
+def test_route_miss_renders_404_with_hint_in_dev(tmp_path):
+    r = _make_renderer(tmp_path, {"todos": object()}, dev=True)
+    html, status, _ = r.render_template("/no-such-page")
+    assert status == "404 NOT FOUND"
+    assert "No route matched" in html
+    assert "/no-such-page" in html
+    assert "routes" in html
+
+
+def test_route_miss_renders_clean_404_in_prod(tmp_path):
+    r = _make_renderer(tmp_path, {"todos": object()}, dev=False)
+    html, status, _ = r.render_template("/no-such-page")
+    assert status == "404 NOT FOUND"
+    assert "404" in html
+    # Zero internals: no dev instructions, no routing machinery names.
+    for leak in ("fymo build", "manifest", "config/routes", "fymo.yml", "No route matched"):
+        assert leak not in html
+
+
+def test_404_page_escapes_the_requested_path(tmp_path):
+    """The dev hint echoes the request path, which is user-controlled."""
+    r = _make_renderer(tmp_path, {}, dev=True)
+    html, status, _ = r.render_template("/<script>alert(1)</script>")
+    assert status == "404 NOT FOUND"
+    assert "<script>alert(1)</script>" not in html
+
+
+def test_declared_route_missing_from_manifest_stays_500(tmp_path):
+    router = Router()
+    router.add_route("/posts", "posts", "index")
+    r = _make_renderer(tmp_path, {}, router=router, dev=True)
+    html, status, _ = r.render_template("/posts")
+    assert status.startswith("500")
+    assert "not in manifest" in html

--- a/tests/integration/test_root_static_and_404.py
+++ b/tests/integration/test_root_static_and_404.py
@@ -1,0 +1,176 @@
+"""Root-static allowlist + built-in 404 through the full WSGI dispatch (issue #75).
+
+Precedence pinned here: app raw routes (app/routes.py) win over the root
+allowlist, which wins over the built-in 404. Unknown routes are a 404 with
+a mode-appropriate body, never a 500.
+"""
+import io
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from fymo.build.pipeline import BuildPipeline
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TODO_APP = REPO_ROOT / "examples" / "todo_app"
+
+# Real .ico magic (ICONDIR: reserved=0, type=1, count=1) plus bytes that are
+# not valid UTF-8, so a decode() regression turns these tests red.
+ICO_BYTES = b"\x00\x00\x01\x00\x01\x00" + bytes(range(250, 256)) * 4
+
+
+@pytest.fixture(scope="module")
+def built_app(tmp_path_factory, node_available):
+    """One built copy of examples/todo_app shared by the whole module.
+
+    Static files are read from disk per request, so tests may add files
+    under app/static/ freely; anything that changes what FymoApp discovers
+    at init (app/routes.py) must build its own app and clean up after.
+    """
+    dest = tmp_path_factory.mktemp("root_static") / "todo_app"
+    shutil.copytree(
+        TODO_APP, dest, ignore=shutil.ignore_patterns("node_modules", "dist", ".fymo")
+    )
+    nm = TODO_APP / "node_modules"
+    if nm.is_dir():
+        (dest / "node_modules").symlink_to(nm)
+    else:
+        pytest.skip("examples/todo_app/node_modules not found — run npm install in examples/todo_app/")
+    (dest / "app" / "static").mkdir(parents=True, exist_ok=True)
+    BuildPipeline(project_root=dest).build(dev=False)
+    return dest
+
+
+@pytest.fixture(scope="module")
+def prod_app(built_app):
+    from fymo import create_app
+    app = create_app(built_app, dev=False)
+    yield app
+    app.shutdown()
+
+
+def _get(app, path, extra_environ=None):
+    responses = []
+
+    def start_response(status, headers):
+        responses.append((status, headers))
+
+    environ = {
+        "REQUEST_METHOD": "GET",
+        "PATH_INFO": path,
+        "QUERY_STRING": "",
+        "SERVER_NAME": "localhost", "SERVER_PORT": "8000", "SERVER_PROTOCOL": "HTTP/1.1",
+        "wsgi.input": io.BytesIO(), "wsgi.errors": sys.stderr, "wsgi.url_scheme": "http",
+    }
+    if extra_environ:
+        environ.update(extra_environ)
+    body = b"".join(app(environ, start_response))
+    status, headers = responses[0]
+    return status, dict(headers), body
+
+
+def test_unknown_route_is_404_with_clean_body_in_prod(prod_app):
+    status, headers, body = _get(prod_app, "/no-such-page")
+    assert status == "404 NOT FOUND"
+    assert headers["Content-Type"] == "text/html"
+    text = body.decode("utf-8")
+    assert "404" in text
+    for leak in ("fymo build", "manifest", "No route matched", "config/routes"):
+        assert leak not in text
+
+
+def test_unknown_route_shows_routing_hint_in_dev(built_app):
+    from fymo import create_app
+    app = create_app(built_app, dev=True)
+    try:
+        status, _, body = _get(app, "/no-such-page")
+        assert status == "404 NOT FOUND"
+        text = body.decode("utf-8")
+        assert "No route matched" in text
+        assert "/no-such-page" in text
+    finally:
+        app.shutdown()
+
+
+def test_favicon_ico_served_from_app_static(built_app, prod_app):
+    (built_app / "app" / "static" / "favicon.ico").write_bytes(ICO_BYTES)
+    status, headers, body = _get(prod_app, "/favicon.ico")
+    assert status == "200 OK"
+    assert headers["Content-Type"] in ("image/x-icon", "image/vnd.microsoft.icon")
+    assert body == ICO_BYTES
+
+
+def test_favicon_conditional_request_gets_304(built_app, prod_app):
+    (built_app / "app" / "static" / "favicon.ico").write_bytes(ICO_BYTES)
+    _, headers, _ = _get(prod_app, "/favicon.ico")
+    etag = headers["ETag"]
+    status, headers, body = _get(prod_app, "/favicon.ico", {"HTTP_IF_NONE_MATCH": etag})
+    assert status == "304 NOT MODIFIED"
+    assert body == b""
+
+
+def test_absent_allowlisted_file_is_404_never_500(prod_app):
+    status, _, body = _get(prod_app, "/favicon.svg")
+    assert status == "404 NOT FOUND"
+    assert b"fymo build" not in body
+
+
+def test_well_known_prefix_maps_to_app_static(built_app, prod_app):
+    well_known = built_app / "app" / "static" / ".well-known"
+    well_known.mkdir(exist_ok=True)
+    (well_known / "security.txt").write_text("Contact: mailto:sec@example.com\n")
+    status, _, body = _get(prod_app, "/.well-known/security.txt")
+    assert status == "200 OK"
+    assert body == b"Contact: mailto:sec@example.com\n"
+
+    status, _, _ = _get(prod_app, "/.well-known/absent.txt")
+    assert status == "404 NOT FOUND"
+
+
+def test_allowlist_is_not_an_open_root_directory(built_app, prod_app):
+    """Only the fixed well-known names are served at /; arbitrary files in
+    app/static keep requiring the /assets/ prefix."""
+    (built_app / "app" / "static" / "notes.txt").write_text("not for root serving")
+    status, _, body = _get(prod_app, "/notes.txt")
+    assert status == "404 NOT FOUND"
+    assert b"not for root serving" not in body
+
+
+def test_app_raw_route_wins_over_static_robots_txt(built_app):
+    """An http_routes() entry for /robots.txt shadows app/static/robots.txt,
+    keeping dynamic robots/sitemaps possible."""
+    (built_app / "app" / "static" / "robots.txt").write_text("User-agent: *\nDisallow: /static-version\n")
+    routes_py = built_app / "app" / "routes.py"
+    routes_py.write_text(
+        "from fymo.core.http import HttpRoute\n"
+        "\n"
+        "def _robots(environ, start_response):\n"
+        "    body = b'User-agent: *\\nDisallow: /dynamic-version\\n'\n"
+        "    start_response('200 OK', [('Content-Type', 'text/plain'),\n"
+        "                              ('Content-Length', str(len(body)))])\n"
+        "    return [body]\n"
+        "\n"
+        "def http_routes():\n"
+        "    return [HttpRoute('GET', '/robots.txt', _robots)]\n"
+    )
+    from fymo import create_app
+    try:
+        app = create_app(built_app, dev=False)
+        try:
+            status, _, body = _get(app, "/robots.txt")
+            assert status == "200 OK"
+            assert b"dynamic-version" in body
+            assert b"static-version" not in body
+        finally:
+            app.shutdown()
+    finally:
+        routes_py.unlink()
+
+
+def test_static_robots_txt_served_when_no_raw_route(built_app, prod_app):
+    (built_app / "app" / "static" / "robots.txt").write_text("User-agent: *\nDisallow:\n")
+    status, _, body = _get(prod_app, "/robots.txt")
+    assert status == "200 OK"
+    assert body == b"User-agent: *\nDisallow:\n"


### PR DESCRIPTION
## Summary

Closes #74 and #75, built together because #75's root allowlist serves through #74's fixed path.

- **#74**: static files from `app/static` no longer decode as UTF-8, so binary content (woff2, png, ico) serves byte-identical instead of 500ing. Responses carry an ETag (mtime_ns+size) with If-None-Match/304 support; error responses no longer carry Cache-Control.
- **#75**: unknown routes return a real 404 instead of 500 "Route not in manifest". Dev shows a routing hint, prod shows a clean page with no internals leaked, requested path is XSS-escaped. A declared route missing from the manifest keeps its 500 (stale build is a genuine error); only convention-fallback misses reclassify.
- Root allowlist: favicon.ico, favicon.svg, robots.txt, apple-touch-icon.png (+precomposed), site.webmanifest, browserconfig.xml, and the .well-known/ prefix serve from `app/static/` at root, checked after app raw routes, before the 404. Nothing else in app/static is root-served.
- `fymo new` scaffolds `app/static/favicon.svg` and the link tag in the root layout, so fresh apps serve a favicon out of the box.

## Test plan

- +25 tests: real binary fixtures (actual woff2/PNG/ICO magic bytes, invalid UTF-8 by construction), 304 conditional flow, route-miss vs render-error matrix, allowlist precedence (app raw route beats static robots.txt), .well-known mapping, 404 body assertions per mode, scaffold assertions.
- Adversarial review passed clean: live traversal battery against .well-known/ (encoded dots, null bytes, planted symlink escaping app/static, directory requests), no false-404 hunt across convention/declared/dynamic routes, RFC 9110 weak-comparison check, XSS probe on the 404 path.
- Full suite: 1156 passed, 57 skipped (env-gated Postgres).