### PR TITLE
console.log during SSR no longer corrupts the sidecar protocol

### DIFF
--- a/fymo/build/js/sidecar.mjs
+++ b/fymo/build/js/sidecar.mjs
@@ -1,5 +1,17 @@
 #!/usr/bin/env node
 import { render } from 'svelte/server';
+import { format } from 'node:util';
+
+// stdout carries the binary frame protocol below and nothing else. Component
+// code (or any dependency bundled into the SSR output) may call console.log
+// during a render; by default Node writes that to stdout, interleaving plain
+// text into the frame stream and desyncing the Python parser (issue #84).
+// Rebind every stdout-targeting console method to stderr before the stdin
+// listener is wired, so no render can ever touch the IPC channel.
+// console.error/trace already target stderr and are left alone.
+for (const method of ['log', 'info', 'warn', 'debug']) {
+    console[method] = (...args) => process.stderr.write(format(...args) + '\n');
+}
 
 const cache = new Map();
 const stdout = process.stdout;

--- a/fymo/core/sidecar.py
+++ b/fymo/core/sidecar.py
@@ -19,7 +19,9 @@ import os
 import select
 import struct
 import subprocess
+import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -56,13 +58,23 @@ class Sidecar:
             return
         if not self.script.is_file():
             raise SidecarError(f"sidecar script not found at {self.script}; run `fymo build` first")
+        # stderr is captured and pumped, not inherited: the sidecar rebinds
+        # console.log/info/warn/debug onto stderr (stdout is the frame
+        # protocol), and the pump prefixes each line so a developer can tell
+        # sidecar output from the WSGI process's own logs. The pump must be a
+        # dedicated always-running thread: a PIPE nobody drains fills the OS
+        # buffer (~64KB) and then blocks Node mid-write, hanging the render.
         self._proc = subprocess.Popen(
             ["node", str(self.script)],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=None,  # inherit so logs surface
+            stderr=subprocess.PIPE,
             cwd=str(self.dist_dir),
         )
+        pump = threading.Thread(
+            target=_pump_stderr, args=(self._proc.stderr,), daemon=True
+        )
+        pump.start()
 
     def stop(self) -> None:
         proc = self._proc
@@ -129,23 +141,48 @@ class Sidecar:
         return reply
 
     def _send_frame_locked(self, frame: bytes) -> bytes:
-        """Write `frame`, wait for response, return body bytes. Caller holds lock + proc alive."""
+        """Write `frame`, wait for response, return body bytes. Caller holds lock + proc alive.
+
+        The timeout is a single deadline for the COMPLETE reply frame, not
+        per-read. A select() that only guards the first byte is worthless
+        against a desynced stream: stray bytes arrive instantly, select
+        reports ready, and an unbounded read then blocks forever waiting for
+        a frame that can never complete (issue #84).
+        """
         assert self._proc is not None and self._proc.stdin is not None and self._proc.stdout is not None
         self._proc.stdin.write(frame)
         self._proc.stdin.flush()
-        if self.timeout is not None:
-            ready, _, _ = select.select([self._proc.stdout], [], [], self.timeout)
-            if not ready:
-                raise _Timeout(f"sidecar render exceeded {self.timeout}s")
-        length_bytes = self._read_exact_locked(4)
+        deadline = None if self.timeout is None else time.monotonic() + self.timeout
+        length_bytes = self._read_exact_locked(4, deadline)
         (length,) = struct.unpack(">I", length_bytes)
-        return self._read_exact_locked(length)
+        return self._read_exact_locked(length, deadline)
 
-    def _read_exact_locked(self, n: int) -> bytes:
+    def _read_exact_locked(self, n: int, deadline: Optional[float]) -> bytes:
+        """Read exactly n bytes from the child's stdout, bounded by `deadline`.
+
+        Reads go through os.read on the raw fd, not the BufferedReader:
+        buffered read(k) blocks until exactly k bytes regardless of what
+        select() saw, and its internal buffer is invisible to select, so
+        pairing the two is unsound. Nothing else may read this pipe.
+        """
         assert self._proc is not None and self._proc.stdout is not None
+        fd = self._proc.stdout.fileno()
         buf = b""
         while len(buf) < n:
-            chunk = self._proc.stdout.read(n - len(buf))
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise _Timeout(
+                        f"sidecar did not deliver a complete frame within "
+                        f"{self.timeout}s (hung render or desynced stream)"
+                    )
+                ready, _, _ = select.select([fd], [], [], remaining)
+                if not ready:
+                    raise _Timeout(
+                        f"sidecar did not deliver a complete frame within "
+                        f"{self.timeout}s (hung render or desynced stream)"
+                    )
+            chunk = os.read(fd, n - len(buf))
             if not chunk:
                 raise BrokenPipeError("sidecar stdout closed")
             buf += chunk
@@ -171,6 +208,29 @@ class Sidecar:
             pass
         try:
             proc.wait(timeout=1)
+        except Exception:
+            pass
+
+
+def _pump_stderr(pipe) -> None:
+    """Forward a sidecar's stderr to the parent's, line by line, prefixed.
+
+    Runs on a daemon thread for the lifetime of one child process and exits
+    at EOF (child death), so restarts get a fresh pump for the fresh pipe.
+    sys.stderr is looked up per write, not bound at spawn, so stream
+    replacement (pytest capture, WSGI servers that rebind stderr) sees the
+    output too.
+    """
+    try:
+        for raw in iter(pipe.readline, b""):
+            line = raw.decode("utf-8", errors="replace")
+            sys.stderr.write(f"[sidecar] {line}")
+            sys.stderr.flush()
+    except (ValueError, OSError):
+        pass  # pipe closed mid-read during shutdown
+    finally:
+        try:
+            pipe.close()
         except Exception:
             pass
 

--- a/journal/journal_039.md
+++ b/journal/journal_039.md
@@ -1,0 +1,75 @@
+# Journal Entry 039: The Most Common Line of JavaScript Was a Hang
+
+**Date**: July 18, 2026
+**Focus**: console.log during SSR corrupted the sidecar protocol and hung requests forever
+**Status**: Shipped
+
+## One Line, No Error, Nothing
+
+Put `console.log('hello')` at the top of any component's script and request
+the page. Not an error page, not a slow response, nothing in the terminal.
+The request just never comes back. curl gives up whenever curl gives up,
+the dev server sits there looking healthy, and there is not one line of
+output anywhere pointing at the cause.
+
+The first debugging tool anyone reaches for, in the language half this
+framework exists to serve, was a remote detonator.
+
+## Two Jobs, One Pipe
+
+The sidecar talks to Python over stdout: four bytes of length, then that
+many bytes of JSON, repeat. Strict, binary, position is everything. And
+stdout is also where Node sends console.log. Component code runs during
+render, render runs inside the sidecar, so a stray log line lands in the
+middle of the frame stream and the parser on the Python side reads the
+word "hello" as a length header. From that byte on, the two processes are
+reading different books.
+
+The part that made it a hang instead of a crash was subtler, and it was on
+my side of the pipe. There was a timeout, thirty seconds, and it looked
+protective. It guarded exactly one thing: how long until the first byte
+arrives. Garbage arrives instantly. After that first byte the code dropped
+into a read loop with no clock at all, waiting patiently for the rest of a
+frame that could never complete. A timeout that only times the wait for
+byte one is a lock on a door standing next to an open window.
+
+## The Fix Is Old
+
+RPC over stdio is not a new idea and neither is this failure. Language
+servers hit it years ago and settled on the answer: the protocol owns
+stdout, everything else goes to stderr. So the sidecar now rebinds
+console.log, info, warn, and debug onto stderr before it wires up its
+stdin listener. Nothing that runs during a render can touch the frame
+stream, including dependencies nobody audited.
+
+That alone would trade a hang for a black hole, logs going somewhere
+nobody looks. So Python now captures the sidecar's stderr and forwards it
+line by line, prefixed `[sidecar]`, onto its own. There is a trap in that
+move: a captured pipe that nobody drains fills up in about sixty-four
+kilobytes and then blocks the child mid-write, which is the same hang
+wearing a different hat. The forwarder is a dedicated thread that starts
+with the process and reads until the pipe dies, and there is a test that
+logs two hundred kilobytes in one render to prove the trap stays shut.
+
+And the clock now covers the whole frame. One deadline, start to last
+byte, checked before every read. A desynced stream fails in bounded time
+with an error that says what it suspects, and the failed process gets
+replaced instead of trusted with the next request. While wiring that I
+had to move the reads off Python's buffered file object onto the raw file
+descriptor, because select watches the fd while the buffer hoards bytes
+above it, and the two disagree about what "ready" means. The kind of
+detail nobody writes down until it costs an afternoon.
+
+## The Test That Freezes
+
+The honest moment of this fix: the first regression test froze the whole
+suite. Of course it did, the bug is a hang, and a test that reproduces a
+hang hangs. The tests now run the render on a worker thread and give it
+ten seconds to come home, so the failure mode is a red assertion instead
+of a suite that never finishes. Watching that thread refuse to die before
+the fix, and come back instantly after, was the whole story in one test
+run.
+
+---
+
+*End of Journal Entry 039*

--- a/tests/core/test_sidecar.py
+++ b/tests/core/test_sidecar.py
@@ -122,3 +122,175 @@ def test_timeout_kills_hung_node_and_raises(tmp_path: Path):
         assert sidecar._restart_count >= 1
     finally:
         sidecar.stop()
+
+
+# ---------------- stdout collision (issue #84) ----------------
+
+
+def _inject_console_line(example_app: Path, line: str) -> None:
+    """Insert a statement at the top of the todos template's script block so it
+    executes during every SSR render of the `todos` route."""
+    template = example_app / "app" / "templates" / "todos" / "index.svelte"
+    source = template.read_text()
+    assert "<script>" in source
+    template.write_text(source.replace("<script>", f"<script>\n  {line}", 1))
+
+
+def _render_in_thread(sidecar: Sidecar, join_seconds: float):
+    """Run one todos render on a worker thread and join with a bound, so a
+    sidecar hang shows up as a failed assertion instead of freezing pytest."""
+    import threading
+
+    outcome = {}
+
+    def work():
+        try:
+            outcome["result"] = sidecar.render(
+                route="todos", props={"todos": [], "user": {}, "stats": {}}
+            )
+        except Exception as e:
+            outcome["error"] = e
+
+    t = threading.Thread(target=work, daemon=True)
+    t.start()
+    t.join(join_seconds)
+    return t, outcome
+
+
+@pytest.mark.usefixtures("node_available")
+def test_console_log_during_render_does_not_hang(example_app: Path):
+    """Issue #84: console.log in component code used to interleave text into
+    the binary IPC stream and hang the request forever."""
+    _inject_console_line(example_app, "console.log('stdout-collision-probe');")
+    BuildPipeline(project_root=example_app).build(dev=False)
+    sidecar = Sidecar(dist_dir=example_app / "dist", timeout=5.0)
+    sidecar.start()
+    try:
+        t, outcome = _render_in_thread(sidecar, join_seconds=10.0)
+        assert not t.is_alive(), "render hung: console.log corrupted the IPC stream"
+        assert "error" not in outcome, outcome.get("error")
+        assert "todo-app" in outcome["result"]["body"]
+
+        # The same process must serve the next request: no corruption carryover.
+        again = sidecar.render(route="todos", props={"todos": [], "user": {}, "stats": {}})
+        assert "todo-app" in again["body"]
+        assert sidecar._restart_count == 0
+    finally:
+        sidecar.stop()
+
+
+@pytest.mark.usefixtures("node_available")
+@pytest.mark.parametrize("method", ["info", "warn", "debug"])
+def test_other_console_methods_do_not_hang(example_app: Path, method: str):
+    _inject_console_line(example_app, f"console.{method}('probe-{method}');")
+    BuildPipeline(project_root=example_app).build(dev=False)
+    sidecar = Sidecar(dist_dir=example_app / "dist", timeout=5.0)
+    sidecar.start()
+    try:
+        t, outcome = _render_in_thread(sidecar, join_seconds=10.0)
+        assert not t.is_alive(), f"render hung on console.{method}"
+        assert "todo-app" in outcome["result"]["body"]
+    finally:
+        sidecar.stop()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_console_output_surfaces_on_stderr_prefixed(example_app: Path, capsys):
+    """Redirected console output must be visible and attributable, not dropped."""
+    import time
+
+    _inject_console_line(example_app, "console.log('visible-probe-84');")
+    BuildPipeline(project_root=example_app).build(dev=False)
+    sidecar = Sidecar(dist_dir=example_app / "dist", timeout=5.0)
+    sidecar.start()
+    try:
+        sidecar.render(route="todos", props={"todos": [], "user": {}, "stats": {}})
+        # The pump thread forwards asynchronously; poll briefly.
+        deadline = time.monotonic() + 3.0
+        err = ""
+        while time.monotonic() < deadline:
+            err += capsys.readouterr().err
+            if "visible-probe-84" in err:
+                break
+            time.sleep(0.05)
+        assert "[sidecar] visible-probe-84" in err
+    finally:
+        sidecar.stop()
+
+
+@pytest.mark.usefixtures("node_available")
+def test_high_volume_console_logging_does_not_deadlock(example_app: Path):
+    """Logging beyond the OS pipe buffer (~64KB) must not wedge Node mid-write."""
+    _inject_console_line(
+        example_app,
+        "for (let i = 0; i < 200; i++) console.log('x'.repeat(1024));",
+    )
+    BuildPipeline(project_root=example_app).build(dev=False)
+    sidecar = Sidecar(dist_dir=example_app / "dist", timeout=10.0)
+    sidecar.start()
+    try:
+        t, outcome = _render_in_thread(sidecar, join_seconds=15.0)
+        assert not t.is_alive(), "render hung: stderr pipe buffer filled without a reader"
+        assert "todo-app" in outcome["result"]["body"]
+    finally:
+        sidecar.stop()
+
+
+def test_garbage_on_stdout_fails_bounded_not_forever(tmp_path: Path):
+    """Any non-frame bytes on the IPC stream (this bug or a future one) must
+    produce a bounded SidecarError, never an indefinite hang. The old code's
+    select() only guarded time-to-first-byte; garbage arrives instantly and
+    then the frame read blocked forever."""
+    import time
+
+    bad_dir = tmp_path / "dist"
+    bad_dir.mkdir()
+    (bad_dir / "sidecar.mjs").write_text(
+        "process.stdin.on('data', () => {\n"
+        "  process.stdout.write('this is not a frame and never will be\\n');\n"
+        "});\n"
+        "setInterval(() => {}, 1000);\n"
+    )
+    sidecar = Sidecar(dist_dir=bad_dir, timeout=0.5)
+    sidecar.start()
+    try:
+        start = time.monotonic()
+        with pytest.raises(SidecarError, match="IPC failed"):
+            sidecar.render(route="anything", props={})
+        elapsed = time.monotonic() - start
+        # One attempt + one retry, each bounded by the 0.5s deadline, plus
+        # process spawn overhead. Generous bound; the point is "not forever".
+        assert elapsed < 5.0, f"desynced stream took {elapsed:.1f}s to fail"
+        # A desynced process must not be reused: the failure path killed it.
+        assert sidecar._restart_count >= 1
+    finally:
+        sidecar.stop()
+
+
+def test_slow_but_valid_frame_within_deadline_succeeds(tmp_path: Path):
+    """The deadline bounds the whole frame, but a legitimately slow trickle
+    that completes in time must not be cut off by any per-read impatience."""
+    slow_dir = tmp_path / "dist"
+    slow_dir.mkdir()
+    (slow_dir / "sidecar.mjs").write_text(
+        "let buf = Buffer.alloc(0);\n"
+        "process.stdin.on('data', (c) => {\n"
+        "  buf = Buffer.concat([buf, c]);\n"
+        "  if (buf.length < 4) return;\n"
+        "  const body = Buffer.from(JSON.stringify({ id: 1, ok: true, body: 'slow', head: '' }));\n"
+        "  const len = Buffer.alloc(4);\n"
+        "  len.writeUInt32BE(body.length, 0);\n"
+        "  process.stdout.write(len);\n"
+        "  setTimeout(() => process.stdout.write(body.subarray(0, 5)), 300);\n"
+        "  setTimeout(() => process.stdout.write(body.subarray(5)), 600);\n"
+        "  buf = Buffer.alloc(0);\n"
+        "});\n"
+        "setInterval(() => {}, 1000);\n"
+    )
+    sidecar = Sidecar(dist_dir=slow_dir, timeout=5.0)
+    sidecar.start()
+    try:
+        result = sidecar.render(route="anything", props={})
+        assert result["body"] == "slow"
+    finally:
+        sidecar.stop()


### PR DESCRIPTION
## Summary

Closes #84. The sidecar used stdout for two jobs at once: the binary length-prefixed frame protocol to Python, and Node's default console.log target. One console.log anywhere in SSR-rendered component code interleaved text into the frame stream, desynced the parser, and hung the request forever with no error anywhere. The 30s timeout never fired because select only guarded time to first byte and the frame read loop under it had no clock.

- `sidecar.mjs`: console.log/info/warn/debug rebound to stderr before the stdin listener wires up, so nothing that runs during a render (including third-party dependencies) can touch the IPC channel.
- `sidecar.py`: the child's stderr is captured and pumped line by line onto the parent's stderr with a `[sidecar]` prefix, on a dedicated daemon thread per process. A captured pipe with no always-running reader would fill the ~64KB OS buffer and block Node mid-write (the same hang in a different hat), so the pump starts with the process and is pinned by a 200KB-in-one-render test.
- The per-call timeout is now a single deadline for the complete reply frame, checked before every read. Reads moved to `os.read` on the raw fd: BufferedReader blocks for exact counts regardless of select and hides buffered bytes from it, so pairing the two is unsound. A mid-frame timeout kills the process, so a desynced stream is never reused for the next request.

## Test plan

- TDD: both core regression tests were watched failing for the right reason first (the console.log render hung its worker thread; the garbage-stream test froze pytest outright, demonstrating the unbounded read).
- 8 new tests in tests/core/test_sidecar.py: console.log render completes and the same process serves the next request; info/warn/debug variants; output visible with the `[sidecar]` prefix; 200KB of logging in one render; garbage on stdout fails bounded (~1s at a 0.5s deadline) with a restart; a slow but valid frame trickling in within the deadline still succeeds.
- Full suite: 1234 passed, 21 skipped.
- End to end: a built todo_app with `console.log('...', {a: 1})` at component script top served 200 twice in a row through the real WSGI path, with the log line surfacing prefixed.